### PR TITLE
Better exception handling for git errors

### DIFF
--- a/tartufo/commands/pre_commit.py
+++ b/tartufo/commands/pre_commit.py
@@ -18,6 +18,6 @@ def main(ctx: click.Context, options: types.GlobalOptions) -> Tuple[str, List[Is
     try:
         scanner = GitPreCommitScanner(options, str(repo_path))
         issues = scanner.scan()
-    except types.TartufoScanException as exc:
+    except types.ScanException as exc:
         util.fail(str(exc), ctx)
     return (str(repo_path), issues)

--- a/tartufo/commands/scan_local_repo.py
+++ b/tartufo/commands/scan_local_repo.py
@@ -40,6 +40,6 @@ def main(
         issues = scanner.scan()
     except InvalidGitRepositoryError as exc:
         util.fail(f"{exc} is not a valid git repository.", ctx)
-    except types.TartufoScanException as exc:
+    except types.TartufoException as exc:
         util.fail(str(exc), ctx)
     return (str(repo_path), issues)

--- a/tartufo/commands/scan_local_repo.py
+++ b/tartufo/commands/scan_local_repo.py
@@ -24,7 +24,7 @@ from tartufo.scanner import GitRepoScanner, Issue
 def main(
     ctx: click.Context,
     options: types.GlobalOptions,
-    repo_path: click.Path,
+    repo_path: str,
     since_commit: Optional[str],
     max_depth: int,
     branch: Optional[str],
@@ -38,7 +38,9 @@ def main(
         scanner = GitRepoScanner(options, git_options, str(repo_path))
         issues = scanner.scan()
     except types.GitLocalException as exc:
-        util.fail(f"{exc} is not a valid git repository.", ctx)
+        util.fail(f"{repo_path} is not a valid git repository.", ctx)
+    except types.GitRemoteException as exc:
+        util.fail(f"There was an error fetching from the remote repository: {exc}", ctx)
     except types.TartufoException as exc:
         util.fail(str(exc), ctx)
     return (str(repo_path), issues)

--- a/tartufo/commands/scan_local_repo.py
+++ b/tartufo/commands/scan_local_repo.py
@@ -1,7 +1,6 @@
 from typing import List, Optional, Tuple
 
 import click
-from git.exc import InvalidGitRepositoryError
 
 from tartufo import types, util
 from tartufo.scanner import GitRepoScanner, Issue
@@ -38,7 +37,7 @@ def main(
     try:
         scanner = GitRepoScanner(options, git_options, str(repo_path))
         issues = scanner.scan()
-    except InvalidGitRepositoryError as exc:
+    except types.GitLocalException as exc:
         util.fail(f"{exc} is not a valid git repository.", ctx)
     except types.TartufoException as exc:
         util.fail(str(exc), ctx)

--- a/tartufo/commands/scan_remote_repo.py
+++ b/tartufo/commands/scan_remote_repo.py
@@ -4,7 +4,6 @@ from typing import List, Optional, Tuple
 from urllib.parse import urlparse
 
 import click
-from git.exc import GitCommandError
 
 from tartufo import types, util
 from tartufo.scanner import GitRepoScanner, Issue
@@ -61,9 +60,9 @@ def main(
         repo_path = util.clone_git_repo(git_url, repo_path)
         scanner = GitRepoScanner(options, git_options, str(repo_path))
         issues = scanner.scan()
-    except GitCommandError as exc:
-        util.fail("Error cloning remote repo: {}".format(exc.stderr.strip()), ctx)
-    except types.TartufoScanException as exc:
+    except types.GitException as exc:
+        util.fail(f"Error cloning remote repo: {exc}", ctx)
+    except types.ScanException as exc:
         util.fail(str(exc), ctx)
     finally:
         if repo_path and repo_path.exists():

--- a/tartufo/commands/scan_remote_repo.py
+++ b/tartufo/commands/scan_remote_repo.py
@@ -62,7 +62,7 @@ def main(
         issues = scanner.scan()
     except types.GitException as exc:
         util.fail(f"Error cloning remote repo: {exc}", ctx)
-    except types.ScanException as exc:
+    except types.TartufoException as exc:
         util.fail(str(exc), ctx)
     finally:
         if repo_path and repo_path.exists():

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -413,13 +413,17 @@ class GitRepoScanner(GitScanner):
         """Yield individual diffs from the repository's history.
 
         :rtype: Generator[Chunk, None, None]
+        :raises types.GitRemoteException: If there was an error fetching branches
         """
         already_searched: Set[bytes] = set()
 
-        if self.git_options.branch:
-            branches = self._repo.remotes.origin.fetch(self.git_options.branch)
-        else:
-            branches = self._repo.remotes.origin.fetch()
+        try:
+            if self.git_options.branch:
+                branches = self._repo.remotes.origin.fetch(self.git_options.branch)
+            else:
+                branches = self._repo.remotes.origin.fetch()
+        except git.GitCommandError as exc:
+            raise types.GitRemoteException(exc.stderr.strip()) from exc
 
         for remote_branch in branches:
             diff_index: git.DiffIndex = None

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -351,6 +351,7 @@ class GitScanner(ScannerBase, abc.ABC):
         """Load and return the repository to be scanned.
 
         :param repo_path: The local filesystem path pointing to the repository
+        :raises types.GitLocalException: If there was a problem loading the repository
         """
 
 
@@ -374,7 +375,10 @@ class GitRepoScanner(GitScanner):
         super().__init__(global_options, repo_path)
 
     def load_repo(self, repo_path: str) -> git.Repo:
-        return git.Repo(repo_path)
+        try:
+            return git.Repo(repo_path)
+        except git.GitError as exc:
+            raise types.GitLocalException(str(exc)) from exc
 
     def _iter_branch_commits(
         self, repo: git.Repo, branch: git.FetchInfo

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -164,7 +164,7 @@ class ScannerBase(abc.ABC):
                     self.global_options.git_rules_files,
                 )
             except (ValueError, re.error) as exc:
-                raise types.TartufoConfigException(str(exc)) from exc
+                raise types.ConfigException(str(exc)) from exc
         return self._rules_regexes
 
     @lru_cache()
@@ -238,11 +238,9 @@ class ScannerBase(abc.ABC):
         """
         issues: List[Issue] = []
         if not any((self.global_options.entropy, self.global_options.regex)):
-            raise types.TartufoConfigException("No analysis requested.")
+            raise types.ConfigException("No analysis requested.")
         if self.global_options.regex and not self.rules_regexes:
-            raise types.TartufoConfigException(
-                "Regex checks requested, but no regexes found."
-            )
+            raise types.ConfigException("Regex checks requested, but no regexes found.")
 
         for chunk in self.chunks:
             # Run regex scans first to trigger a potential fast fail for bad config

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -47,9 +47,17 @@ class ConfigException(TartufoException):
     """Raised if there is a problem with the configuration"""
 
 
+class ScanException(TartufoException):
+    """Raised if there is a problem encountered during a scan"""
+
+
 class GitException(TartufoException):
     """Raised if there is a problem interacting with git"""
 
 
-class ScanException(TartufoException):
-    """Raised if there is a problem encountered during a scan"""
+class GitLocalException(GitException):
+    """Raised if there is an error interacting with a local git repository"""
+
+
+class GitRemoteException(GitException):
+    """Raised if there is an error interacting with a remote git repository"""

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -43,13 +43,13 @@ class TartufoException(Exception):
     """Base class for all package exceptions"""
 
 
-class TartufoConfigException(Exception):
+class ConfigException(TartufoException):
     """Raised if there is a problem with the configuration"""
 
 
-class TartufoGitException(TartufoException):
+class GitException(TartufoException):
     """Raised if there is a problem interacting with git"""
 
 
-class TartufoScanException(TartufoException):
+class ScanException(TartufoException):
     """Raised if there is a problem encountered during a scan"""

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -39,5 +39,17 @@ class Chunk:
     metadata: Dict[str, Any] = field(default_factory=dict)
 
 
-class TartufoScanException(Exception):
-    pass
+class TartufoException(Exception):
+    """Base class for all package exceptions"""
+
+
+class TartufoConfigException(Exception):
+    """Raised if there is a problem with the configuration"""
+
+
+class TartufoGitException(TartufoException):
+    """Raised if there is a problem interacting with git"""
+
+
+class TartufoScanException(TartufoException):
+    """Raised if there is a problem encountered during a scan"""

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -14,6 +14,8 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, TYPE_CHECKING
 import click
 import git
 
+from tartufo import types
+
 if TYPE_CHECKING:
     from tartufo.scanner import Issue  # pylint: disable=cyclic-import
 
@@ -80,13 +82,17 @@ def clone_git_repo(
 
     :param git_url: The URL of the git repository to be cloned
     :param target_dir: Where to clone the repository to
+    :raises types.GitRemoteException: If there was an error cloning the repository
     """
     if not target_dir:
         project_path = tempfile.mkdtemp()
     else:
         project_path = str(target_dir)
 
-    git.Repo.clone_from(git_url, project_path)
+    try:
+        git.Repo.clone_from(git_url, project_path)
+    except git.GitCommandError as exc:
+        raise types.GitRemoteException(exc.stderr.strip()) from exc
     return pathlib.Path(project_path)
 
 

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -31,9 +31,7 @@ class ScanTests(ScannerTestCase):
         self.options.entropy = False
         self.options.regex = False
         test_scanner = TestScanner(self.options)
-        with self.assertRaisesRegex(
-            types.TartufoScanException, "No analysis requested."
-        ):
+        with self.assertRaisesRegex(types.ScanException, "No analysis requested."):
             test_scanner.scan()
 
     def test_scan_aborts_when_regex_requested_but_none_found(self):
@@ -41,7 +39,7 @@ class ScanTests(ScannerTestCase):
         self.options.default_regexes = False
         test_scanner = TestScanner(self.options)
         with self.assertRaisesRegex(
-            types.TartufoScanException, "Regex checks requested, but no regexes found."
+            types.ScanException, "Regex checks requested, but no regexes found."
         ):
             test_scanner.scan()
 
@@ -52,9 +50,7 @@ class ScanTests(ScannerTestCase):
         mock_config.side_effect = re.error(  # type: ignore
             msg="Invalid regular expression", pattern="42"
         )
-        with self.assertRaisesRegex(
-            types.TartufoScanException, "Invalid regular expression"
-        ):
+        with self.assertRaisesRegex(types.ScanException, "Invalid regular expression"):
             test_scanner.scan()
 
     @mock.patch("tartufo.scanner.ScannerBase.scan_entropy")

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -31,7 +31,7 @@ class ScanTests(ScannerTestCase):
         self.options.entropy = False
         self.options.regex = False
         test_scanner = TestScanner(self.options)
-        with self.assertRaisesRegex(types.ScanException, "No analysis requested."):
+        with self.assertRaisesRegex(types.ConfigException, "No analysis requested."):
             test_scanner.scan()
 
     def test_scan_aborts_when_regex_requested_but_none_found(self):
@@ -39,7 +39,7 @@ class ScanTests(ScannerTestCase):
         self.options.default_regexes = False
         test_scanner = TestScanner(self.options)
         with self.assertRaisesRegex(
-            types.ScanException, "Regex checks requested, but no regexes found."
+            types.ConfigException, "Regex checks requested, but no regexes found."
         ):
             test_scanner.scan()
 
@@ -50,7 +50,9 @@ class ScanTests(ScannerTestCase):
         mock_config.side_effect = re.error(  # type: ignore
             msg="Invalid regular expression", pattern="42"
         )
-        with self.assertRaisesRegex(types.ScanException, "Invalid regular expression"):
+        with self.assertRaisesRegex(
+            types.ConfigException, "Invalid regular expression"
+        ):
             test_scanner.scan()
 
     @mock.patch("tartufo.scanner.ScannerBase.scan_entropy")

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -57,6 +57,22 @@ class ChunkGeneratorTests(ScannerTestCase):
             pass
         mock_fetch.assert_called_once_with()
 
+    @mock.patch("git.Repo")
+    def test_explicit_exception_is_raised_if_fetch_fails(
+        self, mock_repo: mock.MagicMock
+    ):
+        mock_repo.return_value.remotes.origin.fetch.side_effect = git.GitCommandError(
+            command="git fetch -v origin", status=42, stderr="Fetch failed!"
+        )
+        test_scanner = scanner.GitRepoScanner(
+            self.global_options, self.git_options, "."
+        )
+        with self.assertRaisesRegex(
+            types.GitRemoteException, "stderr: 'Fetch failed!'"
+        ):
+            for _ in test_scanner.chunks:
+                pass
+
     @mock.patch("tartufo.scanner.GitRepoScanner._iter_branch_commits")
     @mock.patch("git.Repo")
     def test_all_branches_are_scanned_for_commits(

--- a/tests/test_pre_commit.py
+++ b/tests/test_pre_commit.py
@@ -19,9 +19,7 @@ class PreCommitTests(unittest.TestCase):
 
     @mock.patch("tartufo.commands.pre_commit.GitPreCommitScanner")
     def test_scan_fails_on_scan_exception(self, mock_scanner: mock.MagicMock):
-        mock_scanner.return_value.scan.side_effect = types.TartufoScanException(
-            "Scan failed!"
-        )
+        mock_scanner.return_value.scan.side_effect = types.ScanException("Scan failed!")
         runner = CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(cli.main, ["pre-commit"])

--- a/tests/test_scan_local_repo.py
+++ b/tests/test_scan_local_repo.py
@@ -25,3 +25,19 @@ class ScanLocalRepoTests(unittest.TestCase):
             self.assertEqual(
                 result.output, f"{dirname} is not a valid git repository.\n"
             )
+
+    @mock.patch("tartufo.commands.scan_local_repo.GitRepoScanner")
+    def test_scan_exits_gracefully_when_remote_fetch_fails(
+        self, mock_scanner: mock.MagicMock
+    ):
+        mock_scanner.return_value.scan.side_effect = types.GitRemoteException(
+            "Fetch failed!"
+        )
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(cli.main, ["scan-local-repo", "."])
+        self.assertGreater(result.exit_code, 0)
+        self.assertEqual(
+            result.output,
+            "There was an error fetching from the remote repository: Fetch failed!\n",
+        )

--- a/tests/test_scan_local_repo.py
+++ b/tests/test_scan_local_repo.py
@@ -11,9 +11,7 @@ class ScanLocalRepoTests(unittest.TestCase):
     def test_scan_exits_gracefully_on_scan_exception(
         self, mock_scanner: mock.MagicMock
     ):
-        mock_scanner.return_value.scan.side_effect = types.TartufoScanException(
-            "Scan failed!"
-        )
+        mock_scanner.return_value.scan.side_effect = types.ScanException("Scan failed!")
         runner = CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(cli.main, ["scan-local-repo", "."])

--- a/tests/test_scan_remote_repo.py
+++ b/tests/test_scan_remote_repo.py
@@ -2,7 +2,6 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from git.exc import GitCommandError
 from click.testing import CliRunner
 
 from tartufo import cli, types
@@ -65,9 +64,7 @@ class ScanRemoteRepoTests(unittest.TestCase):
     def test_command_fails_on_clone_error(
         self, mock_scanner: mock.MagicMock, mock_clone: mock.MagicMock
     ):
-        mock_clone.side_effect = GitCommandError(
-            command="git clone", status=42, stderr="Bad repo. Bad."
-        )
+        mock_clone.side_effect = types.GitException("stderr: 'Bad repo. Bad.'")
         mock_scanner.return_value.scan.return_value = []
         runner = CliRunner()
         with runner.isolated_filesystem():

--- a/tests/test_scan_remote_repo.py
+++ b/tests/test_scan_remote_repo.py
@@ -85,9 +85,7 @@ class ScanRemoteRepoTests(unittest.TestCase):
         self, mock_scanner: mock.MagicMock, mock_clone: mock.MagicMock
     ):
         mock_clone.return_value = "/foo"
-        mock_scanner.return_value.scan.side_effect = types.TartufoScanException(
-            "Scan failed!"
-        )
+        mock_scanner.return_value.scan.side_effect = types.ScanException("Scan failed!")
         runner = CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -62,10 +62,10 @@ class OutputTests(unittest.TestCase):
     @mock.patch("tartufo.util.json")
     def test_echo_issues_outputs_proper_json_when_requested(self, mock_json):
         issue_1 = scanner.Issue(
-            scanner.IssueType.Entropy, "foo", types.Chunk("foo", "/bar")
+            types.IssueType.Entropy, "foo", types.Chunk("foo", "/bar")
         )
         issue_2 = scanner.Issue(
-            scanner.IssueType.RegEx, "bar", types.Chunk("foo", "/bar")
+            types.IssueType.RegEx, "bar", types.Chunk("foo", "/bar")
         )
         util.echo_issues([issue_1, issue_2], True, "/repo", "/output")
         mock_json.dumps.assert_called_once_with(
@@ -97,10 +97,10 @@ class OutputTests(unittest.TestCase):
     @mock.patch("tartufo.util.json")
     def test_echo_issues_outputs_proper_json_when_requested_pathtype(self, mock_json):
         issue_1 = scanner.Issue(
-            scanner.IssueType.Entropy, "foo", types.Chunk("foo", "/bar")
+            types.IssueType.Entropy, "foo", types.Chunk("foo", "/bar")
         )
         issue_2 = scanner.Issue(
-            scanner.IssueType.RegEx, "bar", types.Chunk("foo", "/bar")
+            types.IssueType.RegEx, "bar", types.Chunk("foo", "/bar")
         )
         util.echo_issues([issue_1, issue_2], True, "/repo", Path("/tmp"))
         mock_json.dumps.assert_called_once_with(


### PR DESCRIPTION
The ultimate goal of this PR is to fix #90.

To that end, I did a bit of reworking of exceptions in general. Instead of just one `TartufoScanException`, there's a whole tree of exception types now:

```
TartufoException
|- ConfigException
|- ScanException
|- GitException
   |- GitLocalException
   |- GitRemoteException
```

This helped refine some error messages and overall hopefully make for a more user-friendly experience.