### PR TITLE
Rebuild the scanner(s) as class(es).

### DIFF
--- a/.tartufo-excludes
+++ b/.tartufo-excludes
@@ -1,3 +1,4 @@
 poetry.lock
 pyproject.toml
 docs/source/(.*)\.rst
+tests/test_base_scanner\.py

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -255,7 +255,8 @@ class ScannerBase(abc.ABC):
                     issues.append(issue)
         return issues
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def chunks(self) -> Generator[Chunk, None, None]:
         """Yield "chunks" of data to be scanned.
 

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -244,11 +244,11 @@ class ScannerBase(abc.ABC):
 
     def scan_regex(self, chunk: Chunk) -> List[Issue]:
         issues: List[Issue] = []
-        for key, pattern in self.rules_regexes:
+        for key, pattern in self.rules_regexes.items():
             found_strings = pattern.findall(chunk.contents)
             for match in found_strings:
                 # Filter out any explicitly "allowed" match signatures
-                if self.signature_is_excluded(match, chunk.file_path):
+                if not self.signature_is_excluded(match, chunk.file_path):
                     issue = Issue(IssueType.RegEx, match)
                     issue.issue_detail = key
                     issues.append(issue)
@@ -345,7 +345,7 @@ class GitRepoScanner(ScannerBase):
                     )
 
             # Finally, yield the first commit to the branch
-            diff = diff_index.diff(git.NULL_TREE, create_patch=True)
+            diff = curr_commit.diff(git.NULL_TREE, create_patch=True)
             for blob, file_path in self._iter_diff_index(diff):
                 yield Chunk(
                     blob,

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -344,13 +344,14 @@ class GitRepoScanner(ScannerBase):
                     )
 
             # Finally, yield the first commit to the branch
-            diff = curr_commit.diff(git.NULL_TREE, create_patch=True)
-            for blob, file_path in self._iter_diff_index(diff):
-                yield Chunk(
-                    blob,
-                    file_path,
-                    util.extract_commit_metadata(prev_commit, remote_branch),
-                )
+            if curr_commit:
+                diff = curr_commit.diff(git.NULL_TREE, create_patch=True)
+                for blob, file_path in self._iter_diff_index(diff):
+                    yield Chunk(
+                        blob,
+                        file_path,
+                        util.extract_commit_metadata(prev_commit, remote_branch),
+                    )
 
 
 def shannon_entropy(data: str, iterator: Iterable[str]) -> float:

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -304,7 +304,7 @@ class GitRepoScanner(ScannerBase):
                     since_commit_reached = True
                 if since_commit_reached:
                     prev_commit = curr_commit
-                    continue
+                    break
             if not prev_commit:
                 prev_commit = curr_commit
                 continue

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -367,33 +367,13 @@ def shannon_entropy(data: str, iterator: Iterable[str]) -> float:
     return entropy
 
 
-def get_strings_of_set(
-    word: str, char_set: Iterable[str], threshold: int = 20
-) -> List[str]:
-    count = 0
-    letters = ""
-    strings = []
-    for char in word:
-        if char in char_set:
-            letters += char
-            count += 1
-        else:
-            if count > threshold:
-                strings.append(letters)
-            letters = ""
-            count = 0
-    if count > threshold:
-        strings.append(letters)
-    return strings
-
-
 def find_entropy(printable_diff: str) -> List[Issue]:
     issues = []
     lines = printable_diff.split("\n")
     for line in lines:
         for word in line.split():
-            base64_strings = get_strings_of_set(word, BASE64_CHARS)
-            hex_strings = get_strings_of_set(word, HEX_CHARS)
+            base64_strings = util.get_strings_of_set(word, BASE64_CHARS)
+            hex_strings = util.get_strings_of_set(word, HEX_CHARS)
             for string in base64_strings:
                 b64_entropy = shannon_entropy(string, BASE64_CHARS)
                 if b64_entropy > 4.5:

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -171,13 +171,13 @@ class ScannerBase(abc.ABC):
 
     @lru_cache()
     def should_scan(self, file_path):
-        """Check if the a file path should included in analysis.
+        """Check if the a file path should be included in analysis.
 
         If non-empty, `self.included_paths` has precedence over
         `self.excluded_paths`, such that a file path that is not matched by any
         of the defined `self.included_paths` will be excluded, even when it is
         not matched by any of the defined `self.excluded_paths`. If either
-        `self.included_pats` or `self.excluded_paths` are undefined or empty,
+        `self.included_paths` or `self.excluded_paths` are undefined or empty,
         they will have no effect, respectively. All file paths are included by
         this function when no inclusions or exclusions exist.
 

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -35,3 +35,9 @@ class GitOptions(GlobalOptions):
 class IssueType(enum.Enum):
     Entropy = "High Entropy"
     RegEx = "Regular Expression Match"
+
+
+@dataclass
+class Chunk:
+    contents: str
+    file_path: str

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -1,7 +1,7 @@
 # pylint: disable=too-many-instance-attributes
 import enum
-from dataclasses import dataclass
-from typing import Optional, TextIO, Tuple
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, TextIO, Tuple
 
 from click import Path
 
@@ -41,3 +41,4 @@ class IssueType(enum.Enum):
 class Chunk:
     contents: str
     file_path: str
+    metadata: Dict[str, Any] = field(default_factory=dict)

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -81,12 +81,11 @@ def generate_signature(snippet: str, filename: str) -> str:
 
 
 def extract_commit_metadata(
-    curr_commit: git.Commit, prev_commit: git.Commit, branch: git.FetchInfo
+    commit: git.Commit, branch: git.FetchInfo
 ) -> Dict[str, Any]:
     return {
-        "diff": curr_commit.diff.decode("utf-8", errors="replace"),
-        "commit_time": datetime.datetime.fromtimestamp(prev_commit.committed_date),
-        "commit_message": prev_commit.message,
-        "commit_hash": prev_commit.hexsha,
+        "commit_time": datetime.datetime.fromtimestamp(commit.committed_date),
+        "commit_message": commit.message,
+        "commit_hash": commit.hexsha,
         "branch": branch.name,
     }

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import datetime
 import json
 import os
 import pathlib
@@ -9,10 +10,10 @@ import tempfile
 import uuid
 from functools import lru_cache, partial
 from hashlib import blake2s
-from typing import Callable, List, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, TYPE_CHECKING
 
 import click
-from git import Repo
+import git
 
 if TYPE_CHECKING:
     from tartufo.scanner import Issue  # pylint: disable=cyclic-import
@@ -55,7 +56,7 @@ def clean_outputs(output_dir: pathlib.Path) -> None:
 
 def clone_git_repo(git_url: str) -> str:
     project_path = tempfile.mkdtemp()
-    Repo.clone_from(git_url, project_path)
+    git.Repo.clone_from(git_url, project_path)
     return project_path
 
 
@@ -77,3 +78,15 @@ def generate_signature(snippet: str, filename: str) -> str:
     These signatures are used for configuring excluded/approved issues,
     such as secrets intentionally embedded in tests."""
     return blake2s("{}$${}".format(snippet, filename).encode("utf-8")).hexdigest()
+
+
+def extract_commit_metadata(
+    curr_commit: git.Commit, prev_commit: git.Commit, branch: git.FetchInfo
+) -> Dict[str, Any]:
+    return {
+        "diff": curr_commit.diff.decode("utf-8", errors="replace"),
+        "commit_time": datetime.datetime.fromtimestamp(prev_commit.committed_date),
+        "commit_message": prev_commit.message,
+        "commit_hash": prev_commit.hexsha,
+        "branch": branch.name,
+    }

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -10,7 +10,7 @@ import tempfile
 import uuid
 from functools import lru_cache, partial
 from hashlib import blake2s
-from typing import Any, Callable, Dict, List, TYPE_CHECKING
+from typing import Any, Callable, Dict, Iterable, List, TYPE_CHECKING
 
 import click
 import git
@@ -89,3 +89,30 @@ def extract_commit_metadata(
         "commit_hash": commit.hexsha,
         "branch": branch.name,
     }
+
+
+def get_strings_of_set(
+    word: str, char_set: Iterable[str], threshold: int = 20
+) -> List[str]:
+    """Split a "word" into a set of "strings", based on a given character set.
+
+    The returned strings must have a length, at minimum, equal to `threshold`.
+    This is meant for extracting long strings which are likely to be things like
+    auto-generated passwords, tokens, hashes, etc.
+    """
+    count: int = 0
+    letters: str = ""
+    strings: List[str] = []
+
+    for char in word:
+        if char in char_set:
+            letters += char
+            count += 1
+        else:
+            if count > threshold:
+                strings.append(letters)
+            letters = ""
+            count = 0
+    if count > threshold:
+        strings.append(letters)
+    return strings

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -236,3 +236,139 @@ class RegexScanTests(ScannerTestCase):
         self.assertEqual(issues[0].issue_detail, "foo")
         self.assertEqual(issues[0].issue_type, types.IssueType.RegEx)
         self.assertEqual(issues[0].matched_string, "foo")
+
+
+class EntropyTests(ScannerTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.options.entropy = True
+        self.chunk = types.Chunk(
+            """
+        foo bar
+        asdfqwer
+        """,
+            "foo.py",
+        )
+        self.scanner = TestScanner(self.options)
+
+    def test_calculate_base64_entropy_calculation(self):
+        random_string = (
+            "ZWVTjPQSdhwRgl204Hc51YCsritMIzn8B=/p9UyeX7xu6KkAGqfm3FJ+oObLDNEva"
+        )
+        self.assertGreaterEqual(
+            self.scanner.calculate_entropy(random_string, scanner.BASE64_CHARS), 4.5
+        )
+
+    def test_calculate_hex_entropy_calculation(self):
+        random_string = "b3A0a1FDfe86dcCE945B72"
+        self.assertGreaterEqual(
+            self.scanner.calculate_entropy(random_string, scanner.HEX_CHARS), 3
+        )
+
+    def test_empty_string_has_no_entropy(self):
+        self.assertEqual(self.scanner.calculate_entropy("", ""), 0.0)
+
+    @mock.patch("tartufo.util.get_strings_of_set")
+    def test_scan_entropy_find_b64_strings_for_every_word_in_diff(
+        self, mock_strings: mock.MagicMock
+    ):
+        mock_strings.return_value = []
+        self.scanner.scan_entropy(self.chunk)
+        mock_strings.assert_has_calls(
+            (
+                mock.call("foo", scanner.BASE64_CHARS),
+                mock.call("foo", scanner.HEX_CHARS),
+                mock.call("bar", scanner.BASE64_CHARS),
+                mock.call("bar", scanner.HEX_CHARS),
+                mock.call("asdfqwer", scanner.BASE64_CHARS),
+                mock.call("asdfqwer", scanner.HEX_CHARS),
+            )
+        )
+
+    @mock.patch("tartufo.util.get_strings_of_set")
+    def test_issues_are_not_created_for_b64_string_excluded_signatures(
+        self, mock_strings: mock.MagicMock
+    ):
+        mock_strings.side_effect = (["foo"], [], [], [], [], [])
+        mock_signature = mock.MagicMock()
+        mock_signature.return_value = True
+        self.scanner.signature_is_excluded = mock_signature  # type: ignore
+        mock_calculate = mock.MagicMock()
+        self.scanner.calculate_entropy = mock_calculate
+        issues = self.scanner.scan_entropy(self.chunk)
+        mock_calculate.assert_not_called()
+        self.assertEqual(issues, [])
+
+    @mock.patch("tartufo.util.get_strings_of_set")
+    def test_issues_are_not_created_for_hex_string_excluded_signatures(
+        self, mock_strings: mock.MagicMock
+    ):
+        mock_strings.side_effect = ([], ["foo"], [], [], [], [])
+        mock_signature = mock.MagicMock()
+        mock_signature.return_value = True
+        self.scanner.signature_is_excluded = mock_signature  # type: ignore
+        mock_calculate = mock.MagicMock()
+        self.scanner.calculate_entropy = mock_calculate
+        issues = self.scanner.scan_entropy(self.chunk)
+        mock_calculate.assert_not_called()
+        self.assertEqual(issues, [])
+
+    @mock.patch("tartufo.util.get_strings_of_set")
+    def test_issues_are_created_for_high_entropy_b64_strings(
+        self, mock_strings: mock.MagicMock
+    ):
+        mock_strings.side_effect = (["foo"], [], [], [], [], [])
+        mock_signature = mock.MagicMock()
+        mock_signature.return_value = False
+        self.scanner.signature_is_excluded = mock_signature  # type: ignore
+        mock_calculate = mock.MagicMock()
+        mock_calculate.return_value = 9.0
+        self.scanner.calculate_entropy = mock_calculate
+        issues = self.scanner.scan_entropy(self.chunk)
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0].issue_type, types.IssueType.Entropy)
+        self.assertEqual(issues[0].matched_string, "foo")
+
+    @mock.patch("tartufo.util.get_strings_of_set")
+    def test_issues_are_created_for_high_entropy_hex_strings(
+        self, mock_strings: mock.MagicMock
+    ):
+        mock_strings.side_effect = ([], ["foo"], [], [], [], [])
+        mock_signature = mock.MagicMock()
+        mock_signature.return_value = False
+        self.scanner.signature_is_excluded = mock_signature  # type: ignore
+        mock_calculate = mock.MagicMock()
+        mock_calculate.return_value = 9.0
+        self.scanner.calculate_entropy = mock_calculate
+        issues = self.scanner.scan_entropy(self.chunk)
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0].issue_type, types.IssueType.Entropy)
+        self.assertEqual(issues[0].matched_string, "foo")
+
+    @mock.patch("tartufo.util.get_strings_of_set")
+    def test_issues_are_not_created_for_low_entropy_b64_strings(
+        self, mock_strings: mock.MagicMock
+    ):
+        mock_strings.side_effect = (["foo"], [], [], [], [], [])
+        mock_signature = mock.MagicMock()
+        mock_signature.return_value = False
+        self.scanner.signature_is_excluded = mock_signature  # type: ignore
+        mock_calculate = mock.MagicMock()
+        mock_calculate.return_value = 1.0
+        self.scanner.calculate_entropy = mock_calculate
+        issues = self.scanner.scan_entropy(self.chunk)
+        self.assertEqual(len(issues), 0)
+
+    @mock.patch("tartufo.util.get_strings_of_set")
+    def test_issues_are_not_created_for_low_entropy_hex_strings(
+        self, mock_strings: mock.MagicMock
+    ):
+        mock_strings.side_effect = ([], ["foo"], [], [], [], [])
+        mock_signature = mock.MagicMock()
+        mock_signature.return_value = False
+        self.scanner.signature_is_excluded = mock_signature  # type: ignore
+        mock_calculate = mock.MagicMock()
+        mock_calculate.return_value = 1.0
+        self.scanner.calculate_entropy = mock_calculate
+        issues = self.scanner.scan_entropy(self.chunk)
+        self.assertEqual(len(issues), 0)

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -14,6 +14,8 @@ class TestScanner(scanner.ScannerBase):  # pylint: disable=too-many-instance-att
     Since `chunks` is an abstract property, we cannot directly instantiate the
     `ScannerBase` class."""
 
+    __test__ = False
+
     @property
     def chunks(self):
         return ("foo", "bar", "baz")

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -372,3 +372,7 @@ class EntropyTests(ScannerTestCase):
         self.scanner.calculate_entropy = mock_calculate
         issues = self.scanner.scan_entropy(self.chunk)
         self.assertEqual(len(issues), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -1,0 +1,141 @@
+# pylint: disable=protected-access
+import unittest
+from unittest import mock
+
+import git
+
+from tartufo import scanner, types
+from tartufo.types import GitOptions
+
+from tests.helpers import generate_options
+
+
+class ScannerTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.options = generate_options(GitOptions)
+
+
+class RepoLoadTests(ScannerTestCase):
+    @mock.patch("git.Repo")
+    def test_repo_is_loaded_on_init(self, mock_repo: mock.MagicMock):
+        scanner.GitRepoScanner(self.options, ".")
+        mock_repo.assert_called_once_with(".")
+
+    @mock.patch("git.Repo")
+    def test_load_repo_loads_new_repo(self, mock_repo: mock.MagicMock):
+        test_scanner = scanner.GitRepoScanner(self.options, ".")
+        test_scanner.load_repo("../tartufo")
+        mock_repo.assert_has_calls((mock.call("."), mock.call("../tartufo")))
+
+
+class ChunkGeneratorTests(ScannerTestCase):
+    @mock.patch("git.Repo")
+    def test_single_branch_is_loaded_if_specified(self, mock_repo: mock.MagicMock):
+        self.options.branch = "foo"
+        mock_fetch = mock.MagicMock()
+        mock_fetch.return_value = []
+        mock_repo.return_value.remotes.origin.fetch = mock_fetch
+        test_scanner = scanner.GitRepoScanner(self.options, ".")
+        for _ in test_scanner.chunks:
+            pass
+        mock_fetch.assert_called_once_with("foo")
+
+    @mock.patch("git.Repo")
+    def test_all_branches_are_loaded_if_specified(self, mock_repo: mock.MagicMock):
+        mock_fetch = mock.MagicMock()
+        mock_fetch.return_value = []
+        mock_repo.return_value.remotes.origin.fetch = mock_fetch
+        test_scanner = scanner.GitRepoScanner(self.options, ".")
+        for _ in test_scanner.chunks:
+            pass
+        mock_fetch.assert_called_once_with()
+
+    @mock.patch("git.Repo")
+    def test_all_branches_are_scanned_for_commits(self, mock_repo: mock.MagicMock):
+        mock_fetch = mock.MagicMock()
+        mock_fetch.return_value = ["foo", "bar"]
+        mock_repo.return_value.remotes.origin.fetch = mock_fetch
+        test_scanner = scanner.GitRepoScanner(self.options, ".")
+        mock_iter_commits = mock.MagicMock()
+        mock_iter_commits.return_value = []
+        test_scanner._iter_branch_commits = (  # type: ignore
+            mock_iter_commits
+        )
+        for _ in test_scanner.chunks:
+            pass
+        mock_iter_commits.assert_has_calls(
+            (
+                mock.call(mock_repo.return_value, "foo"),
+                mock.call(mock_repo.return_value, "bar"),
+            )
+        )
+
+    @mock.patch("git.Repo")
+    def test_all_commits_are_scanned_for_files(self, mock_repo: mock.MagicMock):
+        mock_fetch = mock.MagicMock()
+        mock_fetch.return_value = ["foo"]
+        mock_repo.return_value.remotes.origin.fetch = mock_fetch
+        test_scanner = scanner.GitRepoScanner(self.options, ".")
+        mock_iter_commits = mock.MagicMock()
+        mock_commit_1 = mock.MagicMock()
+        mock_commit_2 = mock.MagicMock()
+        mock_commit_3 = mock.MagicMock()
+        mock_iter_commits.return_value = [
+            (mock_commit_2, mock_commit_3),
+            (mock_commit_1, mock_commit_2),
+        ]
+        test_scanner._iter_branch_commits = mock_iter_commits  # type: ignore
+        mock_iter_diff = mock.MagicMock()
+        mock_iter_diff.return_value = []
+        test_scanner._iter_diff_index = mock_iter_diff  # type: ignore
+        for _ in test_scanner.chunks:
+            pass
+        mock_commit_2.diff.assert_called_once_with(mock_commit_3, create_patch=True)
+        mock_commit_1.diff.assert_has_calls(
+            (
+                mock.call(mock_commit_2, create_patch=True),
+                mock.call(git.NULL_TREE, create_patch=True),
+            )
+        )
+        mock_iter_diff.assert_has_calls(
+            (
+                mock.call(mock_commit_2.diff.return_value),
+                mock.call(mock_commit_1.diff.return_value),
+                mock.call(mock_commit_1.diff.return_value),
+            )
+        )
+
+    @mock.patch("tartufo.util.extract_commit_metadata")
+    @mock.patch("git.Repo")
+    def test_all_files_are_yielded_as_chunks(
+        self, mock_repo: mock.MagicMock, mock_extract: mock.MagicMock
+    ):
+        mock_fetch = mock.MagicMock()
+        mock_fetch.return_value = ["foo"]
+        mock_repo.return_value.remotes.origin.fetch = mock_fetch
+        test_scanner = scanner.GitRepoScanner(self.options, ".")
+        mock_iter_commits = mock.MagicMock()
+        mock_commit_1 = mock.MagicMock()
+        mock_commit_2 = mock.MagicMock()
+        mock_iter_commits.return_value = [(mock_commit_1, mock_commit_2)]
+        test_scanner._iter_branch_commits = mock_iter_commits  # type: ignore
+        mock_iter_diff = mock.MagicMock()
+        mock_iter_diff.return_value = [("foo", "bar.py"), ("baz", "blah.py")]
+        test_scanner._iter_diff_index = mock_iter_diff  # type: ignore
+        chunks = list(test_scanner.chunks)
+        # These get duplicated in this test, because `_iter_diff_index` is called
+        # both in the normal branch/commit iteration, and then once more afterward
+        # to capture the first commit on the branch
+        self.assertEqual(
+            chunks,
+            [
+                types.Chunk("foo", "bar.py", mock_extract.return_value),
+                types.Chunk("baz", "blah.py", mock_extract.return_value),
+                types.Chunk("foo", "bar.py", mock_extract.return_value),
+                types.Chunk("baz", "blah.py", mock_extract.return_value),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -426,6 +426,44 @@ class ScannerBaseTests(unittest.TestCase):
         test_scanner.issues  # pylint: disable=pointless-statement
         mock_scan.assert_not_called()
 
+    @mock.patch("tartufo.config.compile_path_rules")
+    def test_populated_included_paths_list_does_not_recompute(self, mock_compile):
+        test_scanner = TestScanner(self.options)
+        test_scanner._included_paths = []  # pylint: disable=protected-access
+        test_scanner.included_paths  # pylint: disable=pointless-statement
+        mock_compile.assert_not_called()
+
+    def test_included_paths_is_empty_if_not_specified(self):
+        test_scanner = TestScanner(self.options)
+        self.assertEqual(test_scanner.included_paths, [])
+
+    @mock.patch("tartufo.config.compile_path_rules")
+    def test_include_paths_are_calculated_if_specified(self, mock_compile):
+        mock_include = mock.MagicMock()
+        self.options.include_paths = mock_include
+        test_scanner = TestScanner(self.options)
+        test_scanner.included_paths  # pylint: disable=pointless-statement
+        mock_compile.assert_called_once_with(mock_include.readlines.return_value)
+
+    @mock.patch("tartufo.config.compile_path_rules")
+    def test_populated_excluded_paths_list_does_not_recompute(self, mock_compile):
+        test_scanner = TestScanner(self.options)
+        test_scanner._excluded_paths = []  # pylint: disable=protected-access
+        test_scanner.excluded_paths  # pylint: disable=pointless-statement
+        mock_compile.assert_not_called()
+
+    def test_excluded_paths_is_empty_if_not_specified(self):
+        test_scanner = TestScanner(self.options)
+        self.assertEqual(test_scanner.excluded_paths, [])
+
+    @mock.patch("tartufo.config.compile_path_rules")
+    def test_exclude_paths_are_calculated_if_specified(self, mock_compile):
+        mock_exclude = mock.MagicMock()
+        self.options.exclude_paths = mock_exclude
+        test_scanner = TestScanner(self.options)
+        test_scanner.excluded_paths  # pylint: disable=pointless-statement
+        mock_compile.assert_called_once_with(mock_exclude.readlines.return_value)
+
 
 class GitRepoScannerTests(unittest.TestCase):
     pass

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -350,7 +350,7 @@ class DiffWorkerTests(unittest.TestCase):
     @mock.patch("tartufo.scanner.path_included")
     @mock.patch("tartufo.scanner.find_entropy")
     @mock.patch("tartufo.scanner.find_regex")
-    @mock.patch("tartufo.scanner.generate_signature")
+    @mock.patch("tartufo.util.generate_signature")
     def test_excluded_signatures_are_filtered_out(
         self, mock_signature, mock_regex, mock_entropy, mock_paths
     ):

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -369,9 +369,5 @@ class DiffWorkerTests(unittest.TestCase):
         self.assertEqual(issues, [regex_issue])
 
 
-class GitRepoScannerTests(unittest.TestCase):
-    pass
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -17,7 +17,7 @@ class GitTests(unittest.TestCase):
          should only ever rely on the code which is being directly tested.
     """
 
-    @mock.patch("tartufo.util.Repo.clone_from")
+    @mock.patch("git.Repo.clone_from")
     @mock.patch("tartufo.util.tempfile.mkdtemp")
     def test_tartufo_clones_git_repo_into_temp_dir(self, mock_mkdtemp, mock_clone):
         util.clone_git_repo("https://github.com/godaddy/tartufo.git")
@@ -25,7 +25,7 @@ class GitTests(unittest.TestCase):
             "https://github.com/godaddy/tartufo.git", mock_mkdtemp.return_value
         )
 
-    @mock.patch("tartufo.util.Repo.clone_from", new=mock.MagicMock())
+    @mock.patch("git.Repo.clone_from", new=mock.MagicMock())
     @mock.patch("tartufo.util.tempfile.mkdtemp")
     def test_clone_git_repo_returns_path_to_clone(self, mock_mkdtemp):
         repo_path = util.clone_git_repo("https://github.com/godaddy/tartufo.git")


### PR DESCRIPTION
**IMPORTANT UP FRONT NOTE:** This is a part of an incremental change. None of this new code is used yet. ~Honestly, it's not even unit tested yet. I would be open to writing unit tests against it before this gets merged.~ I wanted to at least get this PR in front of eyes quickly though.

This is a huge change. It's basically the first step in a major rewrite. This is an attempt to make the code more readable, more extensible, maintainable... and honestly, for some of it, just to understand what it's even doing.

Basically what I'm offering here is a re-implementation of the scanner, in a class-based form. You will notice that there is a class hierarchy here. It currently consists of the following:

```
ScannerBase
|-- GitRepoScanner
```

The goal is that this can be extended, and we can have many more scanner types in the future. I'm envisioning something like:

```
ScannerBase
|-- FileScanner
|   |-- FolderScanner
|-- GitScanner
    |-- PreCommitScanner
    |-- GitRepoScanner
    |   |-- LocalRepoScanner
    |   |-- RemoteRepoScanner
    |-- GithubOrgScanner
```

That complete structure is, of course, WAY down the line. But these can each be implemented one-by-one, and theoretically much more easily. In this way, this code is a large step toward #23. Also, as a direct result of this structure and modularity, this is a major step toward #39 and even #12. Basically, this restructured code enables the future of this project.

I tried to reduce complexity in as many places as I could, but I'm sure I did not succeed everywhere. One place that is evident is in the `GitRepoScanner._iter_branch_commits()` and `GitRepoScanner._iter_diff_index()` methods. They handle some of the nitty gritty of traversing back through git commit history. Previously this had been handled, along with a lot more, in the `find_strings()` function. This is my attempt to make more purpose-built functions, and keep the functions from growing too large. I hope that comes across well.

If you want to try this code out locally, you can do so! This little snippet will get you along your way. It utilizes a utility function I built for tests to build up a full set of options. This is an example of running this class-based scanner against `tartufo` itself:

```pycon
>>> from tartufo.scanner import GitRepoScanner
>>> from tests.helpers import generate_options
>>> from tartufo.types import GitOptions
>>>
>>> sc = GitRepoScanner(generate_options(GitOptions, exclude_paths=open(".tartufo-excludes", "r"), entropy=True, regex=True, exclude_signatures=(), default_regexes=True), ".")
>>>
>>> issues = sc.scan()
>>>
>>> len(issues)
243
>>>
```

Note that I have not yet verified that this 243 number is in any way correct. It may not be. Did I mention there are no unit tests for this new code yet? The accuracy will shake out in those tests.

I hope y'all like this new direction. Let me know.