### PR TITLE
Change working directory to avoid tartufo self-scan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,7 @@ WORKDIR /app
 
 RUN pip install -e .
 
-ENTRYPOINT [ "tartufo" ]
-CMD [ "-h" ]
+WORKDIR /git
+
+ENTRYPOINT [ "tartufo"]
+CMD ["-h"]

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -32,11 +32,10 @@ in a local repository. The repository location can be specified using
 caller's current working directory is assumed to be somewhere within the local
 clone's tree and the repository root is determined automatically.
 
-The following example demonstrates how tartufo can be used to verify secrets
+The following example demonstrates how tartufo can be used in ``.git/hooks/pre-commit`` to verify that secrets
 will not be committed to a git repository in error:
 
 .. code-block:: sh
-   :caption: .git/hooks/pre-commit
 
    #!/bin/sh
 
@@ -54,9 +53,11 @@ were discovered) will git commit the staged changes.
 Note that it is always possible, although not recommended, to bypass the
 pre-commit hook by using ``git commit --no-verify``.
 
-If you would like to automate these hooks, you can use the `pre-commit`_ tool
-by adding a ``.pre-commit-config.yaml`` file to your repository. You can copy
-and paste the following to get you started:
+If you would like to automate these hooks, you can use either the ``Python pre-commit hook`` Python tartufo invocation, or use the ``Docker pre-commit hook``.
+
+Python pre-commit hook
++++++++++++++++++++++
+Add a ``.pre-commit-config.yaml`` file to your repository. You can copy and paste the following to get you started:
 
 .. code-block:: yaml
 
@@ -73,6 +74,17 @@ That's it! Now your contributors only need to run ``pre-commit install
    You probably don't actually want to use the `master` rev. This is the active
    development branch for this project, and can not be guaranteed stable. Your
    best bet would be to choose the latest version, currently |version|.
+   
+Docker pre-commit hook
+++++++++++++++++++++++
+
+Use the docker image as pre-commit hook by adding the docker run command to `.git/hooks/pre-commit`:
+```
+docker pull godaddy/tartufo
+cat <<EOF > .git/hooks/pre-commit
+docker run -t --rm -v "$PWD:/git" godaddy/tartufo --pre-commit
+EOF
+```
 
 Temporary File Cleanup
 ----------------------

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -79,12 +79,13 @@ Docker pre-commit hook
 ++++++++++++++++++++++
 
 Use the docker image as pre-commit hook by adding the docker run command to `.git/hooks/pre-commit`:
-```
-docker pull godaddy/tartufo
-cat <<EOF > .git/hooks/pre-commit
-docker run -t --rm -v "$PWD:/git" godaddy/tartufo --pre-commit
-EOF
-```
+
+.. code-block:: sh
+
+    docker pull godaddy/tartufo
+    cat <<EOF > .git/hooks/pre-commit
+    docker run -t --rm -v "$PWD:/git" godaddy/tartufo --pre-commit
+    EOF
 
 Temporary File Cleanup
 ----------------------

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -53,10 +53,11 @@ were discovered) will git commit the staged changes.
 Note that it is always possible, although not recommended, to bypass the
 pre-commit hook by using ``git commit --no-verify``.
 
-If you would like to automate these hooks, you can use either the ``Python pre-commit hook`` Python tartufo invocation, or use the ``Docker pre-commit hook``.
+If you would like to automate these hooks, you can use either the ``Python`` or ``Docker`` approach to setting up tartufo as a pre-commit hook
 
 Python pre-commit hook
 +++++++++++++++++++++
+
 Add a ``.pre-commit-config.yaml`` file to your repository. You can copy and paste the following to get you started:
 
 .. code-block:: yaml
@@ -78,7 +79,7 @@ That's it! Now your contributors only need to run ``pre-commit install
 Docker pre-commit hook
 ++++++++++++++++++++++
 
-Use the docker image as pre-commit hook by adding the docker run command to `.git/hooks/pre-commit`:
+Use the docker image as pre-commit hook by adding the docker run command to ``.git/hooks/pre-commit``:
 
 .. code-block:: sh
 


### PR DESCRIPTION
This is a fix for the pre-commit part of [Issue #44](https://github.com/godaddy/tartufo/issues/44) when using the docker image for tartufo secret scanning.

Changing working directory from `/app` go the mounted directory `/git` to avoid tartufo scanning itself. The `--repo-path` will then default to `.` which will be the current `/git` directory that contains the repository we want to scan. 
 
Usage instructions in a pre-commit scenario: 
```
docker run -t --rm -v "$PWD:/git" godaddy/tartufo --pre-commit
```

However, when omitting the `pre-commit` option, tartufo will attempt to do a full history scan that requires cloning the repository. For this to work with the docker image, we would need to mount ssh keys or use a type of github deploy key with access to the repository onto the docker image when running it. Following up this scenario in a separate PR. 
