### PR TITLE
Allow regex rules to be stored in a separate repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## vX.Y.Z -
 
 * Support reading config from `tartufo.toml` for non-Python projects
+* #17 - A separate repository can be used for storing rules files
 * #18 - Read the `pyproject.toml` or `tartufo.toml` from the repo being scanned
 
 ## v1.0.2 - 19 November 2019

--- a/README.md
+++ b/README.md
@@ -221,7 +221,18 @@ Options:
   --cleanup / --no-cleanup        Clean up all temporary result files.
                                   [default: False]
   --pre-commit                    Scan staged files in local repo clone.
-  --config FILENAME               Read configuration from specified file.
+  --git-rules-repo TEXT           A file path, or git URL, pointing to a git
+                                  repository containing regex rules to be used
+                                  for scanning. By default, all .json files
+                                  will be loaded from the root of that
+                                  repository. --git-rules-files can be used to
+                                  override this behavior and load specific
+                                  files.
+  --git-rules-files TEXT          Used in conjunction with --git-rules-repo,
+                                  specify glob-style patterns for files from
+                                  which to load the regex rules. Can be
+                                  specified multiple times.
+  --config FILE                   Read configuration from specified file.
                                   [default: pyproject.toml]
   -h, --help                      Show this message and exit.
 ```

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -91,7 +91,7 @@ def configure_regexes(
         cloned_repo = False
         repo_path = None
         if rules_repo:
-            repo_path = pathlib.Path(rules_repo).resolve()
+            repo_path = pathlib.Path(rules_repo)
             if not repo_path.is_dir():
                 repo_path = pathlib.Path(util.clone_git_repo(rules_repo))
             if not rules_repo_files:

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -1,11 +1,24 @@
+import copy
 import json
 import re
 import shutil
 from functools import partial
-from typing import cast, Dict, Iterable, List, Optional, Pattern, TextIO, Tuple, Union
+from typing import (
+    Any,
+    Dict,
+    IO,
+    Iterable,
+    List,
+    Optional,
+    Pattern,
+    TextIO,
+    Tuple,
+    Union,
+)
 
 import click
 import toml
+import truffleHogRegexes.regexChecks
 from tartufo import util
 
 try:
@@ -20,6 +33,8 @@ err = partial(  # pylint: disable=invalid-name
 OptionTypes = Union[str, int, bool, None, TextIO, Tuple[TextIO, ...]]
 OptionsDict = Dict[str, OptionTypes]
 PatternDict = Dict[str, Union[str, Pattern]]
+
+DEFAULT_REGEXES = truffleHogRegexes.regexChecks.regexes
 
 
 def read_pyproject_toml(ctx, _param, value):
@@ -56,43 +71,47 @@ def read_pyproject_toml(ctx, _param, value):
     return str(value)
 
 
-def configure_regexes_from_args(args, default_regexes):
-    # type: (OptionsDict, PatternDict) -> PatternDict
-    regexes = {}
-    if args["regex"]:
-        if args["default_regexes"]:
-            regexes.update(default_regexes)
-        # FIXME: git_rules(_repo) functionality was never called, nor tested.
-        #   https://github.com/godaddy/tartufo/issues/17 added for a new feature
-        rules_files = cast(Tuple[TextIO, ...], args["rules"])
-        if rules_files:  # or (args.git_rules_repo and args.git_rules):
-            # if args.git_rules_repo and args.git_rules:
-            #     configure_regexes_from_git(args.git_rules_repo, args.git_rules, rules_regexes)
-            if rules_files:
-                for rules_file in rules_files:
-                    loaded = load_rules_from_file(rules_file)
-                    dupes = set(loaded.keys()).intersection(regexes.keys())
-                    if dupes:
-                        raise ValueError(
-                            "Rule(s) were defined multiple time: {}".format(dupes)
-                        )
-                    regexes.update(loaded)
-    return regexes
+def configure_regexes(
+    include_default,  # type: bool
+    rules_files,  # type: Optional[Tuple[TextIO, ...]]
+    rules_repo,  # type: Optional[str]
+    rules_repo_files,  # type: Optional[Tuple[str, ...]]
+):
+    # type: (...) -> PatternDict
+    if include_default:
+        rules = copy.copy(DEFAULT_REGEXES)
+    else:
+        rules = {}
 
-
-def configure_regexes_from_git(
-    git_url, repo_rules_filenames, rules_regexes
-):  # pylint: disable=unused-argument
-    # type: (str, List[str], PatternDict) -> PatternDict
-    # FIXME: This was never called or tested.
-    #  https://github.com/godaddy/tartufo/issues/17 has been added for tracking
-    rules_project_path = util.clone_git_repo(git_url)
+    if rules_files:
+        all_files = list(rules_files)  # type: List[IO[Any]]
+    else:
+        all_files = []
     try:
-        # rules_filenames = [os.path.join(rules_project_path, repo_rules_filename)
-        #                    for repo_rules_filename in repo_rules_filenames]
-        return {}  # configure_regexes_from_rules_files(rules_filenames, rules_regexes)
+        cloned_repo = False
+        repo_path = None
+        if rules_repo:
+            repo_path = pathlib.Path(rules_repo)
+            if not repo_path.is_dir():
+                repo_path = pathlib.Path(util.clone_git_repo(rules_repo))
+            if not rules_repo_files:
+                rules_repo_files = ("*.json",)
+            for repo_file in rules_repo_files:
+                all_files.extend([path.open("r") for path in repo_path.glob(repo_file)])
+        if rules_files:
+            for rules_file in rules_files:
+                loaded = load_rules_from_file(rules_file)
+                dupes = set(loaded.keys()).intersection(rules.keys())
+                if dupes:
+                    raise ValueError(
+                        "Rule(s) were defined multiple times: {}".format(dupes)
+                    )
+                rules.update(loaded)
     finally:
-        shutil.rmtree(rules_project_path)
+        if cloned_repo:
+            shutil.rmtree(repo_path)  # type: ignore
+
+    return rules
 
 
 def load_rules_from_file(rules_file):

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -72,10 +72,10 @@ def read_pyproject_toml(ctx, _param, value):
 
 
 def configure_regexes(
-    include_default,  # type: bool
-    rules_files,  # type: Optional[Tuple[TextIO, ...]]
-    rules_repo,  # type: Optional[str]
-    rules_repo_files,  # type: Optional[Tuple[str, ...]]
+    include_default=True,  # type: bool
+    rules_files=None,  # type: Optional[Iterable[TextIO]]
+    rules_repo=None,  # type: Optional[str]
+    rules_repo_files=None,  # type: Optional[Iterable[str]]
 ):
     # type: (...) -> PatternDict
     if include_default:
@@ -91,7 +91,7 @@ def configure_regexes(
         cloned_repo = False
         repo_path = None
         if rules_repo:
-            repo_path = pathlib.Path(rules_repo)
+            repo_path = pathlib.Path(rules_repo).resolve()
             if not repo_path.is_dir():
                 repo_path = pathlib.Path(util.clone_git_repo(rules_repo))
             if not rules_repo_files:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 import unittest
 
 from click.testing import CliRunner
-from tartufo import cli
+from tartufo import cli, config
 
 try:
     import pathlib
@@ -90,6 +90,49 @@ class CLITests(unittest.TestCase):
                 {
                     "config": None,
                     "regex": False,
+                    "max_depth": 42,
+                    "entropy": True,
+                    "git_url": "git@github.com:godaddy/tartufo.git",
+                    "json": False,
+                    "rules": (),
+                    "default_regexes": True,
+                    "since_commit": None,
+                    "branch": None,
+                    "include_paths": None,
+                    "exclude_paths": None,
+                    "repo_path": None,
+                    "cleanup": False,
+                    "pre_commit": False,
+                    "git_rules_repo": None,
+                    "git_rules_files": (),
+                },
+            )
+
+    @mock.patch("tartufo.cli.util.clone_git_repo")
+    @mock.patch("tartufo.cli.scanner.scan_repo")
+    @mock.patch("tartufo.cli.shutil.rmtree", new=mock.MagicMock())
+    def test_default_regexes_get_used_by_default(self, mock_scan_repo, mock_clone):
+        mock_scan_repo.return_value = {}
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            runner.invoke(
+                cli.main,
+                [
+                    "--regex",
+                    "--max-depth",
+                    "42",
+                    "--entropy",
+                    "git@github.com:godaddy/tartufo.git",
+                ],
+            )
+            mock_scan_repo.assert_called_once_with(
+                mock_clone.return_value,
+                config.DEFAULT_REGEXES,
+                [],
+                [],
+                {
+                    "config": None,
+                    "regex": True,
                     "max_depth": 42,
                     "entropy": True,
                     "git_url": "git@github.com:godaddy/tartufo.git",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,12 +37,12 @@ class CLITests(unittest.TestCase):
                 result.output, "Regex checks requested, but no regexes found.\n"
             )
 
-    @mock.patch("tartufo.cli.config.configure_regexes_from_args")
+    @mock.patch("tartufo.cli.config.configure_regexes")
     def test_command_fails_from_invalid_regex(self, mock_config_regex):
         mock_config_regex.side_effect = ValueError("Foo!")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            result = runner.invoke(cli.main, ["--repo-path", "."])
+            result = runner.invoke(cli.main, ["--repo-path", ".", "--regex"])
             self.assertEqual(result.output, "Foo!\n")
 
     @mock.patch("tartufo.cli.scanner.find_staged")
@@ -103,6 +103,8 @@ class CLITests(unittest.TestCase):
                     "repo_path": None,
                     "cleanup": False,
                     "pre_commit": False,
+                    "git_rules_repo": None,
+                    "git_rules_files": (),
                 },
             )
 
@@ -142,6 +144,8 @@ class CLITests(unittest.TestCase):
                     "repo_path": working_dir,
                     "cleanup": False,
                     "pre_commit": False,
+                    "git_rules_repo": None,
+                    "git_rules_files": (),
                 },
             )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -91,7 +91,7 @@ class ConfigureRegexTests(unittest.TestCase):
     ):
         runner = CliRunner()
         with runner.isolated_filesystem():
-            repo_path = mock_pathlib.Path.return_value.resolve.return_value
+            repo_path = mock_pathlib.Path.return_value
             repo_path.is_dir.return_value = True
             repo_path.glob.return_value = []
             config.configure_regexes(rules_repo=".")
@@ -103,7 +103,7 @@ class ConfigureRegexTests(unittest.TestCase):
     ):
         runner = CliRunner()
         with runner.isolated_filesystem():
-            repo_path = mock_pathlib.Path.return_value.resolve.return_value
+            repo_path = mock_pathlib.Path.return_value
             repo_path.is_dir.return_value = True
             repo_path.glob.return_value = []
             config.configure_regexes(rules_repo=".", rules_repo_files=("tartufo.json",))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,12 +1,12 @@
 from __future__ import unicode_literals
 
+import copy
 import os
 import re
 import unittest
 
 import click
 from click.testing import CliRunner
-from truffleHogRegexes.regexChecks import regexes as default_regexes
 
 from tartufo import config
 
@@ -15,17 +15,23 @@ try:
 except ImportError:
     import pathlib2 as pathlib  # type: ignore
 
+try:
+    from unittest import mock
+except ImportError:
+    import mock  # type: ignore
+
 
 class ConfigureRegexTests(unittest.TestCase):
-    def test_configure_regexes_from_args_rules_files_without_defaults(self):
+    def test_configure_regexes_rules_files_without_defaults(self):
         rules_path = pathlib.Path(__file__).parent / "data" / "testRules.json"
         rules_files = (rules_path.open(),)
         expected_regexes = {
             "RSA private key 2": re.compile("-----BEGIN EC PRIVATE KEY-----")
         }
 
-        args = {"regex": True, "default_regexes": False, "rules": rules_files}
-        actual_regexes = config.configure_regexes_from_args(args, default_regexes)
+        actual_regexes = config.configure_regexes(
+            include_default=False, rules_files=rules_files
+        )
 
         self.assertEqual(
             expected_regexes,
@@ -34,16 +40,17 @@ class ConfigureRegexTests(unittest.TestCase):
             "(expected: {}, actual: {})".format(expected_regexes, actual_regexes),
         )
 
-    def test_configure_regexes_from_args_rules_files_with_defaults(self):
+    def test_configure_regexes_rules_files_with_defaults(self):
         rules_path = pathlib.Path(__file__).parent / "data" / "testRules.json"
         rules_files = (rules_path.open(),)
-        expected_regexes = dict(default_regexes)
+        expected_regexes = copy.copy(config.DEFAULT_REGEXES)
         expected_regexes["RSA private key 2"] = re.compile(
             "-----BEGIN EC PRIVATE KEY-----"
         )
 
-        args = {"regex": True, "default_regexes": True, "rules": rules_files}
-        actual_regexes = config.configure_regexes_from_args(args, default_regexes)
+        actual_regexes = config.configure_regexes(
+            include_default=True, rules_files=rules_files
+        )
 
         self.assertEqual(
             expected_regexes,
@@ -52,29 +59,55 @@ class ConfigureRegexTests(unittest.TestCase):
             "(expected: {}, actual: {})".format(expected_regexes, actual_regexes),
         )
 
-    def test_configure_regexes_from_args_no_do_regex(self):
-        rules_path = pathlib.Path(__file__).parent / "data" / "testRules.json"
-        rules_files = (rules_path.open(),)
-        args = {"regex": False, "default_regexes": True, "rules": rules_files}
-        actual_regexes = config.configure_regexes_from_args(args, default_regexes)
+    def test_configure_regexes_returns_just_default_regexes_by_default(self):
+        actual_regexes = config.configure_regexes()
 
         self.assertEqual(
-            {},
-            actual_regexes,
-            "The regexes dictionary should be empty when do_regex is False",
-        )
-
-    def test_configure_regexes_from_args_no_rules(self):
-        expected_regexes = dict(default_regexes)
-
-        args = {"regex": True, "default_regexes": True, "rules": ()}
-        actual_regexes = config.configure_regexes_from_args(args, default_regexes)
-
-        self.assertEqual(
-            expected_regexes,
+            config.DEFAULT_REGEXES,
             actual_regexes,
             "The regexes dictionary should not have been changed when no rules files are specified",
         )
+
+    @mock.patch("tartufo.config.util.clone_git_repo")
+    def test_configure_regexes_does_not_clone_if_local_rules_repo_defined(
+        self, mock_clone
+    ):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            config.configure_regexes(rules_repo=".")
+        mock_clone.assert_not_called()
+
+    @mock.patch("tartufo.config.util.clone_git_repo")
+    def test_configure_regexes_clones_git_rules_repo(self, mock_clone):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            mock_clone.return_value = pathlib.Path(".").resolve()
+            config.configure_regexes(rules_repo="git@github.com:godaddy/tartufo.git")
+        mock_clone.assert_called_once_with("git@github.com:godaddy/tartufo.git")
+
+    @mock.patch("tartufo.config.pathlib")
+    def test_configure_regexes_grabs_all_json_from_rules_repo_by_default(
+        self, mock_pathlib
+    ):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            repo_path = mock_pathlib.Path.return_value.resolve.return_value
+            repo_path.is_dir.return_value = True
+            repo_path.glob.return_value = []
+            config.configure_regexes(rules_repo=".")
+            repo_path.glob.assert_called_once_with("*.json")
+
+    @mock.patch("tartufo.config.pathlib")
+    def test_configure_regexes_grabs_specified_rules_files_from_repo(
+        self, mock_pathlib
+    ):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            repo_path = mock_pathlib.Path.return_value.resolve.return_value
+            repo_path.is_dir.return_value = True
+            repo_path.glob.return_value = []
+            config.configure_regexes(rules_repo=".", rules_repo_files=("tartufo.json",))
+            repo_path.glob.assert_called_once_with("tartufo.json")
 
 
 class ConfigFileTests(unittest.TestCase):

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -1,8 +1,9 @@
 # pylint: skip-file
 # type: ignore
 
-Optional  # unused import (tartufo/config.py:5)
-repo_rules_filenames  # unused variable (tartufo/config.py:80)
+Any  # unused import (tartufo/config.py:7)
+IO  # unused import (tartufo/config.py:9)
+Optional  # unused import (tartufo/config.py:12)
 Iterable  # unused import (tartufo/scanner.py:16)
 Optional  # unused import (tartufo/scanner.py:16)
 Set  # unused import (tartufo/scanner.py:16)


### PR DESCRIPTION
Fixes #17 

This adds 2 new command line options:
* `--git-rules-repo` for the repo which stores the regex rules
* `--git-rules-files` for the file patterns to match in the rules repo

Did some unification of the regex configuration code into a single `configure_regexes` function, and moved all "default regexes" references to point to `config.DEFAULT_REGEXES`.

Changed to only call `configure_regexes` when necessary. Why try to configure them if the user asked for them to not be used?

I'm also trying to move away from passing the kwargs dict around everywhere, and instead only passing around necessary variables. This is hopefully going to move us in the direction of cleaner, more easily traceable code.