### PR TITLE
Add type annotations

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -14,7 +14,8 @@
 # R0903: Too few public methods
 # R0912: Too many branches
 # R0914: Too many local variables
-disable=C0111,R0201,R0903,R0912,R0914
+# W0511: FIXME
+disable=C0111,R0201,R0903,R0912,R0914,W0511
 
 [BASIC]
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@ from setuptools import setup
 
 INSTALL_REQUIRES = [
     'GitPython == 2.1.1',
-    'truffleHogRegexes == 0.0.7'
+    'truffleHogRegexes == 0.0.7',
+    "typing; python_version < '3.5'",
 ]
 
 EXTRAS_REQUIRE = {

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -2,13 +2,15 @@
 
 import argparse
 import re
+from typing import List, Optional
 
 import truffleHogRegexes.regexChecks
 
 from tartufo import config, scanner, util
 
 
-def main(argv=None):  # noqa:C901
+def main(argv=None):
+    # type: (Optional[List[str]]) -> int
     args = parse_args(argv)
 
     if not (args.do_entropy or args.do_regex):
@@ -69,7 +71,8 @@ def main(argv=None):  # noqa:C901
     return 0
 
 
-def parse_args(argv):
+def parse_args(argv=None):
+    # type: (Optional[List[str]]) -> argparse.Namespace
     parser = argparse.ArgumentParser(
         description="Find secrets hidden in the depths of git."
     )

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -1,12 +1,18 @@
+import argparse  # pylint: disable=unused-import
 import json
 import os
 import re
 import shutil
+from typing import Dict, List, Pattern, Union
 
 from tartufo import util
 
 
+PatternDict = Dict[str, Union[str, Pattern]]
+
+
 def configure_regexes_from_args(args, default_regexes):
+    # type: (argparse.Namespace, PatternDict) -> PatternDict
     if args.do_regex:
         if args.rules_filenames or (args.git_rules_repo and args.git_rules):
             rules_regexes = dict(default_regexes) if args.do_default_regexes else {}
@@ -21,6 +27,7 @@ def configure_regexes_from_args(args, default_regexes):
 
 
 def configure_regexes_from_git(git_url, repo_rules_filenames, rules_regexes):
+    # type: (str, List[str], PatternDict) -> PatternDict
     rules_project_path = util.clone_git_repo(git_url)
     try:
         rules_filenames = [os.path.join(rules_project_path, repo_rules_filename)
@@ -31,6 +38,7 @@ def configure_regexes_from_git(git_url, repo_rules_filenames, rules_regexes):
 
 
 def configure_regexes_from_rules_files(rules_filenames, rules_regexes):
+    # type: (List[str], PatternDict) -> PatternDict
     for rules_filename in rules_filenames:
         load_rules_from_file(rules_filename, rules_regexes)
 
@@ -38,6 +46,8 @@ def configure_regexes_from_rules_files(rules_filenames, rules_regexes):
 
 
 def load_rules_from_file(rules_filename, rules_regexes):
+    # type: (str, PatternDict) -> None
+    # FIXME: This relies on side-effects by mutating the passed-in dictionary
     try:
         with open(rules_filename, "r") as rules_file:
             new_rules = json.loads(rules_file.read())

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -5,11 +5,13 @@ import os
 import shutil
 import stat
 import tempfile
+from typing import Callable
 
 from git import Repo
 
 
 def del_rw(_func, name, _exc):
+    # type: (Callable, str, Exception) -> None
     os.chmod(name, stat.S_IWRITE)
     os.remove(name)
 
@@ -21,6 +23,7 @@ def clean_outputs(output):
 
 
 def str2bool(v_string):
+    # type: (str) -> bool
     if v_string is None:
         return True
 
@@ -34,6 +37,7 @@ def str2bool(v_string):
 
 
 def clone_git_repo(git_url):
+    # type: (str) -> str
     project_path = tempfile.mkdtemp()
     Repo.clone_from(git_url, project_path)
     return project_path

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -33,7 +33,7 @@ class EntropyTests(unittest.TestCase):
 class ScannerTests(unittest.TestCase):
     @mock.patch("tartufo.scanner.hashlib", new=mock.MagicMock())
     @mock.patch("tartufo.scanner.tempfile", new=mock.MagicMock())
-    @mock.patch("tartufo.scanner.Repo")
+    @mock.patch("tartufo.scanner.git.Repo")
     @mock.patch("tartufo.scanner.util.clone_git_repo")
     @mock.patch("tartufo.scanner.util.shutil.rmtree")
     def test_find_strings_works_against_already_cloned_repo(self, mock_rmtree, mock_clone, mock_repo):
@@ -45,13 +45,13 @@ class ScannerTests(unittest.TestCase):
     @mock.patch("tartufo.scanner.util.clone_git_repo", new=mock.MagicMock())
     @mock.patch("tartufo.scanner.util.shutil.rmtree", new=mock.MagicMock())
     @mock.patch("tartufo.scanner.tempfile", new=mock.MagicMock())
-    @mock.patch("tartufo.scanner.Repo")
+    @mock.patch("tartufo.scanner.git.Repo")
     def test_find_strings_checks_out_branch_when_specified(self, mock_repo):
         scanner.find_strings("test_repo", branch="testbranch")
         mock_repo.return_value.remotes.origin.fetch.assert_called_once_with("testbranch")
 
     @mock.patch("tartufo.scanner.tempfile", new=mock.MagicMock())
-    @mock.patch("tartufo.scanner.Repo")
+    @mock.patch("tartufo.scanner.git.Repo")
     @mock.patch("tartufo.scanner.diff_worker")
     def test_all_commits_are_passed_to_diff_worker(self, mock_worker, mock_repo):
         # Expose a "master" branch for our "repo"


### PR DESCRIPTION
This adds full type annotations to the `tartufo` codebase. Most of these should be accurate, but a few were put together from my understanding of the code. `PatternDict` and `IssueDict` in particular are a bit iffy. And I think they also highlight the need for some improved data structures, in order to eliminate some of the confusion.