### PR TITLE
Fixes #86: Prefer tartufo.toml over pyproject.toml if both are present

### DIFF
--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -41,11 +41,11 @@ def read_pyproject_toml(
         if not root_path:
             root_path = "."
         root_path = pathlib.Path(root_path).resolve()
-        config_path = root_path / "pyproject.toml"
+        config_path = root_path / "tartufo.toml"
         if config_path.is_file():
             value = str(config_path)
         else:
-            config_path = root_path / "tartufo.toml"
+            config_path = root_path / "pyproject.toml"
             if config_path.is_file():
                 value = str(config_path)
             else:

--- a/tests/data/multiConfig/pyproject.toml
+++ b/tests/data/multiConfig/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.tartufo]
+regex = false

--- a/tests/data/multiConfig/tartufo.toml
+++ b/tests/data/multiConfig/tartufo.toml
@@ -1,0 +1,2 @@
+[tool.tartufo]
+regex = true

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -125,6 +125,13 @@ class ConfigFileTests(unittest.TestCase):
         os.chdir(str(cur_dir))
         self.assertEqual(self.ctx.default_map, {"regex": True})
 
+    def test_prefer_tartufo_toml_config_if_both_are_present(self):
+        cur_dir = pathlib.Path()
+        os.chdir(str(self.data_dir / "multiConfig"))
+        config.read_pyproject_toml(self.ctx, self.param, "")
+        os.chdir(str(cur_dir))
+        self.assertEqual(self.ctx.default_map, {"regex": True})
+
     def test_specified_file_gets_read(self):
         runner = CliRunner()
         with runner.isolated_filesystem():


### PR DESCRIPTION
Fixes #86 
- Implemented the solution suggested as part of bug description. 
- Added tests to ensure tartufo.toml takes precedence.