### PR TITLE
Read config files from remote repos

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -13,11 +13,12 @@
 # C0301: Line too long (Note: This is all handled by black now)
 # C0330: Wrong hanging indentation before block (Note: black disagrees on this)
 # R0201: Method could be a function
+# R0801: Similar lines in other files
 # R0903: Too few public methods
 # R0912: Too many branches
 # R0914: Too many local variables
 # W0511: FIXME
-disable=C0111,C0301,C0330,R0201,R0903,R0912,R0914,W0511
+disable=C0111,C0301,C0330,R0201,R0801,R0903,R0912,R0914,W0511
 
 [BASIC]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## vX.Y.Z -
+
+* Support reading config from `tartufo.toml` for non-Python projects
+* #18 - Read the `pyproject.toml` or `tartufo.toml` from the repo being scanned
+
 ## v1.0.2 - 19 November 2019
 
 This release is essentially the same as the v1.0.0 release, but with a new number.

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,8 @@ setup(
     author_email="oss@godaddy.com",
     license="GNU",
     packages=["tartufo"],
+    package_data={"tartufo": ["py.typed"]},
+    zip_safe=False,
     install_requires=INSTALL_REQUIRES,
     setup_requires="",
     extras_require=EXTRAS_REQUIRE,

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -93,7 +93,14 @@ err = partial(  # pylint: disable=invalid-name
 )
 @click.option(
     "--config",
-    type=click.File(mode="r"),
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        resolve_path=True,
+        allow_dash=False,
+    ),
     is_eager=True,
     callback=config.read_pyproject_toml,
     help="Read configuration from specified file. [default: pyproject.toml]",

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import re
+import shutil
 from functools import partial
-from typing import cast, TextIO
+from typing import cast, List, Pattern, TextIO
 
 import click
 import truffleHogRegexes.regexChecks
@@ -134,18 +134,14 @@ def main(ctx, **kwargs):
         ctx.exit(1)
 
     # read & compile path inclusion/exclusion patterns
-    path_inclusions = []
-    path_exclusions = []
+    path_inclusions = []  # type: List[Pattern]
+    path_exclusions = []  # type: List[Pattern]
     paths_file = cast(TextIO, kwargs["include_paths"])
     if paths_file:
-        for pattern in [l[:-1].lstrip() for l in paths_file]:
-            if pattern and not pattern.startswith("#"):
-                path_inclusions.append(re.compile(pattern))
+        path_inclusions = config.compile_path_rules(paths_file.readlines())
     paths_file = cast(TextIO, kwargs["exclude_paths"])
     if paths_file:
-        for pattern in [l[:-1].lstrip() for l in paths_file]:
-            if pattern and not pattern.startswith("#"):
-                path_exclusions.append(re.compile(pattern))
+        path_exclusions = config.compile_path_rules(paths_file.readlines())
 
     if kwargs["pre_commit"]:
         output = scanner.find_staged(
@@ -159,20 +155,19 @@ def main(ctx, **kwargs):
             path_exclusions=path_exclusions,
         )
     else:
-        output = scanner.find_strings(
-            cast(str, kwargs["git_url"]),
-            cast(str, kwargs["since_commit"]),
-            cast(int, kwargs["max_depth"]),
-            cast(bool, kwargs["json"]),
-            cast(bool, kwargs["regex"]),
-            cast(bool, kwargs["entropy"]),
-            custom_regexes=rules_regexes,
-            suppress_output=False,
-            branch=cast(str, kwargs["branch"]),
-            repo_path=cast(str, kwargs["repo_path"]),
-            path_inclusions=path_inclusions,
-            path_exclusions=path_exclusions,
+        remove_repo = False
+        if kwargs["git_url"]:
+            repo_path = util.clone_git_repo(cast(str, kwargs["git_url"]))
+            remove_repo = True
+        else:
+            repo_path = cast(str, kwargs["repo_path"])
+
+        output = scanner.scan_repo(
+            repo_path, rules_regexes, path_inclusions, path_exclusions, kwargs
         )
+
+        if remove_repo:
+            shutil.rmtree(repo_path, onerror=util.del_rw)
 
     if kwargs["cleanup"]:
         util.clean_outputs(output)

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -2,7 +2,7 @@ import json
 import re
 import shutil
 from functools import partial
-from typing import cast, Dict, List, Optional, Pattern, TextIO, Tuple, Union
+from typing import cast, Dict, Iterable, List, Optional, Pattern, TextIO, Tuple, Union
 
 import click
 import toml
@@ -105,3 +105,12 @@ def load_rules_from_file(rules_file):
     for rule in new_rules:
         regexes[rule] = re.compile(new_rules[rule])
     return regexes
+
+
+def compile_path_rules(patterns):
+    # type: (Iterable[str]) -> List[Pattern]
+    return [
+        re.compile(pattern.strip())
+        for pattern in patterns
+        if pattern and not pattern.startswith("#")
+    ]

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -33,7 +33,11 @@ def read_pyproject_toml(ctx, _param, value):
         if config_path.is_file():
             value = str(config_path)
         else:
-            return None
+            config_path = root_path / "tartufo.toml"
+            if config_path.is_file():
+                value = str(config_path)
+            else:
+                return None
     try:
         toml_file = toml.load(value)
         config = toml_file.get("tool", {}).get("tartufo", {})

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -23,7 +23,7 @@ PatternDict = Dict[str, Union[str, Pattern]]
 
 
 def read_pyproject_toml(ctx, _param, value):
-    # type: (click.Context, click.Parameter, Union[str, TextIO]) -> Optional[str]
+    # type: (click.Context, click.Parameter, str) -> Optional[str]
     if not value:
         root_path = ctx.params.get("repo_path", None)
         if not root_path:

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -371,7 +371,7 @@ def scan_repo(
         if extra_paths:
             file_path = pathlib.Path(extra_paths).resolve()
             if file_path.is_file():
-                with file_path.open() as paths_file:
+                with file_path.open("r", encoding="utf8") as paths_file:
                     path_inclusions.extend(
                         config.compile_path_rules(paths_file.readlines())
                     )
@@ -379,7 +379,7 @@ def scan_repo(
         if extra_paths:
             file_path = pathlib.Path(extra_paths).resolve()
             if file_path.is_file():
-                with file_path.open() as paths_file:
+                with file_path.open("r", encoding="utf8") as paths_file:
                     path_exclusions.extend(
                         config.compile_path_rules(paths_file.readlines())
                     )

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -361,7 +361,7 @@ def scan_repo(
     if not config_file.is_file():
         config_file = path / "tartufo.toml"
     if config_file.is_file() and str(config_file.resolve()) != str(options["config"]):
-        toml_file = toml.load(config_file)
+        toml_file = toml.load(str(config_file))
         repo_config = toml_file.get("tool", {}).get("tartufo", {})
     if repo_config:
         normalized_config = {

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -9,15 +9,19 @@ import hashlib
 import json
 import math
 import os
-import shutil
 import sys
 import tempfile
 import uuid
-from typing import Dict, Iterable, List, Optional, Pattern, Set, Union
+from typing import cast, Dict, Iterable, List, Optional, Pattern, Set, Union
 
 import git
+import toml
+from tartufo import config
 
-from tartufo import util
+try:
+    import pathlib
+except ImportError:
+    import pathlib2 as pathlib  # type: ignore
 
 
 BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
@@ -261,7 +265,7 @@ def path_included(blob, include_patterns=None, exclude_patterns=None):
 
 
 def find_strings(
-    git_url,  # type: str
+    repo_path,  # type: str
     since_commit=None,  # type: Optional[str]
     max_depth=1000000,  # type: int
     print_json=False,  # type: bool
@@ -270,17 +274,12 @@ def find_strings(
     suppress_output=True,  # type: bool
     custom_regexes=None,  # type: Optional[PatternDict]
     branch=None,  # type: Optional[str]
-    repo_path=None,  # type: Optional[str]
     path_inclusions=None,  # type: Optional[Iterable[Pattern]]
     path_exclusions=None,  # type: Optional[Iterable[Pattern]]
 ):
     # type: (...) -> IssueDict
     output = {"found_issues": []}  # type: IssueDict
-    if repo_path:
-        project_path = repo_path
-    else:
-        project_path = util.clone_git_repo(git_url)
-    repo = git.Repo(project_path)
+    repo = git.Repo(repo_path)
     already_searched = set()  # type: Set[bytes]
     output_dir = tempfile.mkdtemp()
 
@@ -343,11 +342,61 @@ def find_strings(
             branch_name,
         )
         output = handle_results(output, output_dir, found_issues)
-    output["project_path"] = project_path
-    output["clone_uri"] = git_url
+    output["project_path"] = repo_path
     output["issues_path"] = output_dir
-    if not repo_path:
-        shutil.rmtree(project_path, onerror=util.del_rw)
+    return output
+
+
+def scan_repo(
+    repo_path,  # type: str
+    regexes,  # type: Optional[PatternDict]
+    path_inclusions,  # type: List[Pattern]
+    path_exclusions,  # type: List[Pattern]
+    options,  # type: Dict[str, config.OptionTypes]
+):
+    # Check the repo for any local configs
+    repo_config = {}  # type: Dict[str, config.OptionTypes]
+    path = pathlib.Path(repo_path)
+    config_file = path / "pyproject.toml"
+    if not config_file.is_file():
+        config_file = path / "tartufo.toml"
+    if config_file.is_file() and str(config_file.resolve()) != str(options["config"]):
+        toml_file = toml.load(config_file)
+        repo_config = toml_file.get("tool", {}).get("tartufo", {})
+    if repo_config:
+        normalized_config = {
+            k.replace("--", "").replace("-", "_"): v for k, v in repo_config.items()
+        }
+        extra_paths = cast(str, normalized_config.get("include_paths", None))
+        if extra_paths:
+            file_path = pathlib.Path(extra_paths).resolve()
+            if file_path.is_file():
+                with file_path.open() as paths_file:
+                    path_inclusions.extend(
+                        config.compile_path_rules(paths_file.readlines())
+                    )
+        extra_paths = cast(str, normalized_config.get("exclude_paths", None))
+        if extra_paths:
+            file_path = pathlib.Path(extra_paths).resolve()
+            if file_path.is_file():
+                with file_path.open() as paths_file:
+                    path_exclusions.extend(
+                        config.compile_path_rules(paths_file.readlines())
+                    )
+
+    output = find_strings(
+        repo_path,
+        since_commit=cast(str, options["since_commit"]),
+        max_depth=cast(int, options["max_depth"]),
+        print_json=cast(bool, options["json"]),
+        do_regex=cast(bool, options["regex"]),
+        do_entropy=cast(bool, options["entropy"]),
+        custom_regexes=regexes,
+        suppress_output=False,
+        branch=cast(str, options["branch"]),
+        path_inclusions=path_inclusions,
+        path_exclusions=path_exclusions,
+    )
     return output
 
 

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import argparse
 import os
 import shutil
 import stat
@@ -20,20 +19,6 @@ def clean_outputs(output):
     issues_path = output.get("issues_path", None)
     if issues_path and os.path.isdir(issues_path):
         shutil.rmtree(output["issues_path"])
-
-
-def str2bool(v_string):
-    # type: (str) -> bool
-    if v_string is None:
-        return True
-
-    if v_string.lower() in ("yes", "true", "t", "y", "1"):
-        return True
-
-    if v_string.lower() in ("no", "false", "f", "n", "0"):
-        return False
-
-    raise argparse.ArgumentTypeError("Boolean value expected.")
 
 
 def clone_git_repo(git_url):

--- a/tests/data/config/tartufo.toml
+++ b/tests/data/config/tartufo.toml
@@ -1,0 +1,2 @@
+[tool.tartufo]
+regex = true

--- a/tests/data/pyproject.toml
+++ b/tests/data/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.tartufo]
+json = true

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -220,6 +220,8 @@ class CLITests(unittest.TestCase):
             )
 
     @mock.patch("tartufo.cli.scanner.scan_repo")
+    @mock.patch("tartufo.cli.util.clone_git_repo", new=mock.MagicMock())
+    @mock.patch("tartufo.cli.shutil.rmtree", new=mock.MagicMock())
     def test_issues_path_is_called_out(self, mock_scan_repo):
         mock_scan_repo.return_value = {"issues_path": "/foo"}
         runner = CliRunner()
@@ -228,6 +230,8 @@ class CLITests(unittest.TestCase):
             self.assertEqual(result.output, "Results have been saved in /foo\n")
 
     @mock.patch("tartufo.cli.scanner.scan_repo")
+    @mock.patch("tartufo.cli.util.clone_git_repo", new=mock.MagicMock())
+    @mock.patch("tartufo.cli.shutil.rmtree", new=mock.MagicMock())
     def test_command_exits_with_positive_return_code_when_issues_found(
         self, mock_scan_repo
     ):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,11 @@
 from __future__ import unicode_literals
 
+import os
 import re
 import unittest
 
+import click
+from click.testing import CliRunner
 from truffleHogRegexes.regexChecks import regexes as default_regexes
 
 from tartufo import config
@@ -72,6 +75,46 @@ class ConfigureRegexTests(unittest.TestCase):
             actual_regexes,
             "The regexes dictionary should not have been changed when no rules files are specified",
         )
+
+
+class ConfigFileTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.data_dir = pathlib.Path(__file__).parent / "data"
+        return super(ConfigFileTests, cls).setUpClass()
+
+    def setUp(self):
+        self.ctx = click.Context(click.Command("foo"))
+        self.param = click.Option(["--config"])
+        return super(ConfigFileTests, self).setUp()
+
+    def test_pyproject_toml_gets_read_if_no_file_specified(self):
+        cur_dir = pathlib.Path()
+        os.chdir(str(self.data_dir))
+        config.read_pyproject_toml(self.ctx, self.param, "")
+        os.chdir(str(cur_dir))
+        self.assertEqual(self.ctx.default_map, {"json": True})
+
+    def test_tartufo_toml_gets_read_if_no_pyproject_toml(self):
+        cur_dir = pathlib.Path()
+        os.chdir(str(self.data_dir / "config"))
+        config.read_pyproject_toml(self.ctx, self.param, "")
+        os.chdir(str(cur_dir))
+        self.assertEqual(self.ctx.default_map, {"regex": True})
+
+    def test_specified_file_gets_read(self):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            toml_file = self.data_dir / "config" / "tartufo.toml"
+            config.read_pyproject_toml(self.ctx, self.param, str(toml_file))
+        self.assertEqual(self.ctx.default_map, {"regex": True})
+
+    def test_fully_resolved_filename_is_returned(self):
+        cur_dir = pathlib.Path()
+        os.chdir(str(self.data_dir / "config"))
+        result = config.read_pyproject_toml(self.ctx, self.param, "")
+        os.chdir(str(cur_dir))
+        self.assertEqual(result, str(self.data_dir / "config" / "tartufo.toml"))
 
 
 if __name__ == "__main__":

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -8,6 +8,11 @@ import six
 from tartufo import scanner
 
 try:
+    import pathlib
+except ImportError:
+    import pathlib2 as pathlib  # type: ignore
+
+try:
     from unittest import mock
 except ImportError:
     import mock  # type: ignore
@@ -28,21 +33,6 @@ class EntropyTests(unittest.TestCase):
 
 
 class ScannerTests(unittest.TestCase):
-    @mock.patch("tartufo.scanner.hashlib", new=mock.MagicMock())
-    @mock.patch("tartufo.scanner.tempfile", new=mock.MagicMock())
-    @mock.patch("tartufo.scanner.git.Repo")
-    @mock.patch("tartufo.scanner.util.clone_git_repo")
-    @mock.patch("tartufo.scanner.util.shutil.rmtree")
-    def test_find_strings_works_against_already_cloned_repo(
-        self, mock_rmtree, mock_clone, mock_repo
-    ):
-        scanner.find_strings("find_repo", repo_path="/test/path")
-        mock_repo.assert_called_once_with("/test/path")
-        mock_rmtree.assert_not_called()
-        mock_clone.assert_not_called()
-
-    @mock.patch("tartufo.scanner.util.clone_git_repo", new=mock.MagicMock())
-    @mock.patch("tartufo.scanner.util.shutil.rmtree", new=mock.MagicMock())
     @mock.patch("tartufo.scanner.tempfile", new=mock.MagicMock())
     @mock.patch("tartufo.scanner.git.Repo")
     def test_find_strings_checks_out_branch_when_specified(self, mock_repo):
@@ -70,10 +60,7 @@ class ScannerTests(unittest.TestCase):
         ]
 
         scanner.find_strings(
-            "git://fake/repo.git",
-            repo_path="/fake/repo",
-            print_json=True,
-            suppress_output=False,
+            "/fake/repo", print_json=True, suppress_output=False,
         )
 
         call_1 = mock.call(
@@ -114,18 +101,9 @@ class ScannerTests(unittest.TestCase):
         )
         mock_worker.assert_has_calls((call_1, call_2, call_3), any_order=True)
 
-    def test_unicode_expection(self):
-        """FIXME: What is this test actually testing?
-
-        How can we test the same thing without cloning an external repo?
-        """
-        try:
-            scanner.find_strings("https://github.com/dxa4481/tst.git")
-        except UnicodeEncodeError:
-            self.fail("Unicode print error")
-
     def test_return_correct_commit_hash(self):
         """FIXME: Split this test out into multiple smaller tests w/o real clone
+        FIXME: Also, this test will continue to grow slower the more times we commit
 
         Necessary:
             * Make sure all commits are checked (done)
@@ -146,8 +124,10 @@ class ScannerTests(unittest.TestCase):
         # Redirect STDOUT, run scan and re-establish STDOUT
         sys.stdout = tmp_stdout
         try:
+            # Scan this repo itself
+            repo_path = pathlib.Path(__file__).parent.parent
             scanner.find_strings(
-                "https://github.com/godaddy/tartufo.git",
+                str(repo_path),
                 since_commit=since_commit,
                 print_json=True,
                 suppress_output=False,

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,11 +1,12 @@
 import json
 import re
+import shutil
 import sys
 import unittest
 from collections import namedtuple
 
 import six
-from tartufo import scanner
+from tartufo import scanner, util
 
 try:
     import pathlib
@@ -124,14 +125,17 @@ class ScannerTests(unittest.TestCase):
         # Redirect STDOUT, run scan and re-establish STDOUT
         sys.stdout = tmp_stdout
         try:
-            # Scan this repo itself
-            repo_path = pathlib.Path(__file__).parent.parent
-            scanner.find_strings(
-                str(repo_path),
-                since_commit=since_commit,
-                print_json=True,
-                suppress_output=False,
-            )
+            # We have to clone tartufo mostly because TravisCI only does a shallow clone
+            repo_path = util.clone_git_repo("git@github.com:godaddy/tartufo.git")
+            try:
+                scanner.find_strings(
+                    str(repo_path),
+                    since_commit=since_commit,
+                    print_json=True,
+                    suppress_output=False,
+                )
+            finally:
+                shutil.rmtree(repo_path)
         finally:
             sys.stdout = bak_stdout
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 import re
 import shutil
@@ -126,7 +128,7 @@ class ScannerTests(unittest.TestCase):
         sys.stdout = tmp_stdout
         try:
             # We have to clone tartufo mostly because TravisCI only does a shallow clone
-            repo_path = util.clone_git_repo("git@github.com:godaddy/tartufo.git")
+            repo_path = util.clone_git_repo("https://github.com/godaddy/tartufo.git")
             try:
                 scanner.find_strings(
                     str(repo_path),
@@ -418,7 +420,7 @@ class ScanRepoTests(unittest.TestCase):
             branch=None,
             path_inclusions=[],
             path_exclusions=[
-                re.compile(r"tests/"),
+                re.compile("tests/"),
                 re.compile(r"\.venv/"),
                 re.compile(r".*\.egg-info/"),
             ],


### PR DESCRIPTION
Fixes #18.

I added a few things in here:

* We now look for `tartufo.toml` in addition to `pyproject.toml`, for non-Python projects
* When scanning a remote git repo, we look for config files and load their values for `include-paths` and `exclude-paths`. These struck me as the most vital to load from the repo config. Others can be added as necessary, but this seemed like a good first effort.
* Moved the git clone functionality outside the `find_strings` function, because it absolutely did not belong in there in the first place.
* Introduced a new `scan_repo` function which gives a single code path for both remote and local repos being scanned. It is called *after* the git clone, performs the config lookups, and then passes on to `find_strings`.
* Marked the project as "typed", or fully type annotated, so mypy can treat it as such