### PR TITLE
Specify working directory for cloning remote repos

### DIFF
--- a/tartufo/commands/scan_remote_repo.py
+++ b/tartufo/commands/scan_remote_repo.py
@@ -42,7 +42,7 @@ def main(
     since_commit: Optional[str],
     max_depth: int,
     branch: Optional[str],
-    work_dir: click.Path,
+    work_dir: Optional[str],
 ) -> Tuple[str, List[Issue]]:
     """Automatically clone and scan a remote git repository."""
     git_options = types.GitOptions(
@@ -50,7 +50,7 @@ def main(
     )
     repo_path: Optional[Path] = None
     if work_dir:
-        repo_path = Path(str(work_dir))
+        repo_path = Path(work_dir)
     issues: List[Issue] = []
     try:
         repo_path = util.clone_git_repo(git_url, repo_path)

--- a/tartufo/commands/scan_remote_repo.py
+++ b/tartufo/commands/scan_remote_repo.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from shutil import rmtree
 from typing import List, Optional, Tuple
+from urllib.parse import urlparse
 
 import click
 from git.exc import GitCommandError
@@ -50,7 +51,11 @@ def main(
     )
     repo_path: Optional[Path] = None
     if work_dir:
-        repo_path = Path(work_dir)
+        # Make sure we clone into a sub-directory of the working directory
+        #   so that we don't inadvertently delete the working directory
+        repo_name = urlparse(git_url).path.split("/")[-1]
+        repo_path = Path(work_dir) / repo_name
+        repo_path.mkdir(parents=True)
     issues: List[Issue] = []
     try:
         repo_path = util.clone_git_repo(git_url, repo_path)

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -10,7 +10,8 @@ import tempfile
 import uuid
 from functools import lru_cache, partial
 from hashlib import blake2s
-from typing import Any, Callable, Dict, Iterable, List, TYPE_CHECKING
+from typing import Any, Callable, Dict, Iterable, List, Optional, TYPE_CHECKING
+from urllib.parse import urlparse
 
 import click
 import git
@@ -57,10 +58,17 @@ def clean_outputs(output_dir: pathlib.Path) -> None:
         shutil.rmtree(output_dir)
 
 
-def clone_git_repo(git_url: str) -> str:
-    project_path = tempfile.mkdtemp()
+def clone_git_repo(
+    git_url: str, target_dir: Optional[pathlib.Path] = None
+) -> pathlib.Path:
+    if not target_dir:
+        project_path = tempfile.mkdtemp()
+    else:
+        repo_name = urlparse(git_url).path.split("/")[-1]
+        project_path = str(target_dir / repo_name)
+
     git.Repo.clone_from(git_url, project_path)
-    return project_path
+    return pathlib.Path(project_path)
 
 
 style_ok = partial(click.style, fg="bright_green")  # pylint: disable=invalid-name

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -11,7 +11,6 @@ import uuid
 from functools import lru_cache, partial
 from hashlib import blake2s
 from typing import Any, Callable, Dict, Iterable, List, Optional, TYPE_CHECKING
-from urllib.parse import urlparse
 
 import click
 import git
@@ -64,8 +63,7 @@ def clone_git_repo(
     if not target_dir:
         project_path = tempfile.mkdtemp()
     else:
-        repo_name = urlparse(git_url).path.split("/")[-1]
-        project_path = str(target_dir / repo_name)
+        project_path = str(target_dir)
 
     git.Repo.clone_from(git_url, project_path)
     return pathlib.Path(project_path)

--- a/tests/test_scan_remote_repo.py
+++ b/tests/test_scan_remote_repo.py
@@ -98,7 +98,7 @@ class ScanRemoteRepoTests(unittest.TestCase):
     @mock.patch("tartufo.commands.scan_remote_repo.util.clone_git_repo")
     @mock.patch("tartufo.commands.scan_remote_repo.GitRepoScanner")
     @mock.patch("tartufo.commands.scan_remote_repo.rmtree", new=mock.MagicMock())
-    def test_work_dir_is_passed_to_clone_repo(
+    def test_subdir_of_work_dir_is_passed_to_clone_repo(
         self, mock_scanner: mock.MagicMock, mock_clone: mock.MagicMock
     ):
         mock_scanner.return_value.scan.return_value = []
@@ -115,5 +115,5 @@ class ScanRemoteRepoTests(unittest.TestCase):
                 ],
             )
             mock_clone.assert_called_once_with(
-                "git@github.com:godaddy/tartufo.git", Path(dirname)
+                "git@github.com:godaddy/tartufo.git", Path(dirname) / "tartufo.git"
             )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,8 +2,6 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from click.testing import CliRunner
-
 from tartufo import scanner, types, util
 
 
@@ -39,26 +37,17 @@ class GitTests(unittest.TestCase):
         self.assertEqual(repo_path, Path("/foo"))
 
     @mock.patch("git.Repo.clone_from")
-    def test_clone_git_repo_clones_into_subdir_of_target(
-        self, mock_clone: mock.MagicMock
+    @mock.patch("tartufo.util.tempfile.mkdtemp")
+    def test_clone_git_repo_clones_into_target_dir(
+        self, mock_temp: mock.MagicMock, mock_clone: mock.MagicMock
     ):
-        runner = CliRunner()
-        with runner.isolated_filesystem() as dirname:
-            workdir = Path(dirname)
-            util.clone_git_repo("https://github.com/godaddy/tartufo.git", workdir)
-            mock_clone.assert_called_once_with(
-                "https://github.com/godaddy/tartufo.git", str(workdir / "tartufo.git"),
-            )
-
-    @mock.patch("git.Repo.clone_from", new=mock.MagicMock())
-    def test_clone_git_repo_returns_subdir_of_target(self):
-        runner = CliRunner()
-        with runner.isolated_filesystem() as dirname:
-            workdir = Path(dirname)
-            repo_path = util.clone_git_repo(
-                "https://github.com/godaddy/tartufo.git", workdir
-            )
-            self.assertEqual(repo_path, workdir / "tartufo.git")
+        util.clone_git_repo(
+            "https://github.com/godaddy/tartufo.git", Path("/foo/tartufo.git")
+        )
+        mock_temp.assert_not_called()
+        mock_clone.assert_called_once_with(
+            "https://github.com/godaddy/tartufo.git", "/foo/tartufo.git"
+        )
 
 
 class OutputTests(unittest.TestCase):


### PR DESCRIPTION
Fixes #7 

@mxhenry-godaddy -- is this what you had in mind for this? Given that this folder is immediately removed when the run is finished, I think the usefulness is a bit dubious. I think the more useful feature will be allowing specification of `--output-dir` via #11.

Let me know!