### PR TITLE
Add a -V/--version option

### DIFF
--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -127,6 +127,8 @@ class TartufoCLI(click.MultiCommand):
     callback=config.read_pyproject_toml,
     help="Read configuration from specified file. [default: pyproject.toml]",
 )
+# The first positional argument here would be a hard-coded version, hence the `None`
+@click.version_option(None, "-V", "--version")
 @click.pass_context
 def main(ctx: click.Context, **kwargs: config.OptionTypes) -> None:
     """Find secrets hidden in the depths of git.


### PR DESCRIPTION
Super minor, but I've been wanting to get this added for a while now and I figure there's no better time than pre-2.0!

Sample output:

```sh
> tartufo -V
tartufo, version 2.0.0.dev1
```