### PR TITLE
Format the code with `black`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,8 @@ repos:
   rev: v0.730
   hooks:
   - id: mypy
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.7.8
+- repo: https://github.com/psf/black
+  rev: stable
   hooks:
-  - id: flake8
+    - id: black
+      language_version: python3.7

--- a/.pylintrc
+++ b/.pylintrc
@@ -10,12 +10,14 @@
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once).
 # C0111: Missing docstrings
+# C0301: Line too long (Note: This is all handled by black now)
+# C0330: Wrong hanging indentation before block (Note: black disagrees on this)
 # R0201: Method could be a function
 # R0903: Too few public methods
 # R0912: Too many branches
 # R0914: Too many local variables
 # W0511: FIXME
-disable=C0111,R0201,R0903,R0912,R0914,W0511
+disable=C0111,C0301,C0330,R0201,R0903,R0912,R0914,W0511
 
 [BASIC]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
   include:
     - stage: lint
       python: 3.7
-      env: TOXENV=flake8
+      env: TOXENV=black
     - python: 3.7
       env: TOXENV=mypy
     - python: 3.7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,9 +114,15 @@ you:
 
 ### Code Style
 
-Generally speaking, you should follow [PEP 8] when writing code for `tartufo`.
-But the most important thing is to match the style of the surrounding code. Keep
-in mind that all code in this project is scanned by both `flake8` and `pylint`.
+To make code formatting easy on developers, and to simplify the conversation
+around pull request reviews, this project has adopted the
+[black] code formatter. This formatter must be run against any new code written
+for this project. The advantage is, you no longer have to think about how your
+code is styled; it's all handled for you!
+
+To make this easier on you, you can [set up most editors][black-editors] to
+auto-run `black` for you. We have also set up a [pre-commit] hook to run
+automatically on every commit, which is detailed below!
 
 ## Running tests
 
@@ -141,7 +147,7 @@ like the following:
 ```sh
 Tartufo..................................................................Passed
 mypy.....................................................................Passed
-flake8...................................................................Passed
+black....................................................................Passed
 pylint...................................................................Passed
 ```
 
@@ -150,6 +156,8 @@ pylint...................................................................Passed
 - [General GitHub Documentation](https://help.github.com/)
 - [GitHub Pull Request documentation](https://help.github.com/send-pull-requests/)
 
+[black]: https://github.com/psf/black
+[black-editors]: https://github.com/psf/black#editor-integration
 [issues]: https://github.com/godaddy/tartufo/issues
 [PEP 8]: https://www.python.org/dev/peps/pep-0008/
 [pre-commit]: https://pre-commit.com/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,19 @@ json = false
 cleanup = true
 regex = true
 entropy = true
+
+[tool.black]
+target-version = ['py27', 'py35', 'py36', 'py37', 'py38']
+exclude = '''
+/(
+    \.eggs         # exclude a few common directories in the
+    | \.git          # root of the project
+    | \.mypy_cache
+    | \.pytest_cache
+    | \.tox
+    | \.venv
+    | _build
+    | build
+    | dist
+)/
+'''

--- a/scripts/searchOrg.py
+++ b/scripts/searchOrg.py
@@ -19,14 +19,13 @@ RULES = {
     "Facebook Oauth": "[f|F][a|A][c|C][e|E][b|B][o|O][o|O][k|K].{0,30}['\"\\s][0-9a-f]{32}['\"\\s]",
     "Twitter Oauth": "[t|T][w|W][i|I][t|T][t|T][e|E][r|R].{0,30}['\"\\s][0-9a-zA-Z]{35,44}['\"\\s]",
     "GitHub": "[g|G][i|I][t|T][h|H][u|U][b|B].{0,30}['\"\\s][0-9a-zA-Z]{35,40}['\"\\s]",
-    "Google Oauth": "(\"client_secret\":\"[a-zA-Z0-9-_]{24}\")",
+    "Google Oauth": '("client_secret":"[a-zA-Z0-9-_]{24}")',
     "AWS API Key": "AKIA[0-9A-Z]{16}",
-    "Heroku API Key":
-        "[h|H][e|E][r|R][o|O][k|K][u|U].{0,30}[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}",
+    "Heroku API Key": "[h|H][e|E][r|R][o|O][k|K][u|U].{0,30}[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}",
     "Generic Secret": "[s|S][e|E][c|C][r|R][e|E][t|T].{0,30}['\"\\s][0-9a-zA-Z]{32,45}['\"\\s]",
     "Generic API Key": "[a|A][p|P][i|I][_]?[k|K][e|E][y|Y].{0,30}['\"\\s][0-9a-zA-Z]{32,45}['\"\\s]",
     "Slack Webhook": "https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}",
-    "Google (GCP) Service-account": "\"type\": \"service_account\"",
+    "Google (GCP) Service-account": '"type": "service_account"',
     "Twilio API Key": "SK[a-z0-9]{32}",
     "Password in URL": "[a-zA-Z]{3,10}://[^/\\s:@]{3,20}:[^/\\s:@]{3,20}@.{1,100}[\"'\\s]",
 }
@@ -36,22 +35,33 @@ for key in RULES:
 
 
 def get_org_repos(orgname, page):
-    response = requests.get(url='https://api.github.com/users/' + orgname + '/repos?page={}'.format(page))
+    response = requests.get(
+        url="https://api.github.com/users/{}/repos?page={}".format(orgname, page)
+    )
     json = response.json()
     if not json:
         return
     for item in json:
 
-        if item['fork'] is False:  # and reached:
-            print('searching ' + item["html_url"])
-            results = scanner.find_strings(item["html_url"], do_regex=True, custom_regexes=RULES, do_entropy=False,
-                                           max_depth=100000)
+        if item["fork"] is False:  # and reached:
+            print("searching " + item["html_url"])
+            results = scanner.find_strings(
+                item["html_url"],
+                do_regex=True,
+                custom_regexes=RULES,
+                do_entropy=False,
+                max_depth=100000,
+            )
             for issue in results["foundIssues"]:
                 data = loads(open(issue).read())
-                data['github_url'] = "{}/blob/{}/{}".format(item["html_url"], data['commitHash'], data['path'])
-                data['github_commit_url'] = "{}/commit/{}".format(item["html_url"], data['commitHash'])
-                data['diff'] = data['diff'][0:200]
-                data['printDiff'] = data['printDiff'][0:200]
+                data["github_url"] = "{}/blob/{}/{}".format(
+                    item["html_url"], data["commitHash"], data["path"]
+                )
+                data["github_commit_url"] = "{}/commit/{}".format(
+                    item["html_url"], data["commitHash"]
+                )
+                data["diff"] = data["diff"][0:200]
+                data["printDiff"] = data["printDiff"][0:200]
                 print(dumps(data, indent=4))
     get_org_repos(orgname, page + 1)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,6 @@
 [bdist_wheel]
 universal=1
 
-[flake8]
-exclude=.eggs,.venv,.tox,.*_cache
-max-line-length=120
-max-complexity=13
-ignore=F401,F841,F403,W503,W504
-
 [mypy]
 ignore_missing_imports = True
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ INSTALL_REQUIRES = [
 
 EXTRAS_REQUIRE = {
     "tests": [
-        "black==19.10b0; python_version >= '3.6'",
+        "black==19.10b0; python_version >= '3.6' and platform_python_implementation == 'CPython'",
         "coverage",
         "mock; python_version == '2.7'",
         "pre-commit",

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ INSTALL_REQUIRES = [
 
 EXTRAS_REQUIRE = {
     'tests': [
+        "black==19.10b0; python_version >= '3.6'",
         'coverage',
         "mock; python_version == '2.7'",
         "pre-commit",

--- a/setup.py
+++ b/setup.py
@@ -11,42 +11,40 @@ INSTALL_REQUIRES = [
 ]
 
 EXTRAS_REQUIRE = {
-    'tests': [
+    "tests": [
         "black==19.10b0; python_version >= '3.6'",
-        'coverage',
+        "coverage",
         "mock; python_version == '2.7'",
         "pre-commit",
-        'pytest',
-        'pytest-cov',
-        'pytest-sugar',
-        'tox',
+        "pytest",
+        "pytest-cov",
+        "pytest-sugar",
+        "tox",
     ]
 }
 
 
 def read(filename):
-    with codecs.open(filename, 'r', 'utf-8') as file_handle:
+    with codecs.open(filename, "r", "utf-8") as file_handle:
         return file_handle.read().strip()
 
 
 setup(
-    name='tartufo',
-    version=read('VERSION'),
-    description='tartufo is a tool for scanning git repositories for secrets/passwords/high-entropy data',
-    long_description=read('README.md'),
-    long_description_content_type='text/markdown',
-    url='https://github.com/godaddy/tartufo',
-    download_url='https://pypi.org/project/tartufo/#files',
-    author='GoDaddy',
-    author_email='oss@godaddy.com',
-    license='GNU',
-    packages=['tartufo'],
+    name="tartufo",
+    version=read("VERSION"),
+    description="tartufo is a tool for scanning git repositories for secrets/passwords/high-entropy data",
+    long_description=read("README.md"),
+    long_description_content_type="text/markdown",
+    url="https://github.com/godaddy/tartufo",
+    download_url="https://pypi.org/project/tartufo/#files",
+    author="GoDaddy",
+    author_email="oss@godaddy.com",
+    license="GNU",
+    packages=["tartufo"],
     install_requires=INSTALL_REQUIRES,
-    setup_requires='',
+    setup_requires="",
     extras_require=EXTRAS_REQUIRE,
-    entry_points={
-        'console_scripts': ['tartufo = tartufo.cli:main'],
-    },
+    entry_points={"console_scripts": ["tartufo = tartufo.cli:main"],},
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Environment :: Console",
@@ -62,5 +60,5 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Topic :: Security",
         "Topic :: Software Development :: Version Control :: Git",
-    ]
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ EXTRAS_REQUIRE = {
         "pytest-cov",
         "pytest-sugar",
         "tox",
+        "vulture",
     ]
 }
 

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -10,56 +10,94 @@ import truffleHogRegexes.regexChecks
 from tartufo import config, scanner, util
 
 
-err = partial(click.secho, fg="red", bold=True, err=True)  # pylint: disable=invalid-name
+err = partial(
+    click.secho, fg="red", bold=True, err=True
+)  # pylint: disable=invalid-name
 
 
-@click.command(name="tartufo",  # noqa: C901
-               context_settings=dict(help_option_names=["-h", "--help"]))
+@click.command(
+    name="tartufo",  # noqa: C901
+    context_settings=dict(help_option_names=["-h", "--help"]),
+)
 @click.option("--json/--no-json", help="Output in JSON format.", is_flag=True)
-@click.option("--rules", multiple=True, type=click.File("r"),
-              help="Path(s) to regex rules json list file(s).")
-@click.option("--default-regexes/--no-default-regexes", is_flag=True, default=True,
-              help="Whether to include the default regex list when configuring"
-                   " search patterns. Only applicable if --rules is also specified."
-                   " [default: --default-regexes]")
-@click.option("--entropy/--no-entropy", is_flag=True, default=True,
-              help="Enable entropy checks. [default: True]")
-@click.option("--regex/--no-regex", is_flag=True, default=False,
-              help="Enable high signal regexes checks. [default: False]")
+@click.option(
+    "--rules",
+    multiple=True,
+    type=click.File("r"),
+    help="Path(s) to regex rules json list file(s).",
+)
+@click.option(
+    "--default-regexes/--no-default-regexes",
+    is_flag=True,
+    default=True,
+    help="Whether to include the default regex list when configuring"
+    " search patterns. Only applicable if --rules is also specified."
+    " [default: --default-regexes]",
+)
+@click.option(
+    "--entropy/--no-entropy",
+    is_flag=True,
+    default=True,
+    help="Enable entropy checks. [default: True]",
+)
+@click.option(
+    "--regex/--no-regex",
+    is_flag=True,
+    default=False,
+    help="Enable high signal regexes checks. [default: False]",
+)
 @click.option("--since-commit", help="Only scan from a given commit hash.")
-@click.option("--max-depth", default=1000000,
-              help="The max commit depth to go back when searching for secrets."
-                   " [default: 1000000]")
+@click.option(
+    "--max-depth",
+    default=1000000,
+    help="The max commit depth to go back when searching for secrets."
+    " [default: 1000000]",
+)
 @click.option("--branch", help="Specify a branch name to scan only that branch.")
-@click.option("-i", "--include-paths", type=click.File("r"),
-              help="File with regular expressions (one per line), at least one of "
-                   "which must match a Git object path in order for it to be scanned; "
-                   "lines starting with '#' are treated as comments and are ignored. "
-                   "If empty or not provided (default), all Git object paths are "
-                   "included unless otherwise excluded via the --exclude-paths option.")
-@click.option("-x", "--exclude-paths", type=click.File("r"),
-              help="File with regular expressions (one per line), none of which may "
-                   "match a Git object path in order for it to be scanned; lines "
-                   "starting with '#' are treated as comments and are ignored. If "
-                   "empty or not provided (default), no Git object paths are excluded "
-                   "unless effectively excluded via the --include-paths option.")
-@click.option("--repo-path",
-              type=click.Path(
-                  exists=True,
-                  file_okay=False,
-                  resolve_path=True,
-                  allow_dash=False
-              ),
-              help="Path to local repo clone. If provided, git_url will not be used.")
-@click.option("--cleanup/--no-cleanup", is_flag=True, default=False,
-              help="Clean up all temporary result files. [default: False]")
-@click.option("--pre-commit", is_flag=True, default=False,
-              help="Scan staged files in local repo clone.")
-@click.option("--config",
-              type=click.File(mode='r'),
-              is_eager=True,
-              callback=config.read_pyproject_toml,
-              help="Read configuration from specified file. [default: pyproject.toml]")
+@click.option(
+    "-i",
+    "--include-paths",
+    type=click.File("r"),
+    help="File with regular expressions (one per line), at least one of "
+    "which must match a Git object path in order for it to be scanned; "
+    "lines starting with '#' are treated as comments and are ignored. "
+    "If empty or not provided (default), all Git object paths are "
+    "included unless otherwise excluded via the --exclude-paths option.",
+)
+@click.option(
+    "-x",
+    "--exclude-paths",
+    type=click.File("r"),
+    help="File with regular expressions (one per line), none of which may "
+    "match a Git object path in order for it to be scanned; lines "
+    "starting with '#' are treated as comments and are ignored. If "
+    "empty or not provided (default), no Git object paths are excluded "
+    "unless effectively excluded via the --include-paths option.",
+)
+@click.option(
+    "--repo-path",
+    type=click.Path(exists=True, file_okay=False, resolve_path=True, allow_dash=False),
+    help="Path to local repo clone. If provided, git_url will not be used.",
+)
+@click.option(
+    "--cleanup/--no-cleanup",
+    is_flag=True,
+    default=False,
+    help="Clean up all temporary result files. [default: False]",
+)
+@click.option(
+    "--pre-commit",
+    is_flag=True,
+    default=False,
+    help="Scan staged files in local repo clone.",
+)
+@click.option(
+    "--config",
+    type=click.File(mode="r"),
+    is_eager=True,
+    callback=config.read_pyproject_toml,
+    help="Read configuration from specified file. [default: pyproject.toml]",
+)
 @click.argument("git_url", required=False)
 @click.pass_context
 def main(ctx, **kwargs):
@@ -79,8 +117,7 @@ def main(ctx, **kwargs):
         ctx.exit(1)
     try:
         rules_regexes = config.configure_regexes_from_args(
-            kwargs,
-            truffleHogRegexes.regexChecks.regexes
+            kwargs, truffleHogRegexes.regexChecks.regexes
         )
     except ValueError as exc:
         err(str(exc))

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -10,9 +10,9 @@ import truffleHogRegexes.regexChecks
 from tartufo import config, scanner, util
 
 
-err = partial(
+err = partial(  # pylint: disable=invalid-name
     click.secho, fg="red", bold=True, err=True
-)  # pylint: disable=invalid-name
+)
 
 
 @click.command(

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -15,7 +15,9 @@ except ImportError:
     import pathlib2 as pathlib  # type: ignore
 
 
-err = partial(click.secho, fg="red", bold=True, err=True)  # pylint: disable=invalid-name
+err = partial(
+    click.secho, fg="red", bold=True, err=True
+)  # pylint: disable=invalid-name
 OptionTypes = Union[str, int, bool, None, TextIO, Tuple[TextIO, ...]]
 OptionsDict = Dict[str, OptionTypes]
 PatternDict = Dict[str, Union[str, Pattern]]
@@ -39,7 +41,7 @@ def read_pyproject_toml(ctx, _param, value):
     except (toml.TomlDecodeError, OSError) as exc:
         raise click.FileError(
             filename=str(config_path),
-            hint="Error reading configuration file: {}".format(exc)
+            hint="Error reading configuration file: {}".format(exc),
         )
     if not config:
         return None
@@ -68,12 +70,16 @@ def configure_regexes_from_args(args, default_regexes):
                     loaded = load_rules_from_file(rules_file)
                     dupes = set(loaded.keys()).intersection(regexes.keys())
                     if dupes:
-                        raise ValueError("Rule(s) were defined multiple time: {}".format(dupes))
+                        raise ValueError(
+                            "Rule(s) were defined multiple time: {}".format(dupes)
+                        )
                     regexes.update(loaded)
     return regexes
 
 
-def configure_regexes_from_git(git_url, repo_rules_filenames, rules_regexes):  # pylint: disable=unused-argument
+def configure_regexes_from_git(
+    git_url, repo_rules_filenames, rules_regexes
+):  # pylint: disable=unused-argument
     # type: (str, List[str], PatternDict) -> PatternDict
     # FIXME: This was never called or tested.
     #  https://github.com/godaddy/tartufo/issues/17 has been added for tracking

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -1,4 +1,3 @@
-import argparse  # pylint: disable=unused-import
 import json
 import re
 import shutil
@@ -15,9 +14,9 @@ except ImportError:
     import pathlib2 as pathlib  # type: ignore
 
 
-err = partial(
+err = partial(  # pylint: disable=invalid-name
     click.secho, fg="red", bold=True, err=True
-)  # pylint: disable=invalid-name
+)
 OptionTypes = Union[str, int, bool, None, TextIO, Tuple[TextIO, ...]]
 OptionsDict = Dict[str, OptionTypes]
 PatternDict = Dict[str, Union[str, Pattern]]

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -176,16 +176,16 @@ def find_regex(printable_diff, regex_list=None):
 
 
 def diff_worker(
-        diff,              # type: git.Diff
-        custom_regexes,    # type: Optional[PatternDict]
-        do_entropy,        # type: bool
-        do_regex,          # type: bool
-        print_json,        # type: bool
-        suppress_output,   # type: bool
-        path_inclusions,   # type: Optional[Iterable[Pattern]]
-        path_exclusions,   # type: Optional[Iterable[Pattern]]
-        prev_commit=None,  # type: Optional[git.Commit]
-        branch_name=None,  # type: Optional[str]
+    diff,  # type: git.Diff
+    custom_regexes,  # type: Optional[PatternDict]
+    do_entropy,  # type: bool
+    do_regex,  # type: bool
+    print_json,  # type: bool
+    suppress_output,  # type: bool
+    path_inclusions,  # type: Optional[Iterable[Pattern]]
+    path_exclusions,  # type: Optional[Iterable[Pattern]]
+    prev_commit=None,  # type: Optional[git.Commit]
+    branch_name=None,  # type: Optional[str]
 ):
     # type: (...) -> List[IssueDict]
     issues = []  # type: List[IssueDict]
@@ -261,18 +261,18 @@ def path_included(blob, include_patterns=None, exclude_patterns=None):
 
 
 def find_strings(
-        git_url,               # type: str
-        since_commit=None,     # type: Optional[str]
-        max_depth=1000000,     # type: int
-        print_json=False,      # type: bool
-        do_regex=False,        # type: bool
-        do_entropy=True,       # type: bool
-        suppress_output=True,  # type: bool
-        custom_regexes=None,   # type: Optional[PatternDict]
-        branch=None,           # type: Optional[str]
-        repo_path=None,        # type: Optional[str]
-        path_inclusions=None,  # type: Optional[Iterable[Pattern]]
-        path_exclusions=None,  # type: Optional[Iterable[Pattern]]
+    git_url,  # type: str
+    since_commit=None,  # type: Optional[str]
+    max_depth=1000000,  # type: int
+    print_json=False,  # type: bool
+    do_regex=False,  # type: bool
+    do_entropy=True,  # type: bool
+    suppress_output=True,  # type: bool
+    custom_regexes=None,  # type: Optional[PatternDict]
+    branch=None,  # type: Optional[str]
+    repo_path=None,  # type: Optional[str]
+    path_inclusions=None,  # type: Optional[Iterable[Pattern]]
+    path_exclusions=None,  # type: Optional[Iterable[Pattern]]
 ):
     # type: (...) -> IssueDict
     output = {"found_issues": []}  # type: IssueDict
@@ -352,14 +352,14 @@ def find_strings(
 
 
 def find_staged(
-        project_path,          # type: str
-        print_json=False,      # type: bool
-        do_regex=False,        # type: bool
-        do_entropy=True,       # type: bool
-        suppress_output=True,  # type: bool
-        custom_regexes=None,   # type: Optional[PatternDict]
-        path_inclusions=None,  # type: Optional[Iterable[Pattern]]
-        path_exclusions=None,  # type: Optional[Iterable[Pattern]]
+    project_path,  # type: str
+    print_json=False,  # type: bool
+    do_regex=False,  # type: bool
+    do_entropy=True,  # type: bool
+    suppress_output=True,  # type: bool
+    custom_regexes=None,  # type: Optional[PatternDict]
+    path_inclusions=None,  # type: Optional[Iterable[Pattern]]
+    path_exclusions=None,  # type: Optional[Iterable[Pattern]]
 ):
     # type: (...) -> IssueDict
     output = {"found_issues": []}  # type: IssueDict

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,6 @@ except ImportError:
 
 
 class CLITests(unittest.TestCase):
-
     def test_command_exits_gracefully_with_empty_argv(self):
         runner = CliRunner()
         with runner.isolated_filesystem():
@@ -44,20 +43,17 @@ class CLITests(unittest.TestCase):
         mock_config_regex.side_effect = ValueError("Foo!")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            result = runner.invoke(
-                cli.main, ["--repo-path", "."]
-            )
+            result = runner.invoke(cli.main, ["--repo-path", "."])
             self.assertEqual(result.output, "Foo!\n")
 
     @mock.patch("tartufo.cli.scanner.find_staged")
-    def test_command_calls_find_staged_for_pre_commit(
-            self, mock_find_staged
-    ):
+    def test_command_calls_find_staged_for_pre_commit(self, mock_find_staged):
         mock_find_staged.return_value = {}
         runner = CliRunner()
         with runner.isolated_filesystem():
             runner.invoke(
-                cli.main, ["--pre-commit", "--repo-path", "/", "--no-regex", "--entropy"]
+                cli.main,
+                ["--pre-commit", "--repo-path", "/", "--no-regex", "--entropy"],
             )
             mock_find_staged.assert_called_once_with(
                 "/",
@@ -67,18 +63,23 @@ class CLITests(unittest.TestCase):
                 custom_regexes={},
                 suppress_output=False,
                 path_inclusions=[],
-                path_exclusions=[]
+                path_exclusions=[],
             )
 
     @mock.patch("tartufo.cli.scanner.find_strings")
-    def test_command_calls_find_strings_by_default(
-            self, mock_find_strings
-    ):
+    def test_command_calls_find_strings_by_default(self, mock_find_strings):
         mock_find_strings.return_value = {}
         runner = CliRunner()
         with runner.isolated_filesystem():
             runner.invoke(
-                cli.main, ["--no-regex", "--max-depth", "42", "--entropy", "git@github.com:godaddy/tartufo.git"]
+                cli.main,
+                [
+                    "--no-regex",
+                    "--max-depth",
+                    "42",
+                    "--entropy",
+                    "git@github.com:godaddy/tartufo.git",
+                ],
             )
             mock_find_strings.assert_called_once_with(
                 "git@github.com:godaddy/tartufo.git",
@@ -92,20 +93,25 @@ class CLITests(unittest.TestCase):
                 branch=None,
                 repo_path=None,
                 path_inclusions=[],
-                path_exclusions=[]
+                path_exclusions=[],
             )
 
     @mock.patch("tartufo.cli.scanner.find_strings")
     @mock.patch("tartufo.cli.util.clean_outputs")
-    def test_command_calls_cleanup_when_requested(
-            self, mock_clean, mock_find_strings
-    ):
+    def test_command_calls_cleanup_when_requested(self, mock_clean, mock_find_strings):
         mock_find_strings.return_value = {"foo": "bar"}
         runner = CliRunner()
         with runner.isolated_filesystem():
             runner.invoke(
                 cli.main,
-                ["--cleanup", "--no-regex", "--max-depth", "42", "--entropy", "git@github.com:godaddy/tartufo.git"]
+                [
+                    "--cleanup",
+                    "--no-regex",
+                    "--max-depth",
+                    "42",
+                    "--entropy",
+                    "git@github.com:godaddy/tartufo.git",
+                ],
             )
             mock_clean.assert_called_once_with({"foo": "bar"})
 
@@ -124,8 +130,8 @@ class CLITests(unittest.TestCase):
                     "--max-depth",
                     "42",
                     "--entropy",
-                    "git@github.com:godaddy/tartufo.git"
-                ]
+                    "git@github.com:godaddy/tartufo.git",
+                ],
             )
             mock_find_strings.assert_called_once_with(
                 "git@github.com:godaddy/tartufo.git",
@@ -139,7 +145,7 @@ class CLITests(unittest.TestCase):
                 branch=None,
                 repo_path=None,
                 path_inclusions=[re.compile("tartufo/"), re.compile("scripts/")],
-                path_exclusions=[]
+                path_exclusions=[],
             )
 
     @mock.patch("tartufo.cli.scanner.find_strings")
@@ -157,8 +163,8 @@ class CLITests(unittest.TestCase):
                     "--max-depth",
                     "42",
                     "--entropy",
-                    "git@github.com:godaddy/tartufo.git"
-                ]
+                    "git@github.com:godaddy/tartufo.git",
+                ],
             )
             mock_find_strings.assert_called_once_with(
                 "git@github.com:godaddy/tartufo.git",
@@ -172,7 +178,11 @@ class CLITests(unittest.TestCase):
                 branch=None,
                 repo_path=None,
                 path_inclusions=[],
-                path_exclusions=[re.compile("tests/"), re.compile(r"\.venv/"), re.compile(r".*\.egg-info/")]
+                path_exclusions=[
+                    re.compile("tests/"),
+                    re.compile(r"\.venv/"),
+                    re.compile(r".*\.egg-info/"),
+                ],
             )
 
     @mock.patch("tartufo.cli.scanner.find_strings")
@@ -180,21 +190,17 @@ class CLITests(unittest.TestCase):
         mock_find_strings.return_value = {"issues_path": "/foo"}
         runner = CliRunner()
         with runner.isolated_filesystem():
-            result = runner.invoke(
-                cli.main,
-                ["git@github.com:godaddy/tartufo.git"]
-            )
+            result = runner.invoke(cli.main, ["git@github.com:godaddy/tartufo.git"])
             self.assertEqual(result.output, "Results have been saved in /foo\n")
 
     @mock.patch("tartufo.cli.scanner.find_strings")
-    def test_command_exits_with_positive_return_code_when_issues_found(self, mock_find_strings):
+    def test_command_exits_with_positive_return_code_when_issues_found(
+        self, mock_find_strings
+    ):
         mock_find_strings.return_value = {"found_issues": True}
         runner = CliRunner()
         with runner.isolated_filesystem():
-            result = runner.invoke(
-                cli.main,
-                ["git@github.com:godaddy/tartufo.git"]
-            )
+            result = runner.invoke(cli.main, ["git@github.com:godaddy/tartufo.git"])
             self.assertGreater(result.exit_code, 0)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,43 +14,52 @@ except ImportError:
 
 
 class ConfigureRegexTests(unittest.TestCase):
-
     def test_configure_regexes_from_args_rules_files_without_defaults(self):
         rules_path = pathlib.Path(__file__).parent / "data" / "testRules.json"
-        rules_files = (rules_path.open(), )
-        expected_regexes = {"RSA private key 2": re.compile("-----BEGIN EC PRIVATE KEY-----")}
+        rules_files = (rules_path.open(),)
+        expected_regexes = {
+            "RSA private key 2": re.compile("-----BEGIN EC PRIVATE KEY-----")
+        }
 
         args = {"regex": True, "default_regexes": False, "rules": rules_files}
         actual_regexes = config.configure_regexes_from_args(args, default_regexes)
 
         self.assertEqual(
-            expected_regexes, actual_regexes,
+            expected_regexes,
+            actual_regexes,
             "The regexes dictionary should match the test rules "
-            "(expected: {}, actual: {})".format(expected_regexes, actual_regexes)
+            "(expected: {}, actual: {})".format(expected_regexes, actual_regexes),
         )
 
     def test_configure_regexes_from_args_rules_files_with_defaults(self):
         rules_path = pathlib.Path(__file__).parent / "data" / "testRules.json"
-        rules_files = (rules_path.open(), )
+        rules_files = (rules_path.open(),)
         expected_regexes = dict(default_regexes)
-        expected_regexes["RSA private key 2"] = re.compile("-----BEGIN EC PRIVATE KEY-----")
+        expected_regexes["RSA private key 2"] = re.compile(
+            "-----BEGIN EC PRIVATE KEY-----"
+        )
 
         args = {"regex": True, "default_regexes": True, "rules": rules_files}
         actual_regexes = config.configure_regexes_from_args(args, default_regexes)
 
         self.assertEqual(
-            expected_regexes, actual_regexes,
+            expected_regexes,
+            actual_regexes,
             "The regexes dictionary should match the test rules "
-            "(expected: {}, actual: {})".format(expected_regexes, actual_regexes)
+            "(expected: {}, actual: {})".format(expected_regexes, actual_regexes),
         )
 
     def test_configure_regexes_from_args_no_do_regex(self):
         rules_path = pathlib.Path(__file__).parent / "data" / "testRules.json"
-        rules_files = (rules_path.open(), )
+        rules_files = (rules_path.open(),)
         args = {"regex": False, "default_regexes": True, "rules": rules_files}
         actual_regexes = config.configure_regexes_from_args(args, default_regexes)
 
-        self.assertEqual({}, actual_regexes, "The regexes dictionary should be empty when do_regex is False")
+        self.assertEqual(
+            {},
+            actual_regexes,
+            "The regexes dictionary should be empty when do_regex is False",
+        )
 
     def test_configure_regexes_from_args_no_rules(self):
         expected_regexes = dict(default_regexes)
@@ -59,8 +68,9 @@ class ConfigureRegexTests(unittest.TestCase):
         actual_regexes = config.configure_regexes_from_args(args, default_regexes)
 
         self.assertEqual(
-            expected_regexes, actual_regexes,
-            "The regexes dictionary should not have been changed when no rules files are specified"
+            expected_regexes,
+            actual_regexes,
+            "The regexes dictionary should not have been changed when no rules files are specified",
         )
 
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -14,19 +14,16 @@ except ImportError:
 
 
 class EntropyTests(unittest.TestCase):
-
     def test_shannon(self):
         random_string_b64 = (
             "ZWVTjPQSdhwRgl204Hc51YCsritMIzn8B=/p9UyeX7xu6KkAGqfm3FJ+oObLDNEva"
         )
         random_string_hex = "b3A0a1FDfe86dcCE945B72"
         self.assertGreater(
-            scanner.shannon_entropy(random_string_b64, scanner.BASE64_CHARS),
-            4.5
+            scanner.shannon_entropy(random_string_b64, scanner.BASE64_CHARS), 4.5
         )
         self.assertGreater(
-            scanner.shannon_entropy(random_string_hex, scanner.HEX_CHARS),
-            3
+            scanner.shannon_entropy(random_string_hex, scanner.HEX_CHARS), 3
         )
 
 
@@ -36,7 +33,9 @@ class ScannerTests(unittest.TestCase):
     @mock.patch("tartufo.scanner.git.Repo")
     @mock.patch("tartufo.scanner.util.clone_git_repo")
     @mock.patch("tartufo.scanner.util.shutil.rmtree")
-    def test_find_strings_works_against_already_cloned_repo(self, mock_rmtree, mock_clone, mock_repo):
+    def test_find_strings_works_against_already_cloned_repo(
+        self, mock_rmtree, mock_clone, mock_repo
+    ):
         scanner.find_strings("find_repo", repo_path="/test/path")
         mock_repo.assert_called_once_with("/test/path")
         mock_rmtree.assert_not_called()
@@ -48,7 +47,9 @@ class ScannerTests(unittest.TestCase):
     @mock.patch("tartufo.scanner.git.Repo")
     def test_find_strings_checks_out_branch_when_specified(self, mock_repo):
         scanner.find_strings("test_repo", branch="testbranch")
-        mock_repo.return_value.remotes.origin.fetch.assert_called_once_with("testbranch")
+        mock_repo.return_value.remotes.origin.fetch.assert_called_once_with(
+            "testbranch"
+        )
 
     @mock.patch("tartufo.scanner.tempfile", new=mock.MagicMock())
     @mock.patch("tartufo.scanner.git.Repo")
@@ -62,24 +63,54 @@ class ScannerTests(unittest.TestCase):
         commit_1 = mock.MagicMock(name="third commit")
         commit_2 = mock.MagicMock(name="second commit")
         commit_3 = mock.MagicMock(name="first commit")
-        mock_repo.return_value.iter_commits.return_value = [commit_1, commit_2, commit_3]
+        mock_repo.return_value.iter_commits.return_value = [
+            commit_1,
+            commit_2,
+            commit_3,
+        ]
 
         scanner.find_strings(
-            "git://fake/repo.git", repo_path="/fake/repo",
-            print_json=True, suppress_output=False
+            "git://fake/repo.git",
+            repo_path="/fake/repo",
+            print_json=True,
+            suppress_output=False,
         )
 
         call_1 = mock.call(
-            commit_1.diff.return_value, None, True, False, True, False,
-            None, None, commit_1, master_branch.name
+            commit_1.diff.return_value,
+            None,
+            True,
+            False,
+            True,
+            False,
+            None,
+            None,
+            commit_1,
+            master_branch.name,
         )
         call_2 = mock.call(
-            commit_2.diff.return_value, None, True, False, True, False,
-            None, None, commit_2, master_branch.name
+            commit_2.diff.return_value,
+            None,
+            True,
+            False,
+            True,
+            False,
+            None,
+            None,
+            commit_2,
+            master_branch.name,
         )
         call_3 = mock.call(
-            commit_3.diff.return_value, None, True, False, True, False,
-            None, None, commit_3, master_branch.name
+            commit_3.diff.return_value,
+            None,
+            True,
+            False,
+            True,
+            False,
+            None,
+            None,
+            commit_3,
+            master_branch.name,
         )
         mock_worker.assert_has_calls((call_1, call_2, call_3), any_order=True)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -26,8 +26,7 @@ class GitTests(unittest.TestCase):
     def test_tartufo_clones_git_repo_into_temp_dir(self, mock_mkdtemp, mock_clone):
         util.clone_git_repo("https://github.com/godaddy/tartufo.git")
         mock_clone.assert_called_once_with(
-            "https://github.com/godaddy/tartufo.git",
-            mock_mkdtemp.return_value
+            "https://github.com/godaddy/tartufo.git", mock_mkdtemp.return_value
         )
 
     @mock.patch("tartufo.util.Repo.clone_from", new=mock.MagicMock())

--- a/tox.ini
+++ b/tox.ini
@@ -48,4 +48,5 @@ commands =
     setup.py \
     scripts/ \
     tartufo/ \
-    tests/
+    tests/ \
+    vulture_whitelist.py

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ minversion = 3.7.0
 toxworkdir = {env:TOX_WORK_DIR:.tox}
 skip_missing_interpreters = True
 usedevelop = True
-envlist = py{27,35,36,37,38,py,py3},black,flake8,mypy,pylint,vulture
+envlist = py{27,35,36,37,38,py,py3},black,mypy,pylint,vulture
 parallel_show_output = True
 isolated_build = True
 
@@ -20,12 +20,6 @@ basepython = python3.7
 skip_install = True
 deps = black==19.10b0
 commands = black --check .
-
-[testenv:flake8]
-basepython = python3.7
-skip_install = True
-deps = flake8
-commands = flake8 .
 
 [testenv:mypy]
 basepython = python3.7

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ minversion = 3.7.0
 toxworkdir = {env:TOX_WORK_DIR:.tox}
 skip_missing_interpreters = True
 usedevelop = True
-envlist = py{27,35,36,37,38,py,py3},flake8,mypy,pylint,vulture
+envlist = py{27,35,36,37,38,py,py3},black,flake8,mypy,pylint,vulture
 parallel_show_output = True
 isolated_build = True
 
@@ -13,8 +13,13 @@ setenv =
     PYTHONHASHSEED=0
     PYTHONWARNINGS=ignore
 extras = tests
-whitelist_externals = mkdir
 commands = pytest {posargs}
+
+[testenv:black]
+basepython = python3.7
+skip_install = True
+deps = black==19.10b0
+commands = black --check .
 
 [testenv:flake8]
 basepython = python3.7

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -1,0 +1,9 @@
+# pylint: skip-file
+# type: ignore
+
+Optional  # unused import (tartufo/config.py:5)
+repo_rules_filenames  # unused variable (tartufo/config.py:80)
+Iterable  # unused import (tartufo/scanner.py:16)
+Optional  # unused import (tartufo/scanner.py:16)
+Set  # unused import (tartufo/scanner.py:16)
+Callable  # unused import (tartufo/util.py:8)


### PR DESCRIPTION
This swaps in `black` instead of `flake8`. Because automatically enforced code style is much easier to deal with than a nitpicking style checker after the fact.

And I also made the `vulture` check actually pass. 😄 