### PR TITLE
Add a --output-dir/-od option in place of --cleanup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
   - id: tartufo
     name: tartufo
     entry: tartufo
-    args: [--cleanup, pre-commit]
+    args: [pre-commit]
     language: python
     pass_filenames: false
   - id: pylint

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,5 @@
   description: '`tartufo` is a tool for scanning git repositories for secrets/passwords/high-entropy data'
   entry: tartufo
   language: python
-  args: [--cleanup, pre-commit]
+  args: [pre-commit]
   pass_filenames: false

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -2,6 +2,7 @@
 
 import importlib
 import pathlib
+from datetime import datetime
 from typing import List, Tuple
 
 import click
@@ -104,7 +105,8 @@ class TartufoCLI(click.MultiCommand):
         allow_dash=False,
     ),
     help="If specified, all issues will be written out as individual JSON files "
-    "in this directory.",
+    "to a uniquely named directory under this one. This will help with keeping "
+    "the results of individual runs of tartufo separated.",
 )
 @click.option(
     "--git-rules-repo",
@@ -159,9 +161,9 @@ def process_issues(
     options = types.GlobalOptions(**kwargs)  # type: ignore
     output_dir = None
     if options.output_dir:
-        output_dir = pathlib.Path(options.output_dir)
-        if not output_dir.exists():
-            output_dir.mkdir(parents=True)
+        now = datetime.now().isoformat("T", "microseconds")
+        output_dir = pathlib.Path(options.output_dir) / f"tartufo-scan-results-{now}"
+        output_dir.mkdir(parents=True)
 
     if issues:
         util.echo_issues(issues, options.json, repo_path, output_dir)

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -160,6 +160,8 @@ def process_issues(
     output_dir = None
     if options.output_dir:
         output_dir = pathlib.Path(options.output_dir)
+        if not output_dir.exists():
+            output_dir.mkdir(parents=True)
 
     if issues:
         util.echo_issues(issues, options.json, repo_path, output_dir)

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -14,7 +14,7 @@ class GlobalOptions:
     include_paths: Optional[TextIO]
     exclude_paths: Optional[TextIO]
     exclude_signatures: Tuple[str, ...]
-    cleanup: bool
+    output_dir: Optional[str]
     git_rules_repo: Optional[str]
     git_rules_files: Tuple[str, ...]
     config: Optional[TextIO]

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -4,7 +4,6 @@ import datetime
 import json
 import os
 import pathlib
-import shutil
 import stat
 import tempfile
 import uuid
@@ -28,13 +27,16 @@ def del_rw(_func: Callable, name: str, _exc: Exception) -> None:
 
 
 def echo_issues(
-    issues: "List[Issue]", as_json: bool, repo_path: str, output_dir: pathlib.Path
+    issues: "List[Issue]",
+    as_json: bool,
+    repo_path: str,
+    output_dir: Optional[pathlib.Path],
 ) -> None:
     """Print all found issues out to the console, optionally as JSON."""
     if as_json:
         output = {
             "project_path": repo_path,
-            "issues_path": str(output_dir),
+            "output_dir": str(output_dir) if output_dir else None,
             "found_issues": [issue.as_dict() for issue in issues],
         }
         click.echo(json.dumps(output))
@@ -46,15 +48,10 @@ def echo_issues(
 def write_outputs(found_issues: "List[Issue]", output_dir: pathlib.Path) -> List[str]:
     result_files = []
     for issue in found_issues:
-        result_file = output_dir / str(uuid.uuid4())
+        result_file = output_dir / f"{uuid.uuid4()}.json"
         result_file.write_text(json.dumps(issue.as_dict()))
         result_files.append(str(result_file))
     return result_files
-
-
-def clean_outputs(output_dir: pathlib.Path) -> None:
-    if output_dir and output_dir.is_dir():
-        shutil.rmtree(output_dir)
 
 
 def clone_git_repo(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,52 +52,38 @@ class ListCommandTests(unittest.TestCase):
 
 
 class ProcessIssuesTest(unittest.TestCase):
-    @mock.patch("tartufo.util.clean_outputs")
-    @mock.patch("tartufo.commands.scan_local_repo.GitRepoScanner")
-    def test_output_is_cleaned_when_requested(
-        self, mock_scanner: mock.MagicMock, mock_clean: mock.MagicMock
-    ):
-        mock_scanner.return_value.scan.return_value = []
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            runner.invoke(cli.main, ["--cleanup", "scan-local-repo", "."])
-        mock_clean.assert_called_once_with(None)
-
-    @mock.patch("tartufo.cli.mkdtemp")
     @mock.patch("tartufo.commands.scan_local_repo.GitRepoScanner")
     @mock.patch("tartufo.util.echo_issues", new=mock.MagicMock())
     @mock.patch("tartufo.util.write_outputs", new=mock.MagicMock())
-    def test_issues_path_is_called_out(
-        self, mock_scanner: mock.MagicMock, mock_temp: mock.MagicMock
-    ):
+    def test_output_dir_is_called_out(self, mock_scanner: mock.MagicMock):
         mock_scanner.return_value.scan.return_value = [
             scanner.Issue(types.IssueType.Entropy, "foo", types.Chunk("foo", "/bar"))
         ]
-        mock_temp.return_value = "/foo"
         runner = CliRunner()
         with runner.isolated_filesystem():
-            result = runner.invoke(cli.main, ["scan-local-repo", "."])
+            result = runner.invoke(
+                cli.main, ["--output-dir", "/foo", "scan-local-repo", "."]
+            )
         self.assertEqual(result.output, "Results have been saved in /foo\n")
 
-    @mock.patch("tartufo.cli.mkdtemp")
     @mock.patch("tartufo.commands.scan_local_repo.GitRepoScanner")
     @mock.patch("tartufo.util.echo_issues", new=mock.MagicMock())
     @mock.patch("tartufo.util.write_outputs", new=mock.MagicMock())
-    def test_issues_path_is_not_called_out_when_outputting_json(
-        self, mock_scanner: mock.MagicMock, mock_temp: mock.MagicMock
+    def test_output_dir_is_not_called_out_when_outputting_json(
+        self, mock_scanner: mock.MagicMock
     ):
         mock_scanner.return_value.scan.return_value = [
             scanner.Issue(types.IssueType.Entropy, "foo", types.Chunk("foo", "/bar"))
         ]
-        mock_temp.return_value = "/foo"
         runner = CliRunner()
         with runner.isolated_filesystem():
-            result = runner.invoke(cli.main, ["--json", "scan-local-repo", "."])
+            result = runner.invoke(
+                cli.main, ["--output-dir", "/foo", "--json", "scan-local-repo", "."]
+            )
         # All other outputs are mocked, so this is ensuring that the
         #   "Results have been saved in ..." message is not output.
         self.assertEqual(result.output, "")
 
-    @mock.patch("tartufo.cli.mkdtemp", new=mock.MagicMock())
     @mock.patch("tartufo.util.write_outputs", new=mock.MagicMock())
     @mock.patch("tartufo.util.echo_issues", new=mock.MagicMock())
     @mock.patch("tartufo.commands.scan_local_repo.GitRepoScanner")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -71,7 +71,7 @@ class OutputTests(unittest.TestCase):
         mock_json.dumps.assert_called_once_with(
             {
                 "project_path": "/repo",
-                "issues_path": "/output",
+                "output_dir": "/output",
                 "found_issues": [
                     {
                         "issue_type": "High Entropy",
@@ -106,7 +106,7 @@ class OutputTests(unittest.TestCase):
         mock_json.dumps.assert_called_once_with(
             {
                 "project_path": "/repo",
-                "issues_path": "/tmp",
+                "output_dir": "/tmp",
                 "found_issues": [
                     {
                         "issue_type": "High Entropy",
@@ -127,21 +127,6 @@ class OutputTests(unittest.TestCase):
                 ],
             }
         )
-
-    @mock.patch("tartufo.util.shutil")
-    def test_clean_outputs_deletes_output_directory_if_it_exists(self, mock_shutil):
-        class ExistingDir:
-            def is_dir(self):
-                return True
-
-        output = ExistingDir()
-        util.clean_outputs(output)
-        mock_shutil.rmtree.assert_called_once_with(output)
-
-    @mock.patch("tartufo.util.shutil")
-    def test_clean_outputs_does_nothing_if_output_dir_doesnt_exist(self, mock_shutil):
-        util.clean_outputs(None)
-        mock_shutil.rmtree.assert_not_called()
 
 
 class GeneralUtilTests(unittest.TestCase):


### PR DESCRIPTION
Fixes #11 -- @rscottbailey does this work for what you were thinking on this?

Now, there is no `--cleanup` flag. There is only `--output-dir`. If you don't specify one, nothing ever get written to disk. What a revelation!

I also changed the key in the commands JSON output from `issues_path` to `output_dir`, to match. And I took the liberty of appending `.json` to the filenames being output. Because they are JSON files, and file extensions are a good thing.