### PR TITLE
Represent issues with a class, rather than a dictionary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from setuptools import setup
 INSTALL_REQUIRES = [
     "click >= 7.0.0, < 8.0.0",
     "colorama; sys_platform == 'win32'",
+    "enum34; python_version < '3.4'",
     "GitPython >= 2.1.1, < 4.0.0",
     "pathlib2; python_version < '3.4'",
     "toml >= 0.10.0, < 1.0.0",

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup
 
 INSTALL_REQUIRES = [
     "click >= 7.0.0, < 8.0.0",
+    "colorama; sys_platform == 'win32'",
     "GitPython >= 2.1.1, < 4.0.0",
     "pathlib2; python_version < '3.4'",
     "toml >= 0.10.0, < 1.0.0",

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -4,8 +4,10 @@ import os
 import shutil
 import stat
 import tempfile
+from functools import partial
 from typing import Callable
 
+import click
 from git import Repo
 
 
@@ -26,3 +28,10 @@ def clone_git_repo(git_url):
     project_path = tempfile.mkdtemp()
     Repo.clone_from(git_url, project_path)
     return project_path
+
+
+style_ok = partial(click.style, fg="bright_green")  # pylint: disable=invalid-name
+style_error = partial(  # pylint: disable=invalid-name
+    click.style, fg="red", bold=True, err=True
+)
+style_warning = partial(click.style, fg="bright_yellow")  # pylint: disable=invalid-name

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -150,7 +150,7 @@ class ScannerTests(unittest.TestCase):
         self.assertEqual(commit_w_secret, filtered_results[0]["commit_hash"])
         # Additionally, we cross-validate the commit comment matches the expected comment
         self.assertEqual(
-            xcheck_commit_w_scrt_comment, filtered_results[0]["commit"].strip()
+            xcheck_commit_w_scrt_comment, filtered_results[0]["commit_message"].strip()
         )
 
     def test_path_included(self):


### PR DESCRIPTION
Taking the text of the primary commit in this PR:

> This was a rather large shift in the code, and the start of a larger cleanup discussed, in part, in #23. The actual changes include:
> 
> * `Issue` is now a top level class used to represent issues found in scanning The `Bcolors` class is gone, replaced by the styling functionality of1 the `click` library
> * `print_results` has been removed, in favor of the `__str__` method on the `Issue` class. This greatly improves the testability of the code and makes it easier to output everything at once and potentially even use a pager for output in the future.
> * JSON output now uses the `as_dict` method on the `Issue` class, for a more clear representation of what exactly is output.
> 
> There is also one larger implied change here; I have not been explicitly including Python 2.7 support. The one immediate place this is likely to be a problem is in the use of the `enum` library. This was not added to Python until 3.4. While there is a backport available via the `enum34` package, I hesitate to add this. I would prefer to take this as the beginning of 2.0 development, in which we drop support for Python 2.7 entirely.

The one notable deviance, since writing that, is that Python 2.7 is still supported. It turns out that `enum34` is easy enough of a drop-in backport to not use it. For now. This does not, however, change my opinion that we should drop Python 2 support in the next major version. But I think that this should be done as one atomic PR, as opposed to piecemeal as this would have been.

Also, it was far too easy to adapt the tests to the new code. I changed one single assertion, even after I made massive changes to the internal API. This makes my confidence in the reliability of the tests even lower. I think they need some pretty major reworking before they can be truly relied upon. But that should come naturally with the rest of the work in #23.