### PR TITLE
Drop support for Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: python
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
-  - "pypy"
   - "pypy3"
 install: pip install tox-travis codecov
 script: tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ regex = true
 entropy = true
 
 [tool.black]
-target-version = ['py27', 'py35', 'py36', 'py37', 'py38']
+target-version = ['py35', 'py36', 'py37', 'py38']
 exclude = '''
 /(
     \.eggs         # exclude a few common directories in the

--- a/setup.py
+++ b/setup.py
@@ -4,19 +4,15 @@ from setuptools import setup
 INSTALL_REQUIRES = [
     "click >= 7.0.0, < 8.0.0",
     "colorama; sys_platform == 'win32'",
-    "enum34; python_version < '3.4'",
     "GitPython >= 2.1.1, < 4.0.0",
-    "pathlib2; python_version < '3.4'",
     "toml >= 0.10.0, < 1.0.0",
     "truffleHogRegexes >= 0.0.7, < 1.0.0",
-    "typing; python_version < '3.5'",
 ]
 
 EXTRAS_REQUIRE = {
     "tests": [
         "black==19.10b0; python_version >= '3.6' and platform_python_implementation == 'CPython'",
         "coverage",
-        "mock; python_version == '2.7'",
         "pre-commit",
         "pytest",
         "pytest-cov",
@@ -58,7 +54,6 @@ setup(
         "Natural Language :: English",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/setup.py
+++ b/setup.py
@@ -60,5 +60,6 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Topic :: Security",
         "Topic :: Software Development :: Version Control :: Git",
+        "Typing :: Typed",
     ],
 )

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -119,8 +119,7 @@ err = partial(  # pylint: disable=invalid-name
 )
 @click.argument("git_url", required=False)
 @click.pass_context
-def main(ctx, **kwargs):
-    # type: (click.Context, config.OptionTypes) -> None
+def main(ctx: click.Context, **kwargs: config.OptionTypes) -> None:
     """Find secrets hidden in the depths of git.
 
     Tartufo will, by default, scan the entire history of a git repository

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -1,9 +1,10 @@
 import copy
 import json
+import pathlib
 import re
 import shutil
 from functools import partial
-from typing import (
+from typing import (  # pylint: disable=unused-import
     Any,
     Dict,
     IO,
@@ -20,11 +21,6 @@ import click
 import toml
 import truffleHogRegexes.regexChecks
 from tartufo import util
-
-try:
-    import pathlib
-except ImportError:
-    import pathlib2 as pathlib  # type: ignore
 
 
 err = partial(  # pylint: disable=invalid-name

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -28,13 +28,13 @@ err = partial(  # pylint: disable=invalid-name
 )
 OptionTypes = Union[str, int, bool, None, TextIO, Tuple[TextIO, ...]]
 OptionsDict = Dict[str, OptionTypes]
-PatternDict = Dict[str, Union[str, Pattern]]
 
 DEFAULT_REGEXES = truffleHogRegexes.regexChecks.regexes
 
 
-def read_pyproject_toml(ctx, _param, value):
-    # type: (click.Context, click.Parameter, str) -> Optional[str]
+def read_pyproject_toml(
+    ctx: click.Context, _param: click.Parameter, value: str
+) -> Optional[str]:
     if not value:
         root_path = ctx.params.get("repo_path", None)
         if not root_path:
@@ -68,12 +68,11 @@ def read_pyproject_toml(ctx, _param, value):
 
 
 def configure_regexes(
-    include_default=True,  # type: bool
-    rules_files=None,  # type: Optional[Iterable[TextIO]]
-    rules_repo=None,  # type: Optional[str]
-    rules_repo_files=None,  # type: Optional[Iterable[str]]
-):
-    # type: (...) -> PatternDict
+    include_default: bool = True,
+    rules_files: Optional[Iterable[TextIO]] = None,
+    rules_repo: Optional[str] = None,
+    rules_repo_files: Optional[Iterable[str]] = None,
+) -> Dict[str, Pattern]:
     if include_default:
         rules = copy.copy(DEFAULT_REGEXES)
     else:
@@ -110,8 +109,7 @@ def configure_regexes(
     return rules
 
 
-def load_rules_from_file(rules_file):
-    # type: (TextIO) -> Dict[str, Pattern]
+def load_rules_from_file(rules_file: TextIO) -> Dict[str, Pattern]:
     regexes = {}
     try:
         new_rules = json.load(rules_file)
@@ -122,8 +120,7 @@ def load_rules_from_file(rules_file):
     return regexes
 
 
-def compile_path_rules(patterns):
-    # type: (Iterable[str]) -> List[Pattern]
+def compile_path_rules(patterns: Iterable[str]) -> List[Pattern]:
     return [
         re.compile(pattern.strip())
         for pattern in patterns

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -23,7 +23,6 @@ HEX_CHARS = "1234567890abcdefABCDEF"
 
 # FIXME: This should be replaced with a dataclass to better track the attributes
 IssueDict = Dict[str, Union[str, List[str]]]
-PatternDict = Dict[str, Union[str, Pattern]]
 
 
 class IssueType(enum.Enum):
@@ -44,13 +43,11 @@ class Issue:
     commit = None  # type: Optional[git.Commit]
     branch_name = None  # type: Optional[str]
 
-    def __init__(self, issue_type, strings_found):
-        # type: (IssueType, List[str]) -> None
+    def __init__(self, issue_type: IssueType, strings_found: List[str]) -> None:
         self.issue_type = issue_type
         self.strings_found = strings_found
 
-    def as_dict(self):
-        # type: () -> Dict[str, Optional[str]]
+    def as_dict(self) -> Dict[str, Optional[str]]:
         """Return a dictionary representation of an issue.
 
         This is primarily meant to aid in JSON serialization.
@@ -69,45 +66,39 @@ class Issue:
         return output
 
     @property
-    def printable_diff(self):
-        # type: () -> str
+    def printable_diff(self) -> str:
         if not self.diff:
             return "No diff available."
         return self.diff.diff.decode("utf-8", errors="replace")
 
     @property
-    def commit_time(self):
-        # type: () -> Optional[str]
+    def commit_time(self) -> Optional[str]:
         if not self.commit:
             return None
         commit_time = datetime.datetime.fromtimestamp(self.commit.committed_date)
         return commit_time.strftime(self.DATETIME_FORMAT)
 
     @property
-    def commit_message(self):
-        # type: () -> Optional[str]
+    def commit_message(self) -> Optional[str]:
         if not self.commit:
             return None
         return self.commit.message
 
     @property
-    def commit_hash(self):
-        # type: () -> Optional[str]
+    def commit_hash(self) -> Optional[str]:
         if not self.commit:
             return None
         return self.commit.hexsha
 
     @property
-    def file_path(self):
-        # type: () -> Optional[str]
+    def file_path(self) -> Optional[str]:
         if not self.diff:
             return None
         if self.diff.b_path:
             return self.diff.b_path
         return self.diff.a_path
 
-    def __str__(self):
-        # type: () -> str
+    def __str__(self) -> str:
         output = []
         diff_body = self.printable_diff
         for bad_str in self.strings_found:  # type: ignore
@@ -130,8 +121,7 @@ class Issue:
         return "\n".join(output)
 
 
-def shannon_entropy(data, iterator):
-    # type: (str, Iterable[str]) -> float
+def shannon_entropy(data: str, iterator: Iterable[str]) -> float:
     """
     Borrowed from http://blog.dkbza.org/2007/05/scanning-data-for-entropy-anomalies.html
     """
@@ -145,8 +135,9 @@ def shannon_entropy(data, iterator):
     return entropy
 
 
-def get_strings_of_set(word, char_set, threshold=20):
-    # type: (str, Iterable[str], int) -> List[str]
+def get_strings_of_set(
+    word: str, char_set: Iterable[str], threshold: int = 20
+) -> List[str]:
     count = 0
     letters = ""
     strings = []
@@ -164,8 +155,7 @@ def get_strings_of_set(word, char_set, threshold=20):
     return strings
 
 
-def find_entropy(printable_diff):
-    # type: (str) -> Optional[Issue]
+def find_entropy(printable_diff: str) -> Optional[Issue]:
     strings_found = []
     lines = printable_diff.split("\n")
     for line in lines:
@@ -185,13 +175,14 @@ def find_entropy(printable_diff):
     return None
 
 
-def find_regex(printable_diff, regex_list=None):
-    # type: (str, Optional[PatternDict]) -> List[Issue]
+def find_regex(
+    printable_diff: str, regex_list: Optional[Dict[str, Pattern]] = None
+) -> List[Issue]:
     if regex_list is None:
         regex_list = {}
     regex_matches = []
     for key in regex_list:
-        found_strings = regex_list[key].findall(printable_diff)  # type: ignore
+        found_strings = regex_list[key].findall(printable_diff)
         if found_strings:
             issue = Issue(IssueType.RegEx, found_strings)
             issue.issue_detail = key
@@ -200,18 +191,17 @@ def find_regex(printable_diff, regex_list=None):
 
 
 def diff_worker(
-    diff,  # type: git.DiffIndex
-    custom_regexes,  # type: Optional[PatternDict]
-    do_entropy,  # type: bool
-    do_regex,  # type: bool
-    print_json,  # type: bool
-    suppress_output,  # type: bool
-    path_inclusions,  # type: Optional[Iterable[Pattern]]
-    path_exclusions,  # type: Optional[Iterable[Pattern]]
-    prev_commit=None,  # type: Optional[git.Commit]
-    branch_name=None,  # type: Optional[str]
-):
-    # type: (...) -> List[Issue]
+    diff: git.DiffIndex,
+    custom_regexes: Optional[Dict[str, Pattern]],
+    do_entropy: bool,
+    do_regex: bool,
+    print_json: bool,
+    suppress_output: bool,
+    path_inclusions: Optional[Iterable[Pattern]],
+    path_exclusions: Optional[Iterable[Pattern]],
+    prev_commit: Optional[git.Commit] = None,
+    branch_name: Optional[str] = None,
+) -> List[Issue]:
     issues = []  # type: List[Issue]
     for blob in diff:
         printable_diff = blob.diff.decode("utf-8", errors="replace")
@@ -239,8 +229,9 @@ def diff_worker(
     return issues
 
 
-def handle_results(output, output_dir, found_issues):
-    # type: (IssueDict, str, List[Issue]) -> IssueDict
+def handle_results(
+    output: IssueDict, output_dir: str, found_issues: List[Issue]
+) -> IssueDict:
     for found_issue in found_issues:
         result_path = os.path.join(output_dir, str(uuid.uuid4()))
         with open(result_path, "w+") as result_file:
@@ -249,8 +240,11 @@ def handle_results(output, output_dir, found_issues):
     return output
 
 
-def path_included(blob, include_patterns=None, exclude_patterns=None):
-    # type: (git.Blob, Optional[Iterable[Pattern]], Optional[Iterable[Pattern]]) -> bool
+def path_included(
+    blob: git.Blob,
+    include_patterns: Optional[Iterable[Pattern]] = None,
+    exclude_patterns: Optional[Iterable[Pattern]] = None,
+) -> bool:
     """Check if the diff blob object should included in analysis.
 
     If defined and non-empty, `include_patterns` has precedence over `exclude_patterns`, such that a blob that is not
@@ -277,19 +271,18 @@ def path_included(blob, include_patterns=None, exclude_patterns=None):
 
 
 def find_strings(
-    repo_path,  # type: str
-    since_commit=None,  # type: Optional[str]
-    max_depth=1000000,  # type: int
-    print_json=False,  # type: bool
-    do_regex=False,  # type: bool
-    do_entropy=True,  # type: bool
-    suppress_output=True,  # type: bool
-    custom_regexes=None,  # type: Optional[PatternDict]
-    branch=None,  # type: Optional[str]
-    path_inclusions=None,  # type: Optional[Iterable[Pattern]]
-    path_exclusions=None,  # type: Optional[Iterable[Pattern]]
-):
-    # type: (...) -> IssueDict
+    repo_path: str,
+    since_commit: Optional[str] = None,
+    max_depth: int = 1000000,
+    print_json: bool = False,
+    do_regex: bool = False,
+    do_entropy: bool = True,
+    suppress_output: bool = True,
+    custom_regexes: Optional[Dict[str, Pattern]] = None,
+    branch: Optional[str] = None,
+    path_inclusions: Optional[Iterable[Pattern]] = None,
+    path_exclusions: Optional[Iterable[Pattern]] = None,
+) -> IssueDict:
     output = {"found_issues": []}  # type: IssueDict
     repo = git.Repo(repo_path)
     already_searched = set()  # type: Set[bytes]
@@ -360,12 +353,12 @@ def find_strings(
 
 
 def scan_repo(
-    repo_path,  # type: str
-    regexes,  # type: Optional[PatternDict]
-    path_inclusions,  # type: List[Pattern]
-    path_exclusions,  # type: List[Pattern]
-    options,  # type: Dict[str, config.OptionTypes]
-):
+    repo_path: str,
+    regexes: Optional[Dict[str, Pattern]],
+    path_inclusions: List[Pattern],
+    path_exclusions: List[Pattern],
+    options: Dict[str, config.OptionTypes],
+) -> IssueDict:
     # Check the repo for any local configs
     repo_config = {}  # type: Dict[str, config.OptionTypes]
     path = pathlib.Path(repo_path)
@@ -413,16 +406,15 @@ def scan_repo(
 
 
 def find_staged(
-    project_path,  # type: str
-    print_json=False,  # type: bool
-    do_regex=False,  # type: bool
-    do_entropy=True,  # type: bool
-    suppress_output=True,  # type: bool
-    custom_regexes=None,  # type: Optional[PatternDict]
-    path_inclusions=None,  # type: Optional[Iterable[Pattern]]
-    path_exclusions=None,  # type: Optional[Iterable[Pattern]]
-):
-    # type: (...) -> IssueDict
+    project_path: str,
+    print_json: bool = False,
+    do_regex: bool = False,
+    do_entropy: bool = True,
+    suppress_output: bool = True,
+    custom_regexes: Optional[Dict[str, Pattern]] = None,
+    path_inclusions: Optional[Iterable[Pattern]] = None,
+    path_exclusions: Optional[Iterable[Pattern]] = None,
+) -> IssueDict:
     output = {"found_issues": []}  # type: IssueDict
     output_dir = tempfile.mkdtemp()
     repo = git.Repo(project_path, search_parent_directories=True)

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -1,15 +1,12 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import datetime
 import enum
 import hashlib
 import json
 import math
 import os
+import pathlib
 import tempfile
 import uuid
 from typing import cast, Dict, Iterable, List, Optional, Pattern, Set, Union
@@ -19,11 +16,6 @@ import git
 import toml
 from tartufo import config
 from tartufo.util import style_ok, style_warning
-
-try:
-    import pathlib
-except ImportError:
-    import pathlib2 as pathlib  # type: ignore
 
 
 BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -5,26 +5,24 @@ import shutil
 import stat
 import tempfile
 from functools import partial
-from typing import Callable
+from typing import Any, Callable, Dict
 
 import click
 from git import Repo
 
 
-def del_rw(_func, name, _exc):
-    # type: (Callable, str, Exception) -> None
+def del_rw(_func: Callable, name: str, _exc: Exception) -> None:
     os.chmod(name, stat.S_IWRITE)
     os.remove(name)
 
 
-def clean_outputs(output):
+def clean_outputs(output: Dict[str, Any]) -> None:
     issues_path = output.get("issues_path", None)
     if issues_path and os.path.isdir(issues_path):
         shutil.rmtree(output["issues_path"])
 
 
-def clone_git_repo(git_url):
-    # type: (str) -> str
+def clone_git_repo(git_url: str) -> str:
     project_path = tempfile.mkdtemp()
     Repo.clone_from(git_url, project_path)
     return project_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,17 +1,9 @@
+import pathlib
 import unittest
+from unittest import mock
 
 from click.testing import CliRunner
 from tartufo import cli, config
-
-try:
-    import pathlib
-except ImportError:
-    import pathlib2 as pathlib  # type: ignore
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock  # type: ignore
 
 
 class CLITests(unittest.TestCase):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,24 +1,14 @@
-from __future__ import unicode_literals
-
 import copy
 import os
+import pathlib
 import re
 import unittest
+from unittest import mock
 
 import click
 from click.testing import CliRunner
 
 from tartufo import config
-
-try:
-    import pathlib
-except ImportError:
-    import pathlib2 as pathlib  # type: ignore
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock  # type: ignore
 
 
 class ConfigureRegexTests(unittest.TestCase):

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,24 +1,14 @@
-from __future__ import unicode_literals
-
 import json
+import pathlib
 import re
 import shutil
 import sys
 import unittest
 from collections import namedtuple
+from unittest import mock
 
 import six
 from tartufo import scanner, util
-
-try:
-    import pathlib
-except ImportError:
-    import pathlib2 as pathlib  # type: ignore
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock  # type: ignore
 
 
 class EntropyTests(unittest.TestCase):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,11 +1,7 @@
 import unittest
+from unittest import mock
 
 from tartufo import util
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock  # type: ignore
 
 
 class GitTests(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ minversion = 3.7.0
 toxworkdir = {env:TOX_WORK_DIR:.tox}
 skip_missing_interpreters = True
 usedevelop = True
-envlist = py{27,35,36,37,38,py,py3},black,mypy,pylint,vulture
+envlist = py{35,36,37,38,py3},black,mypy,pylint,vulture
 parallel_show_output = True
 isolated_build = True
 


### PR DESCRIPTION
Python 2 is dead! Long live Python 3!

This removes all support for Python 2, and start using some more recent syntax. From here on, only 3.5+ are supported.

* Removed all `__future__` imports
* Removed the backport packages `enum34`, `mock`, `pathlib2`, and `typing`.
* Stopped testing against Python 2
* Moved the function type annotations inline (inline variable annotations are only available in 3.6+)

Fixes #30 