### PR TITLE
Bugfix: Load config from scanned repos

### DIFF
--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -30,7 +30,7 @@ DEFAULT_REGEXES = truffleHogRegexes.regexChecks.regexes
 
 
 def load_config_from_path(
-    config_path: pathlib.Path, filename: Optional[str], traverse: bool = True
+    config_path: pathlib.Path, filename: Optional[str] = None, traverse: bool = True
 ) -> Tuple[pathlib.Path, MutableMapping[str, Any]]:
     """Scan a path for a configuration file, and return its contents.
 
@@ -92,7 +92,7 @@ def load_config_from_path(
     if not config and traverse and config_path.parent != config_path:
         return load_config_from_path(config_path.parent, filename, traverse)
     if not config:
-        raise FileNotFoundError(f"Could not file config file in {config_path}.")
+        raise FileNotFoundError(f"Could not find config file in {config_path}.")
     return (full_path, config)  # type: ignore
 
 

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -3,12 +3,13 @@ import json
 import pathlib
 import re
 import shutil
-from typing import (  # pylint: disable=unused-import
+from typing import (
     Any,
     Dict,
     IO,
     Iterable,
     List,
+    MutableMapping,
     Optional,
     Pattern,
     TextIO,
@@ -19,12 +20,80 @@ from typing import (  # pylint: disable=unused-import
 import click
 import toml
 import truffleHogRegexes.regexChecks
-from tartufo import util
+
+from tartufo import types, util
 
 
 OptionTypes = Union[str, int, bool, None, TextIO, Tuple[TextIO, ...]]
 
 DEFAULT_REGEXES = truffleHogRegexes.regexChecks.regexes
+
+
+def load_config_from_path(
+    config_path: pathlib.Path, filename: Optional[str], traverse: bool = True
+) -> Tuple[pathlib.Path, MutableMapping[str, Any]]:
+    """Scan a path for a configuration file, and return its contents.
+
+    In addition to checking the specified path, if ``traverse`` is ``True``,
+    this will traverse up through the directory structure, looking for a
+    configuration file in parent directories. For example, given this directory
+    structure:
+
+    ::
+
+      working_dir/
+      |- tartufo.toml
+      |- group1/
+      |  |- project1/
+      |  |  |- tartufo.toml
+      |  |- project2/
+      |- group2/
+         |- tartufo.toml
+         |- project1/
+         |- project2/
+            |- tartufo.toml
+
+    The following ``config_path`` values will load the configuration files at
+    the corresponding paths:
+
+    ============================ ====
+    config_path                  file
+    ---------------------------- ----
+    working_dir/group1/project1/ working_dir/group1/project1/tartufo.toml
+    working_dir/group1/project2/ working_dir/tartufo.toml
+    working_dir/group2/project1/ working_dir/group2/tartufo.toml
+    working_dir/group2/project2/ working_dir/group2/project2/tartufo.toml
+    ============================ ====
+
+    :param config_path: The path to search for configuration files
+    :param filename: A specific filename to look for. By default, this will look
+      for both ``tartufo.toml`` and then ``pyproject.toml``.
+    :raises FileNotFoundError: If no config file was found
+    :raises types.ConfigException: If a config file was found, but could not be
+      read
+    :returns: A tuple consisting of the config file that was discovered, and the
+      contents of that file loaded in as TOML data
+    """
+    config: MutableMapping[str, Any] = {}
+    full_path: Optional[pathlib.Path] = None
+    if filename:
+        config_filenames = [filename]
+    else:
+        config_filenames = ["tartufo.toml", "pyproject.toml"]
+    for possibility in config_filenames:
+        full_path = config_path / possibility
+        if full_path.exists():
+            try:
+                toml_file = toml.load(full_path)
+                config = toml_file.get("tool", {}).get("tartufo", {})
+                break
+            except (toml.TomlDecodeError, OSError) as exc:
+                raise types.ConfigException(f"Error reading configuration file: {exc}")
+    if not config and traverse and config_path.parent != config_path:
+        return load_config_from_path(config_path.parent, filename, traverse)
+    if not config:
+        raise FileNotFoundError(f"Could not file config file in {config_path}.")
+    return (full_path, config)  # type: ignore
 
 
 def read_pyproject_toml(
@@ -35,29 +104,37 @@ def read_pyproject_toml(
     :param ctx: A context from a currently executing Click command
     :param _param: The command parameter that triggered this callback
     :param value: The value passed to the command parameter
+    :raises click.FileError: If there was a problem loading the configuration
     """
-    if not value:
-        root_path = ctx.params.get("repo_path", None)
-        if not root_path:
-            root_path = "."
-        root_path = pathlib.Path(root_path).resolve()
-        config_path = root_path / "tartufo.toml"
-        if config_path.is_file():
-            value = str(config_path)
-        else:
-            config_path = root_path / "pyproject.toml"
-            if config_path.is_file():
-                value = str(config_path)
-            else:
-                return None
+    config_path: Optional[pathlib.Path] = None
+    # These are the names of the arguments the sub-commands can receive.
+    # NOTE: If a new sub-command is added, make sure its argument is
+    #   captured in this list.
+    target_args = ["repo_path", "git_url"]
+    for arg in target_args:
+        target_path = ctx.params.get(arg, None)
+        if target_path:
+            config_path = pathlib.Path(target_path)
+            break
+    if not config_path:
+        # If no path was specified, default to the current working directory
+        config_path = pathlib.Path().cwd()
     try:
-        toml_file = toml.load(value)
-        config = toml_file.get("tool", {}).get("tartufo", {})
-    except (toml.TomlDecodeError, OSError) as exc:
-        raise click.FileError(
-            filename=str(value),
-            hint="Error reading configuration file: {}".format(exc),
-        )
+        config_file, config = load_config_from_path(config_path, value)
+    except FileNotFoundError as exc:
+        # If a config file was specified but not found, raise an error.
+        # Otherwise, pass quietly.
+        if value:
+            raise click.FileError(filename=str(config_path / value), hint=str(exc))
+        return None
+    except types.ConfigException as exc:
+        # If a config file was found, but could not be read, raise an error.
+        if value:
+            target_file = config_path / value
+        else:
+            target_file = config_path / "tartufo.toml"
+        raise click.FileError(filename=str(target_file), hint=str(exc))
+
     if not config:
         return None
     if ctx.default_map is None:
@@ -65,7 +142,7 @@ def read_pyproject_toml(
     ctx.default_map.update(  # type: ignore
         {k.replace("--", "").replace("-", "_"): v for k, v in config.items()}
     )
-    return str(value)
+    return str(config_file)
 
 
 def configure_regexes(

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -34,6 +34,9 @@ def load_config_from_path(
 ) -> Tuple[pathlib.Path, MutableMapping[str, Any]]:
     """Scan a path for a configuration file, and return its contents.
 
+    All key names are normalized to remove leading "-"/"--" and replace "-"
+    with "_". For example, "--repo-path" becomes "repo_path".
+
     In addition to checking the specified path, if ``traverse`` is ``True``,
     this will traverse up through the directory structure, looking for a
     configuration file in parent directories. For example, given this directory
@@ -93,7 +96,7 @@ def load_config_from_path(
         return load_config_from_path(config_path.parent, filename, traverse)
     if not config:
         raise FileNotFoundError(f"Could not find config file in {config_path}.")
-    return (full_path, config)  # type: ignore
+    return (full_path, {k.replace("--", "").replace("-", "_"): v for k, v in config.items()})  # type: ignore
 
 
 def read_pyproject_toml(
@@ -139,9 +142,7 @@ def read_pyproject_toml(
         return None
     if ctx.default_map is None:
         ctx.default_map = {}
-    ctx.default_map.update(  # type: ignore
-        {k.replace("--", "").replace("-", "_"): v for k, v in config.items()}
-    )
+    ctx.default_map.update(config)  # type: ignore
     return str(config_file)
 
 

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -397,6 +397,11 @@ class GitRepoScanner(GitScanner):
         except (FileNotFoundError, types.ConfigException) as exc:
             config_file = None
         if config_file and config_file != self.global_options.config:
+            signatures = data.get("exclude_signatures", None)
+            if signatures:
+                self.global_options.exclude_signatures = tuple(
+                    set(self.global_options.exclude_signatures + tuple(signatures))
+                )
             extras_path = data.get("include_paths", None)
             if extras_path:
                 extras_file = pathlib.Path(repo_path, extras_path)

--- a/tests/data/config/other_config.toml
+++ b/tests/data/config/other_config.toml
@@ -1,0 +1,2 @@
+[tool.tartufo]
+entropy = false

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,9 +6,10 @@ import unittest
 from unittest import mock
 
 import click
+import toml
 from click.testing import CliRunner
 
-from tartufo import config
+from tartufo import config, types
 
 
 class ConfigureRegexTests(unittest.TestCase):
@@ -100,44 +101,107 @@ class ConfigureRegexTests(unittest.TestCase):
             repo_path.glob.assert_called_once_with("tartufo.json")
 
 
-class ConfigFileTests(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.data_dir = pathlib.Path(__file__).parent / "data"
-        return super().setUpClass()
-
+class LoadConfigFromPathTests(unittest.TestCase):
     def setUp(self):
+        self.data_dir = pathlib.Path(__file__).parent / "data"
         self.ctx = click.Context(click.Command("foo"))
         self.param = click.Option(["--config"])
         return super().setUp()
 
-    def test_pyproject_toml_gets_read_if_no_file_specified(self):
-        cur_dir = pathlib.Path()
-        os.chdir(str(self.data_dir))
-        config.read_pyproject_toml(self.ctx, self.param, "")
-        os.chdir(str(cur_dir))
-        self.assertEqual(self.ctx.default_map, {"json": True})
+    def test_pyproject_toml_is_discovered_if_present(self):
+        (config_path, _) = config.load_config_from_path(self.data_dir)
+        self.assertEqual(config_path, self.data_dir / "pyproject.toml")
 
-    def test_tartufo_toml_gets_read_if_no_pyproject_toml(self):
-        cur_dir = pathlib.Path()
-        os.chdir(str(self.data_dir / "config"))
-        config.read_pyproject_toml(self.ctx, self.param, "")
-        os.chdir(str(cur_dir))
-        self.assertEqual(self.ctx.default_map, {"regex": True})
+    def test_tartufo_toml_is_discovered_if_present(self):
+        (config_path, _) = config.load_config_from_path(self.data_dir / "config")
+        self.assertEqual(config_path, self.data_dir / "config" / "tartufo.toml")
 
     def test_prefer_tartufo_toml_config_if_both_are_present(self):
-        cur_dir = pathlib.Path()
-        os.chdir(str(self.data_dir / "multiConfig"))
-        config.read_pyproject_toml(self.ctx, self.param, "")
-        os.chdir(str(cur_dir))
-        self.assertEqual(self.ctx.default_map, {"regex": True})
+        (config_path, _) = config.load_config_from_path(self.data_dir / "multiConfig")
+        self.assertEqual(config_path, self.data_dir / "multiConfig" / "tartufo.toml")
 
     def test_specified_file_gets_read(self):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            toml_file = self.data_dir / "config" / "tartufo.toml"
-            config.read_pyproject_toml(self.ctx, self.param, str(toml_file))
-        self.assertEqual(self.ctx.default_map, {"regex": True})
+        (config_path, _) = config.load_config_from_path(
+            self.data_dir / "config", "other_config.toml"
+        )
+        self.assertEqual(config_path, self.data_dir / "config" / "other_config.toml")
+
+    @mock.patch("toml.load")
+    def test_config_exception_is_raised_if_trouble_reading_file(
+        self, mock_toml: mock.MagicMock
+    ):
+        mock_toml.side_effect = toml.TomlDecodeError("Bad TOML!", "foo", 42)
+        with self.assertRaisesRegex(
+            types.ConfigException, "Error reading configuration file: Bad TOML!"
+        ):
+            config.load_config_from_path(self.data_dir)
+
+    def test_parent_directory_not_checked_if_traverse_is_false(self):
+        with self.assertRaisesRegex(
+            FileNotFoundError,
+            f"Could not find config file in {self.data_dir / 'config'}.",
+        ):
+            config.load_config_from_path(
+                self.data_dir / "config", "pyproject.toml", False
+            )
+
+
+class ReadPyprojectTomlTests(unittest.TestCase):
+    def setUp(self):
+        self.data_dir = pathlib.Path(__file__).parent / "data"
+        self.ctx = click.Context(click.Command("foo"))
+        self.param = click.Option(["--config"])
+        return super().setUp()
+
+    @mock.patch("tartufo.config.load_config_from_path")
+    def test_scan_target_is_searched_for_config_if_found(
+        self, mock_load: mock.MagicMock
+    ):
+        mock_load.return_value = (self.data_dir / "config" / "tartufo.toml", {})
+        self.ctx.params["repo_path"] = str(self.data_dir / "config")
+        config.read_pyproject_toml(self.ctx, self.param, "")
+        mock_load.assert_called_once_with(self.data_dir / "config", "")
+
+    @mock.patch("tartufo.config.load_config_from_path")
+    def test_file_error_is_raised_if_specified_file_not_found(
+        self, mock_load: mock.MagicMock
+    ):
+        mock_load.side_effect = FileNotFoundError("No file for you!")
+        with self.assertRaisesRegex(click.FileError, "No file for you!"):
+            config.read_pyproject_toml(self.ctx, self.param, "foobar.toml")
+
+    @mock.patch("tartufo.config.load_config_from_path")
+    def test_none_is_returned_if_file_not_found_and_none_specified(
+        self, mock_load: mock.MagicMock
+    ):
+        mock_load.side_effect = FileNotFoundError("No file for you!")
+        self.assertIsNone(config.read_pyproject_toml(self.ctx, self.param, ""))
+
+    @mock.patch("tartufo.config.load_config_from_path")
+    def test_file_error_is_raised_if_specified_config_file_cant_be_read(
+        self, mock_load: mock.MagicMock
+    ):
+        cur_dir = pathlib.Path()
+        os.chdir(str(self.data_dir))
+        mock_load.side_effect = types.ConfigException("Bad TOML!")
+        with self.assertRaisesRegex(click.FileError, "Bad TOML!") as exc:
+            config.read_pyproject_toml(self.ctx, self.param, "foobar.toml")
+            self.assertEqual(exc.exception.filename, str(self.data_dir / "foobar.toml"))
+        os.chdir(str(cur_dir))
+
+    @mock.patch("tartufo.config.load_config_from_path")
+    def test_file_error_is_raised_if_non_specified_config_file_cant_be_read(
+        self, mock_load: mock.MagicMock
+    ):
+        cur_dir = pathlib.Path()
+        os.chdir(str(self.data_dir))
+        mock_load.side_effect = types.ConfigException("Bad TOML!")
+        with self.assertRaisesRegex(click.FileError, "Bad TOML!") as exc:
+            config.read_pyproject_toml(self.ctx, self.param, "")
+            self.assertEqual(
+                exc.exception.filename, str(self.data_dir / "tartufo.toml")
+            )
+        os.chdir(str(cur_dir))
 
     def test_fully_resolved_filename_is_returned(self):
         cur_dir = pathlib.Path()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -145,6 +145,12 @@ class LoadConfigFromPathTests(unittest.TestCase):
                 self.data_dir / "config", "pyproject.toml", False
             )
 
+    @mock.patch("toml.load")
+    def test_config_keys_are_normalized(self, mock_load: mock.MagicMock):
+        mock_load.return_value = {"tool": {"tartufo": {"--repo-path": "."}}}
+        (_, data) = config.load_config_from_path(self.data_dir)
+        self.assertEqual(data, {"repo_path": "."})
+
 
 class ReadPyprojectTomlTests(unittest.TestCase):
     def setUp(self):

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -1,4 +1,6 @@
 # pylint: disable=protected-access
+import pathlib
+import re
 import unittest
 from unittest import mock
 
@@ -17,6 +19,10 @@ class ScannerTestCase(unittest.TestCase):
 
 
 class RepoLoadTests(ScannerTestCase):
+    def setUp(self):
+        self.data_dir = pathlib.Path(__file__).parent / "data"
+        super().setUp()
+
     @mock.patch("git.Repo")
     def test_repo_is_loaded_on_init(self, mock_repo: mock.MagicMock):
         scanner.GitRepoScanner(self.global_options, self.git_options, ".")
@@ -29,6 +35,42 @@ class RepoLoadTests(ScannerTestCase):
         )
         test_scanner.load_repo("../tartufo")
         mock_repo.assert_has_calls((mock.call("."), mock.call("../tartufo")))
+
+    @mock.patch("git.Repo", new=mock.MagicMock())
+    @mock.patch("tartufo.config.load_config_from_path")
+    def test_extra_inclusions_get_added(self, mock_load: mock.MagicMock):
+        mock_load.return_value = (
+            self.data_dir / "pyproject.toml",
+            {"include_paths": "include-files"},
+        )
+        test_scanner = scanner.GitRepoScanner(
+            self.global_options, self.git_options, str(self.data_dir)
+        )
+        test_scanner.load_repo("../tartufo")
+        self.assertEqual(
+            test_scanner.included_paths,
+            [re.compile("tartufo/"), re.compile("scripts/")],
+        )
+
+    @mock.patch("git.Repo", new=mock.MagicMock())
+    @mock.patch("tartufo.config.load_config_from_path")
+    def test_extra_exclusions_get_added(self, mock_load: mock.MagicMock):
+        mock_load.return_value = (
+            self.data_dir / "pyproject.toml",
+            {"exclude_paths": "exclude-files"},
+        )
+        test_scanner = scanner.GitRepoScanner(
+            self.global_options, self.git_options, str(self.data_dir)
+        )
+        test_scanner.load_repo("../tartufo")
+        self.assertEqual(
+            test_scanner.excluded_paths,
+            [
+                re.compile("tests/"),
+                re.compile(r"\.venv/"),
+                re.compile(r".*\.egg-info/"),
+            ],
+        )
 
 
 class ChunkGeneratorTests(ScannerTestCase):

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -72,6 +72,20 @@ class RepoLoadTests(ScannerTestCase):
             ],
         )
 
+    @mock.patch("git.Repo", new=mock.MagicMock())
+    @mock.patch("tartufo.config.load_config_from_path")
+    def test_extra_signatures_get_added(self, mock_load: mock.MagicMock):
+        self.global_options.exclude_signatures = ()
+        mock_load.return_value = (
+            self.data_dir / "pyproject.toml",
+            {"exclude_signatures": ["foo", "bar"]},
+        )
+        test_scanner = scanner.GitRepoScanner(
+            self.global_options, self.git_options, str(self.data_dir)
+        )
+        test_scanner.load_repo("../tartufo")
+        self.assertEqual(test_scanner.global_options.exclude_signatures, ("foo", "bar"))
+
 
 class ChunkGeneratorTests(ScannerTestCase):
     @mock.patch("git.Repo")

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -84,7 +84,9 @@ class RepoLoadTests(ScannerTestCase):
             self.global_options, self.git_options, str(self.data_dir)
         )
         test_scanner.load_repo("../tartufo")
-        self.assertEqual(test_scanner.global_options.exclude_signatures, ("foo", "bar"))
+        self.assertEqual(
+            sorted(test_scanner.global_options.exclude_signatures), ["bar", "foo"]
+        )
 
 
 class ChunkGeneratorTests(ScannerTestCase):


### PR DESCRIPTION
Fixes #91 

Now, whenever a repo is loaded, it is checked for config and it is merged with the config previously specified. Specifically, the "include-paths", "exclude-paths", and "exclude-signatures" config items are loaded.

As a result, the config loading is now further split out and more easily testable.

I get the feeling that this functionality will also need to get split out of `load_repo` at some point, especially to add similar support to other commands, such as the folder scanner requested in #83 (tentatively implemented in #102.)