### PR TITLE
Split the functionality into sub-commands

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
   - id: tartufo
     name: tartufo
     entry: tartufo
-    args: [--pre-commit, --cleanup]
+    args: [--cleanup, pre-commit]
     language: python
     pass_filenames: false
   - id: pylint

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: tartufo
   name: Tartufo
   description: '`tartufo` is a tool for scanning git repositories for secrets/passwords/high-entropy data'
-  entry: tartufo --pre-commit
+  entry: tartufo
   language: python
-  args: [--cleanup]
+  args: [--cleanup, pre-commit]
   pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,12 +172,6 @@ ignore = "docs/"
 [tool.coverage.run]
 branch = true
 source = ["tartufo"]
-omit = [
-    # The commands are all dynamically loaded and executed so they don't
-    #   get captured and measured by coverage. They will have to be covered
-    #   on the honor system. Luckily they have almost nothing to them.
-    "tartufo/commands/*"
-]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,12 @@ ignore = "docs/"
 [tool.coverage.run]
 branch = true
 source = ["tartufo"]
+omit = [
+    # The commands are all dynamically loaded and executed so they don't
+    #   get captured and measured by coverage. They will have to be covered
+    #   on the honor system. Luckily they have almost nothing to them.
+    "tartufo/commands/*"
+]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
+import importlib
 import pathlib
 from tempfile import mkdtemp
-from typing import Any, Dict, List, Tuple
+from typing import List, Tuple
 
 import click
 
@@ -10,6 +11,7 @@ from tartufo import config, scanner, types, util
 
 
 PLUGIN_DIR = pathlib.Path(__file__).parent / "commands"
+PLUGIN_MODULE = "tartufo.commands"
 
 
 class TartufoCLI(click.MultiCommand):
@@ -21,12 +23,10 @@ class TartufoCLI(click.MultiCommand):
         ]
 
     def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command:
-        exec_ns: Dict[str, Any] = {}
-        cmd_file = PLUGIN_DIR / "{}.py".format(cmd_name.replace("-", "_"))
-        with cmd_file.open() as handle:
-            cmd_code = compile(handle.read(), cmd_file.name, "exec")
-            eval(cmd_code, exec_ns, exec_ns)  # pylint: disable=eval-used
-        return exec_ns["main"]
+        module = importlib.import_module(
+            f".{cmd_name.replace('-', '_')}", PLUGIN_MODULE
+        )
+        return module.main  # type: ignore
 
 
 @click.command(

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -124,7 +124,6 @@ class TartufoCLI(click.MultiCommand):
     callback=config.read_pyproject_toml,
     help="Read configuration from specified file. [default: pyproject.toml]",
 )
-# @click.argument("git_url", required=False)
 @click.pass_context
 def main(ctx: click.Context, **kwargs: config.OptionTypes) -> None:
     """Find secrets hidden in the depths of git.

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -45,21 +45,23 @@ class TartufoCLI(click.MultiCommand):
     "--default-regexes/--no-default-regexes",
     is_flag=True,
     default=True,
+    show_default=True,
     help="Whether to include the default regex list when configuring"
-    " search patterns. Only applicable if --rules is also specified."
-    " [default: --default-regexes]",
+    " search patterns. Only applicable if --rules is also specified.",
 )
 @click.option(
     "--entropy/--no-entropy",
     is_flag=True,
     default=True,
-    help="Enable entropy checks. [default: True]",
+    show_default=True,
+    help="Enable entropy checks.",
 )
 @click.option(
     "--regex/--no-regex",
     is_flag=True,
     default=False,
-    help="Enable high signal regexes checks. [default: False]",
+    show_default=True,
+    help="Enable high signal regexes checks.",
 )
 @click.option(
     "-i",
@@ -95,7 +97,8 @@ class TartufoCLI(click.MultiCommand):
     "--cleanup/--no-cleanup",
     is_flag=True,
     default=False,
-    help="Clean up all temporary result files. [default: False]",
+    show_default=True,
+    help="Clean up all temporary result files.",
 )
 @click.option(
     "--git-rules-repo",

--- a/tartufo/commands/pre_commit.py
+++ b/tartufo/commands/pre_commit.py
@@ -1,0 +1,25 @@
+import pathlib
+from typing import List, Tuple
+
+import click
+
+from tartufo import types, util
+from tartufo.scanner import GitPreCommitScanner, Issue
+
+
+@click.command("pre-commit")
+@click.pass_obj
+@click.pass_context
+def main(ctx: click.Context, options: types.GlobalOptions) -> Tuple[str, List[Issue]]:
+    """Scan staged changes in a pre-commit hook."""
+    print("*** SCANNING PRE-COMMIT")
+    print("*** OBJECT:", options)
+    # Assume that the current working directory is the appropriate git repo
+    repo_path = pathlib.Path.cwd()
+    issues: List[Issue] = []
+    try:
+        scanner = GitPreCommitScanner(options, str(repo_path))
+        issues = scanner.scan()
+    except types.TartufoScanException as exc:
+        util.fail(str(exc), ctx)
+    return (str(repo_path), issues)

--- a/tartufo/commands/pre_commit.py
+++ b/tartufo/commands/pre_commit.py
@@ -12,8 +12,6 @@ from tartufo.scanner import GitPreCommitScanner, Issue
 @click.pass_context
 def main(ctx: click.Context, options: types.GlobalOptions) -> Tuple[str, List[Issue]]:
     """Scan staged changes in a pre-commit hook."""
-    print("*** SCANNING PRE-COMMIT")
-    print("*** OBJECT:", options)
     # Assume that the current working directory is the appropriate git repo
     repo_path = pathlib.Path.cwd()
     issues: List[Issue] = []

--- a/tartufo/commands/scan_local_repo.py
+++ b/tartufo/commands/scan_local_repo.py
@@ -11,8 +11,8 @@ from tartufo.scanner import GitRepoScanner, Issue
 @click.option(
     "--max-depth",
     default=1000000,
-    help="The max commit depth to go back when searching for secrets."
-    " [default: 1000000]",
+    show_default=True,
+    help="The max commit depth to go back when searching for secrets.",
 )
 @click.option("--branch", help="Specify a branch name to scan only that branch.")
 @click.argument(

--- a/tartufo/commands/scan_local_repo.py
+++ b/tartufo/commands/scan_local_repo.py
@@ -1,0 +1,42 @@
+from typing import List, Optional, Tuple
+
+import click
+
+from tartufo import types, util
+from tartufo.scanner import GitRepoScanner, Issue
+
+
+@click.command("scan-local-repo")
+@click.option("--since-commit", help="Only scan from a given commit hash.")
+@click.option(
+    "--max-depth",
+    default=1000000,
+    help="The max commit depth to go back when searching for secrets."
+    " [default: 1000000]",
+)
+@click.option("--branch", help="Specify a branch name to scan only that branch.")
+@click.argument(
+    "repo-path",
+    type=click.Path(exists=True, file_okay=False, resolve_path=True, allow_dash=False),
+)
+@click.pass_obj
+@click.pass_context
+def main(
+    ctx: click.Context,
+    options: types.GlobalOptions,
+    repo_path: click.Path,
+    since_commit: Optional[str],
+    max_depth: int,
+    branch: Optional[str],
+) -> Tuple[str, List[Issue]]:
+    """Scan a repository already cloned to your local system."""
+    git_options = types.GitOptions(
+        since_commit=since_commit, max_depth=max_depth, branch=branch
+    )
+    issues: List[Issue] = []
+    try:
+        scanner = GitRepoScanner(options, git_options, str(repo_path))
+        issues = scanner.scan()
+    except types.TartufoScanException as exc:
+        util.fail(str(exc), ctx)
+    return (str(repo_path), issues)

--- a/tartufo/commands/scan_remote_repo.py
+++ b/tartufo/commands/scan_remote_repo.py
@@ -1,0 +1,49 @@
+import pathlib
+import shutil
+from typing import List, Optional, Tuple
+
+import click
+from git.exc import GitCommandError
+
+from tartufo import types, util
+from tartufo.scanner import GitRepoScanner, Issue
+
+
+@click.command("scan-remote-repo")
+@click.option("--since-commit", help="Only scan from a given commit hash.")
+@click.option(
+    "--max-depth",
+    default=1000000,
+    help="The max commit depth to go back when searching for secrets."
+    " [default: 1000000]",
+)
+@click.option("--branch", help="Specify a branch name to scan only that branch.")
+@click.argument("git-url")
+@click.pass_obj
+@click.pass_context
+def main(
+    ctx: click.Context,
+    options: types.GlobalOptions,
+    git_url: str,
+    since_commit: Optional[str],
+    max_depth: int,
+    branch: Optional[str],
+) -> Tuple[str, List[Issue]]:
+    """Automatically clone and scan a remote git repository."""
+    git_options = types.GitOptions(
+        since_commit=since_commit, max_depth=max_depth, branch=branch
+    )
+    repo_path = None
+    issues: List[Issue] = []
+    try:
+        repo_path = util.clone_git_repo(git_url)
+        scanner = GitRepoScanner(options, git_options, str(repo_path))
+        issues = scanner.scan()
+    except GitCommandError as exc:
+        util.fail("Error cloning remote repo: {}".format(exc.stderr.strip()), ctx)
+    except types.TartufoScanException as exc:
+        util.fail(str(exc), ctx)
+    finally:
+        if repo_path and pathlib.Path(repo_path).exists():
+            shutil.rmtree(repo_path, onerror=util.del_rw)
+    return (git_url, issues)

--- a/tartufo/commands/scan_remote_repo.py
+++ b/tartufo/commands/scan_remote_repo.py
@@ -1,5 +1,5 @@
-import pathlib
-import shutil
+from pathlib import Path
+from shutil import rmtree
 from typing import List, Optional, Tuple
 
 import click
@@ -44,6 +44,6 @@ def main(
     except types.TartufoScanException as exc:
         util.fail(str(exc), ctx)
     finally:
-        if repo_path and pathlib.Path(repo_path).exists():
-            shutil.rmtree(repo_path, onerror=util.del_rw)
+        if repo_path and Path(repo_path).exists():
+            rmtree(repo_path, onerror=util.del_rw)
     return (git_url, issues)

--- a/tartufo/commands/scan_remote_repo.py
+++ b/tartufo/commands/scan_remote_repo.py
@@ -14,8 +14,8 @@ from tartufo.scanner import GitRepoScanner, Issue
 @click.option(
     "--max-depth",
     default=1000000,
-    help="The max commit depth to go back when searching for secrets."
-    " [default: 1000000]",
+    show_default=True,
+    help="The max commit depth to go back when searching for secrets.",
 )
 @click.option("--branch", help="Specify a branch name to scan only that branch.")
 @click.argument("git-url")

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -348,6 +348,5 @@ class GitPreCommitScanner(GitScanner):
         diff_index = self._repo.index.diff(
             self._repo.head.commit, create_patch=True, R=True
         )
-        print("*** WORKING ON DIFF INDEX:", diff_index)
         for blob, file_path in self._iter_diff_index(diff_index):
             yield Chunk(blob, file_path)

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -86,10 +86,10 @@ class ScannerBase(abc.ABC):
     _included_paths: Optional[List[Pattern]] = None
     _excluded_paths: Optional[List[Pattern]] = None
     _rules_regexes: Optional[Dict[str, Pattern]] = None
-    options: GlobalOptions
+    global_options: GlobalOptions
 
     def __init__(self, options: GlobalOptions) -> None:
-        self.options = options
+        self.global_options = options
 
     @property
     def issues(self) -> List[Issue]:
@@ -100,9 +100,9 @@ class ScannerBase(abc.ABC):
     @property
     def included_paths(self) -> List[Pattern]:
         if self._included_paths is None:
-            if self.options.include_paths:
+            if self.global_options.include_paths:
                 self._included_paths = config.compile_path_rules(
-                    self.options.include_paths.readlines()
+                    self.global_options.include_paths.readlines()
                 )
             else:
                 self._included_paths = []
@@ -111,9 +111,9 @@ class ScannerBase(abc.ABC):
     @property
     def excluded_paths(self) -> List[Pattern]:
         if self._excluded_paths is None:
-            if self.options.exclude_paths:
+            if self.global_options.exclude_paths:
                 self._excluded_paths = config.compile_path_rules(
-                    self.options.exclude_paths.readlines()
+                    self.global_options.exclude_paths.readlines()
                 )
             else:
                 self._excluded_paths = []
@@ -124,10 +124,10 @@ class ScannerBase(abc.ABC):
         if self._rules_regexes is None:
             try:
                 self._rules_regexes = config.configure_regexes(
-                    self.options.default_regexes,
-                    self.options.rules,
-                    self.options.git_rules_repo,
-                    self.options.git_rules_files,
+                    self.global_options.default_regexes,
+                    self.global_options.rules,
+                    self.global_options.git_rules_repo,
+                    self.global_options.git_rules_files,
                 )
             except (ValueError, re.error) as exc:
                 raise TartufoScanException(str(exc)) from exc
@@ -160,7 +160,8 @@ class ScannerBase(abc.ABC):
 
     def signature_is_excluded(self, blob: str, file_path: str) -> bool:
         return (
-            util.generate_signature(blob, file_path) in self.options.exclude_signatures
+            util.generate_signature(blob, file_path)
+            in self.global_options.exclude_signatures
         )
 
     @lru_cache()
@@ -179,16 +180,16 @@ class ScannerBase(abc.ABC):
 
     def scan(self) -> List[Issue]:
         issues: List[Issue] = []
-        if not any((self.options.entropy, self.options.regex)):
+        if not any((self.global_options.entropy, self.global_options.regex)):
             raise TartufoScanException("No analysis requested.")
-        if self.options.regex and not self.rules_regexes:
+        if self.global_options.regex and not self.rules_regexes:
             raise TartufoScanException("Regex checks requested, but no regexes found.")
 
         for chunk in self.chunks:
             # Run regex scans first to trigger a potential fast fail for bad config
-            if self.options.regex and self.rules_regexes:
+            if self.global_options.regex and self.rules_regexes:
                 issues += self.scan_regex(chunk)
-            if self.options.entropy:
+            if self.global_options.entropy:
                 issues += self.scan_entropy(chunk)
         self._issues = issues
         return self._issues
@@ -237,12 +238,11 @@ class ScannerBase(abc.ABC):
 
 class GitScanner(ScannerBase, abc.ABC):
     _repo: git.Repo
-    options: GitOptions
 
-    def __init__(self, options: GitOptions, repo_path: str) -> None:
+    def __init__(self, global_options: GlobalOptions, repo_path: str) -> None:
         self.repo_path = repo_path
         self._repo = self.load_repo(self.repo_path)
-        super().__init__(options)
+        super().__init__(global_options)
 
     def _iter_diff_index(
         self, diff_index: git.DiffIndex
@@ -262,6 +262,14 @@ class GitScanner(ScannerBase, abc.ABC):
 
 
 class GitRepoScanner(GitScanner):
+    git_options: GitOptions
+
+    def __init__(
+        self, global_options: GlobalOptions, git_options: GitOptions, repo_path: str
+    ) -> None:
+        self.git_options = git_options
+        super().__init__(global_options, repo_path)
+
     def load_repo(self, repo_path: str):
         return git.Repo(repo_path)
 
@@ -273,11 +281,11 @@ class GitRepoScanner(GitScanner):
         curr_commit: git.Commit = None
 
         for curr_commit in repo.iter_commits(
-            branch.name, max_count=self.options.max_depth
+            branch.name, max_count=self.git_options.max_depth
         ):
             commit_hash = curr_commit.hexsha
-            if self.options.since_commit:
-                if commit_hash == self.options.since_commit:
+            if self.git_options.since_commit:
+                if commit_hash == self.git_options.since_commit:
                     since_commit_reached = True
                 if since_commit_reached:
                     prev_commit = curr_commit
@@ -292,8 +300,8 @@ class GitRepoScanner(GitScanner):
     def chunks(self) -> Generator[Chunk, None, None]:
         already_searched: Set[bytes] = set()
 
-        if self.options.branch:
-            branches = self._repo.remotes.origin.fetch(self.options.branch)
+        if self.git_options.branch:
+            branches = self._repo.remotes.origin.fetch(self.git_options.branch)
         else:
             branches = self._repo.remotes.origin.fetch()
 
@@ -340,5 +348,6 @@ class GitPreCommitScanner(GitScanner):
         diff_index = self._repo.index.diff(
             self._repo.head.commit, create_patch=True, R=True
         )
+        print("*** WORKING ON DIFF INDEX:", diff_index)
         for blob, file_path in self._iter_diff_index(diff_index):
             yield Chunk(blob, file_path)

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -3,8 +3,6 @@ import enum
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, TextIO, Tuple
 
-from click import Path
-
 
 @dataclass
 class GlobalOptions:
@@ -23,13 +21,10 @@ class GlobalOptions:
 
 
 @dataclass
-class GitOptions(GlobalOptions):
+class GitOptions:
     since_commit: Optional[str]
     max_depth: int
     branch: Optional[str]
-    repo_path: Optional[Path]
-    pre_commit: bool
-    git_url: Optional[str]
 
 
 class IssueType(enum.Enum):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,7 +53,7 @@ class ListCommandTests(unittest.TestCase):
 
 class ProcessIssuesTest(unittest.TestCase):
     @mock.patch("tartufo.util.clean_outputs")
-    @mock.patch("tartufo.scanner.GitRepoScanner")
+    @mock.patch("tartufo.commands.scan_local_repo.GitRepoScanner")
     def test_output_is_cleaned_when_requested(
         self, mock_scanner: mock.MagicMock, mock_clean: mock.MagicMock
     ):
@@ -64,7 +64,7 @@ class ProcessIssuesTest(unittest.TestCase):
         mock_clean.assert_called_once_with(None)
 
     @mock.patch("tartufo.cli.mkdtemp")
-    @mock.patch("tartufo.scanner.GitRepoScanner")
+    @mock.patch("tartufo.commands.scan_local_repo.GitRepoScanner")
     @mock.patch("tartufo.util.echo_issues", new=mock.MagicMock())
     @mock.patch("tartufo.util.write_outputs", new=mock.MagicMock())
     def test_issues_path_is_called_out(
@@ -80,7 +80,7 @@ class ProcessIssuesTest(unittest.TestCase):
         self.assertEqual(result.output, "Results have been saved in /foo\n")
 
     @mock.patch("tartufo.cli.mkdtemp")
-    @mock.patch("tartufo.scanner.GitRepoScanner")
+    @mock.patch("tartufo.commands.scan_local_repo.GitRepoScanner")
     @mock.patch("tartufo.util.echo_issues", new=mock.MagicMock())
     @mock.patch("tartufo.util.write_outputs", new=mock.MagicMock())
     def test_issues_path_is_not_called_out_when_outputting_json(
@@ -100,7 +100,7 @@ class ProcessIssuesTest(unittest.TestCase):
     @mock.patch("tartufo.cli.mkdtemp", new=mock.MagicMock())
     @mock.patch("tartufo.util.write_outputs", new=mock.MagicMock())
     @mock.patch("tartufo.util.echo_issues", new=mock.MagicMock())
-    @mock.patch("tartufo.scanner.GitRepoScanner")
+    @mock.patch("tartufo.commands.scan_local_repo.GitRepoScanner")
     def test_command_exits_with_positive_return_code_when_issues_are_found(
         self, mock_scanner: mock.MagicMock
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,191 +1,116 @@
-import pathlib
 import unittest
+from collections import namedtuple
 from unittest import mock
 
 from click.testing import CliRunner
 from tartufo import cli, scanner, types
 
 
-class CLITests(unittest.TestCase):
-    repo_path: str
+FakeFile = namedtuple("FakeFile", ["name"])
 
-    @classmethod
-    def setUpClass(cls) -> None:
-        cls.repo_path = str(pathlib.Path(__file__).parent.parent)
 
-    def test_command_exits_gracefully_with_empty_argv(self):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(cli.main)
-            self.assertEqual(result.exit_code, 1)
+class ListCommandTests(unittest.TestCase):
+    @mock.patch("tartufo.cli.PLUGIN_DIR")
+    def test_list_commands_excludes_init_py(self, mock_dir: mock.MagicMock):
+        mock_dir.glob.return_value = [
+            FakeFile("__init__.py"),
+            FakeFile("foo.py"),
+            FakeFile("bar.py"),
+        ]
+        commands = cli.TartufoCLI().list_commands(None)  # type: ignore
+        self.assertNotIn("__init__", commands)
 
-    def test_command_fails_when_no_entropy_or_regex(self):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                cli.main, ["--no-entropy", "--no-regex", "--repo-path", self.repo_path]
-            )
-            self.assertEqual(result.output, "No analysis requested.\n")
+    @mock.patch("tartufo.cli.PLUGIN_DIR")
+    def test_list_commands_only_looks_at_python_files(self, mock_dir: mock.MagicMock):
+        mock_dir.glob.return_value = [
+            FakeFile("__init__.py"),
+            FakeFile("foo.py"),
+            FakeFile("bar.py"),
+        ]
+        cli.TartufoCLI().list_commands(None)  # type: ignore
+        mock_dir.glob.assert_called_once_with("*.py")
 
-    def test_command_fails_when_regex_requested_but_none_available(self):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                cli.main,
-                ["--regex", "--no-default-regexes", "--repo-path", self.repo_path],
-            )
-            self.assertEqual(
-                result.output, "Regex checks requested, but no regexes found.\n"
-            )
+    @mock.patch("tartufo.cli.PLUGIN_DIR")
+    def test_list_commands_strips_file_extensions(self, mock_dir: mock.MagicMock):
+        mock_dir.glob.return_value = [
+            FakeFile("foo.py"),
+            FakeFile("bar.py"),
+            FakeFile("baz.py"),
+        ]
+        commands = cli.TartufoCLI().list_commands(None)  # type: ignore
+        self.assertEqual(commands, ["foo", "bar", "baz"])
 
-    @mock.patch("tartufo.cli.config.configure_regexes")
-    def test_command_fails_from_invalid_regex(self, mock_config_regex: mock.MagicMock):
-        mock_config_regex.side_effect = ValueError("Foo!")
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(cli.main, ["--repo-path", self.repo_path, "--regex"])
-            self.assertEqual(result.output, "Foo!\n")
-
-    @mock.patch("tartufo.scanner.GitPreCommitScanner")
-    def test_command_uses_git_pre_commit_scanner_for_pre_commit(
-        self, mock_scanner: mock.MagicMock
+    @mock.patch("tartufo.cli.PLUGIN_DIR")
+    def test_list_commands_converts_underscore_to_hyphen(
+        self, mock_dir: mock.MagicMock
     ):
-        mock_scanner.return_value.scan.return_value = []
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            runner.invoke(
-                cli.main,
-                [
-                    "--pre-commit",
-                    "--repo-path",
-                    self.repo_path,
-                    "--no-regex",
-                    "--entropy",
-                ],
-            )
-            mock_scanner.assert_called_once()
+        mock_dir.glob.return_value = [
+            FakeFile("foo_bar.py"),
+        ]
+        commands = cli.TartufoCLI().list_commands(None)  # type: ignore
+        self.assertEqual(commands, ["foo-bar"])
 
-    @mock.patch("tartufo.util.clone_git_repo", new=mock.MagicMock())
-    @mock.patch("tartufo.scanner.GitRepoScanner")
-    @mock.patch("tartufo.cli.shutil.rmtree", new=mock.MagicMock())
-    def test_command_uses_git_repo_scanner_by_default(
-        self, mock_scanner: mock.MagicMock
-    ):
-        mock_scanner.return_value.scan.return_value = []
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            runner.invoke(
-                cli.main,
-                [
-                    "--no-regex",
-                    "--max-depth",
-                    "42",
-                    "--entropy",
-                    "git@github.com:godaddy/tartufo.git",
-                ],
-            )
-            mock_scanner.assert_called_once()
 
-    @mock.patch("tartufo.util.clone_git_repo", new=mock.MagicMock())
-    @mock.patch("tartufo.scanner.GitRepoScanner")
-    @mock.patch("tartufo.cli.shutil.rmtree", new=mock.MagicMock())
-    def test_default_regexes_get_used_by_default(self, mock_scanner: mock.MagicMock):
-        mock_scanner.return_value.scan.return_value = []
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            runner.invoke(
-                cli.main,
-                [
-                    "--regex",
-                    "--max-depth",
-                    "42",
-                    "--entropy",
-                    "git@github.com:godaddy/tartufo.git",
-                ],
-            )
-            options: types.GitOptions = mock_scanner.call_args[0][0]
-            self.assertTrue(options.default_regexes)
-
-    @mock.patch("tartufo.util.clone_git_repo")
-    @mock.patch("tartufo.scanner.GitRepoScanner")
-    def test_clone_not_called_when_repo_path_specified(
-        self, mock_scanner: mock.MagicMock, mock_clone: mock.MagicMock
-    ):
-        mock_scanner.return_value.scan.return_value = []
-        runner = CliRunner()
-        with runner.isolated_filesystem() as working_dir:
-            # Resolve all symlinks etc to give us an absolute path
-            working_dir = str(pathlib.Path(working_dir).resolve())
-            runner.invoke(
-                cli.main,
-                ["--no-regex", "--max-depth", "42", "--entropy", "--repo-path", ".",],
-            )
-            mock_clone.assert_not_called()
-            mock_scanner.assert_called_once()
-
-    @mock.patch("tartufo.scanner.GitRepoScanner")
+class ProcessIssuesTest(unittest.TestCase):
     @mock.patch("tartufo.util.clean_outputs")
-    @mock.patch("tartufo.util.clone_git_repo", new=mock.MagicMock())
-    @mock.patch("tartufo.util.echo_issues", new=mock.MagicMock())
-    @mock.patch("tartufo.cli.shutil.rmtree", new=mock.MagicMock())
-    def test_command_calls_cleanup_when_requested(
-        self, mock_clean: mock.MagicMock, mock_scanner: mock.MagicMock
+    @mock.patch("tartufo.scanner.GitRepoScanner")
+    def test_output_is_cleaned_when_requested(
+        self, mock_scanner: mock.MagicMock, mock_clean: mock.MagicMock
     ):
         mock_scanner.return_value.scan.return_value = []
         runner = CliRunner()
         with runner.isolated_filesystem():
-            runner.invoke(
-                cli.main,
-                [
-                    "--cleanup",
-                    "--no-regex",
-                    "--max-depth",
-                    "42",
-                    "--entropy",
-                    "git@github.com:godaddy/tartufo.git",
-                ],
-            )
-            mock_clean.assert_called_once_with(None)
+            runner.invoke(cli.main, ["--cleanup", "scan-local-repo", "."])
+        mock_clean.assert_called_once_with(None)
 
     @mock.patch("tartufo.cli.mkdtemp")
     @mock.patch("tartufo.scanner.GitRepoScanner")
-    @mock.patch("tartufo.util.clone_git_repo", new=mock.MagicMock())
     @mock.patch("tartufo.util.echo_issues", new=mock.MagicMock())
     @mock.patch("tartufo.util.write_outputs", new=mock.MagicMock())
-    @mock.patch("tartufo.cli.shutil.rmtree", new=mock.MagicMock())
     def test_issues_path_is_called_out(
         self, mock_scanner: mock.MagicMock, mock_temp: mock.MagicMock
     ):
         mock_scanner.return_value.scan.return_value = [
-            scanner.Issue(types.IssueType.Entropy, "", types.Chunk("foo", "/bar"))
+            scanner.Issue(types.IssueType.Entropy, "foo", types.Chunk("foo", "/bar"))
         ]
         mock_temp.return_value = "/foo"
         runner = CliRunner()
         with runner.isolated_filesystem():
-            result = runner.invoke(
-                cli.main,
-                [
-                    "--no-cleanup",
-                    "--no-regex",
-                    "--entropy",
-                    "git@github.com:godaddy/tartufo.git",
-                ],
-            )
-            self.assertEqual(result.output, "Results have been saved in /foo\n")
+            result = runner.invoke(cli.main, ["scan-local-repo", "."])
+        self.assertEqual(result.output, "Results have been saved in /foo\n")
 
+    @mock.patch("tartufo.cli.mkdtemp")
     @mock.patch("tartufo.scanner.GitRepoScanner")
-    @mock.patch("tartufo.util.clone_git_repo", new=mock.MagicMock())
-    @mock.patch("tartufo.cli.shutil.rmtree", new=mock.MagicMock())
-    def test_command_exits_with_positive_return_code_when_issues_found(
+    @mock.patch("tartufo.util.echo_issues", new=mock.MagicMock())
+    @mock.patch("tartufo.util.write_outputs", new=mock.MagicMock())
+    def test_issues_path_is_not_called_out_when_outputting_json(
+        self, mock_scanner: mock.MagicMock, mock_temp: mock.MagicMock
+    ):
+        mock_scanner.return_value.scan.return_value = [
+            scanner.Issue(types.IssueType.Entropy, "foo", types.Chunk("foo", "/bar"))
+        ]
+        mock_temp.return_value = "/foo"
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(cli.main, ["--json", "scan-local-repo", "."])
+        # All other outputs are mocked, so this is ensuring that the
+        #   "Results have been saved in ..." message is not output.
+        self.assertEqual(result.output, "")
+
+    @mock.patch("tartufo.cli.mkdtemp", new=mock.MagicMock())
+    @mock.patch("tartufo.util.write_outputs", new=mock.MagicMock())
+    @mock.patch("tartufo.util.echo_issues", new=mock.MagicMock())
+    @mock.patch("tartufo.scanner.GitRepoScanner")
+    def test_command_exits_with_positive_return_code_when_issues_are_found(
         self, mock_scanner: mock.MagicMock
     ):
         mock_scanner.return_value.scan.return_value = [
-            scanner.Issue(types.IssueType.Entropy, "", types.Chunk("foo", "/bar"))
+            scanner.Issue(types.IssueType.Entropy, "foo", types.Chunk("foo", "/bar"))
         ]
         runner = CliRunner()
         with runner.isolated_filesystem():
-            result = runner.invoke(cli.main, ["git@github.com:godaddy/tartufo.git"])
-            self.assertGreater(result.exit_code, 0)
+            result = runner.invoke(cli.main, ["scan-local-repo", "."])
+        self.assertGreater(result.exit_code, 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_pre_commit.py
+++ b/tests/test_pre_commit.py
@@ -1,0 +1,28 @@
+import unittest
+from unittest import mock
+
+from click.testing import CliRunner
+
+from tartufo import cli, types
+
+
+class PreCommitTests(unittest.TestCase):
+    @mock.patch("tartufo.commands.pre_commit.GitPreCommitScanner")
+    def test_scan_is_executed_against_current_working_directory(
+        self, mock_scanner: mock.MagicMock
+    ):
+        mock_scanner.return_value.scan.return_value = []
+        runner = CliRunner()
+        with runner.isolated_filesystem() as tempdir:
+            runner.invoke(cli.main, ["pre-commit"])
+        self.assertEqual(mock_scanner.call_args[0][1], tempdir)
+
+    @mock.patch("tartufo.commands.pre_commit.GitPreCommitScanner")
+    def test_scan_fails_on_scan_exception(self, mock_scanner: mock.MagicMock):
+        mock_scanner.return_value.scan.side_effect = types.TartufoScanException(
+            "Scan failed!"
+        )
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(cli.main, ["pre-commit"])
+        self.assertEqual(result.output, "Scan failed!\n")

--- a/tests/test_scan_local_repo.py
+++ b/tests/test_scan_local_repo.py
@@ -1,0 +1,21 @@
+import unittest
+from unittest import mock
+
+from click.testing import CliRunner
+
+from tartufo import cli, types
+
+
+class ScanLocalRepoTests(unittest.TestCase):
+    @mock.patch("tartufo.commands.scan_local_repo.GitRepoScanner")
+    def test_scan_exits_gracefully_on_scan_exception(
+        self, mock_scanner: mock.MagicMock
+    ):
+        mock_scanner.return_value.scan.side_effect = types.TartufoScanException(
+            "Scan failed!"
+        )
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(cli.main, ["scan-local-repo", "."])
+        self.assertGreater(result.exit_code, 0)
+        self.assertEqual(result.output, "Scan failed!\n")

--- a/tests/test_scan_remote_repo.py
+++ b/tests/test_scan_remote_repo.py
@@ -1,0 +1,95 @@
+import unittest
+from unittest import mock
+
+from git.exc import GitCommandError
+from click.testing import CliRunner
+
+from tartufo import cli, types
+
+
+class ScanRemoteRepoTests(unittest.TestCase):
+    @mock.patch("tartufo.commands.scan_remote_repo.util.clone_git_repo")
+    @mock.patch("tartufo.commands.scan_remote_repo.GitRepoScanner")
+    @mock.patch("tartufo.commands.scan_remote_repo.rmtree", new=mock.MagicMock())
+    def test_scan_clones_remote_repo(
+        self, mock_scanner: mock.MagicMock, mock_clone: mock.MagicMock
+    ):
+        mock_scanner.return_value.scan.return_value = []
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            runner.invoke(
+                cli.main, ["scan-remote-repo", "git@github.com:godaddy/tartufo.git"]
+            )
+        mock_clone.assert_called_once_with("git@github.com:godaddy/tartufo.git")
+
+    @mock.patch("tartufo.commands.scan_remote_repo.util.clone_git_repo")
+    @mock.patch("tartufo.commands.scan_remote_repo.GitRepoScanner")
+    @mock.patch("tartufo.commands.scan_remote_repo.rmtree", new=mock.MagicMock())
+    def test_cloned_path_is_scanned(
+        self, mock_scanner: mock.MagicMock, mock_clone: mock.MagicMock
+    ):
+        mock_clone.return_value = "/foo"
+        mock_scanner.return_value.scan.return_value = []
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            runner.invoke(
+                cli.main, ["scan-remote-repo", "git@github.com:godaddy/tartufo.git"]
+            )
+        self.assertEqual(mock_scanner.call_args[0][2], "/foo")
+
+    @mock.patch("tartufo.commands.scan_remote_repo.util.clone_git_repo")
+    @mock.patch("tartufo.commands.scan_remote_repo.GitRepoScanner")
+    @mock.patch("tartufo.commands.scan_remote_repo.Path")
+    @mock.patch("tartufo.commands.scan_remote_repo.rmtree")
+    def test_clone_is_deleted_after_scan(
+        self,
+        mock_rmtree: mock.MagicMock,
+        mock_path: mock.MagicMock,
+        mock_scanner: mock.MagicMock,
+        mock_clone: mock.MagicMock,
+    ):
+        mock_clone.return_value = "/foo"
+        mock_scanner.return_value.scan.return_value = []
+        mock_path.return_value.exists.return_value = True
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            runner.invoke(
+                cli.main, ["scan-remote-repo", "git@github.com:godaddy/tartufo.git"]
+            )
+        self.assertEqual(mock_rmtree.call_args[0][0], "/foo")
+
+    @mock.patch("tartufo.commands.scan_remote_repo.util.clone_git_repo")
+    @mock.patch("tartufo.commands.scan_remote_repo.GitRepoScanner")
+    @mock.patch("tartufo.commands.scan_remote_repo.rmtree", new=mock.MagicMock())
+    def test_command_fails_on_clone_error(
+        self, mock_scanner: mock.MagicMock, mock_clone: mock.MagicMock
+    ):
+        mock_clone.side_effect = GitCommandError(
+            command="git clone", status=42, stderr="Bad repo. Bad."
+        )
+        mock_scanner.return_value.scan.return_value = []
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                cli.main, ["scan-remote-repo", "git@github.com:godaddy/tartufo.git"]
+            )
+        self.assertEqual(
+            result.output, "Error cloning remote repo: stderr: 'Bad repo. Bad.'\n"
+        )
+
+    @mock.patch("tartufo.commands.scan_remote_repo.util.clone_git_repo")
+    @mock.patch("tartufo.commands.scan_remote_repo.GitRepoScanner")
+    @mock.patch("tartufo.commands.scan_remote_repo.rmtree", new=mock.MagicMock())
+    def test_command_fails_on_scan_exception(
+        self, mock_scanner: mock.MagicMock, mock_clone: mock.MagicMock
+    ):
+        mock_clone.return_value = "/foo"
+        mock_scanner.return_value.scan.side_effect = types.TartufoScanException(
+            "Scan failed!"
+        )
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                cli.main, ["scan-remote-repo", "git@github.com:godaddy/tartufo.git"]
+            )
+        self.assertEqual(result.output, "Scan failed!\n")


### PR DESCRIPTION
Fixes #39 

Now instead of the confusing options and parsing of the options for the different execution paths, they're now all distinctly separated. So now you have:

* `tartufo pre-commit`
* `tartufo scan-local-repo <path>`
* `tartufo scan-remote-repo <url>`

Between this and the other recent work this means that we will easily be able to add more execution modes in the future, such as `scan-local-folder` and `scan-github-org`.

I debated about the repetition of `scan-` at the beginning of the commands, but I think it's the right choice. I'm open to discussion around this though. The reasoning is I would like to be able, in the future, to add other commands like `tartufo create-exclusion-list` to generate a list of signatures to ignore, and `tartufo check-config`, for example.
