### PR TITLE
feat(rules): Add path specific rules (#88)

### DIFF
--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -1,7 +1,7 @@
 # pylint: disable=too-many-instance-attributes
 import enum
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional, TextIO, Tuple
+from typing import Any, Dict, Optional, TextIO, Tuple, Pattern
 
 
 @dataclass
@@ -37,6 +37,13 @@ class Chunk:
     contents: str
     file_path: str
     metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Rule:
+    name: Optional[str]
+    pattern: Pattern
+    path_pattern: Optional[Pattern]
 
 
 class TartufoException(Exception):

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -9,12 +9,13 @@ import tempfile
 import uuid
 from functools import lru_cache, partial
 from hashlib import blake2s
-from typing import Any, Callable, Dict, Iterable, List, Optional, TYPE_CHECKING
+from typing import Any, Callable, Dict, Iterable, List, Optional, TYPE_CHECKING, Pattern
 
 import click
 import git
 
 from tartufo import types
+from tartufo.types import Rule
 
 if TYPE_CHECKING:
     from tartufo.scanner import Issue  # pylint: disable=cyclic-import
@@ -34,6 +35,15 @@ def del_rw(_func: Callable, name: str, _exc: Exception) -> None:
     """
     os.chmod(name, stat.S_IWRITE)
     os.remove(name)
+
+
+def convert_regexes_to_rules(regexes: Dict[str, Pattern]) -> Dict[str, Rule]:
+    rules: Dict[str, Rule] = {}
+    for regex_name in regexes:
+        rules[regex_name] = Rule(
+            name=regex_name, pattern=regexes[regex_name], path_pattern=None
+        )
+    return rules
 
 
 def echo_issues(

--- a/tests/data/testRules.json
+++ b/tests/data/testRules.json
@@ -1,3 +1,7 @@
 {
-  "RSA private key 2": "-----BEGIN EC PRIVATE KEY-----"
+  "RSA private key 2": "-----BEGIN EC PRIVATE KEY-----",
+  "Complex Rule": {
+    "pattern": "complex-rule",
+    "path_pattern": "/tmp/[a-z0-9A-Z]+\\.(py|js|json)"
+  }
 }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,7 @@ import toml
 from click.testing import CliRunner
 
 from tartufo import config, types
+from tartufo.types import Rule
 
 
 class ConfigureRegexTests(unittest.TestCase):
@@ -17,7 +18,16 @@ class ConfigureRegexTests(unittest.TestCase):
         rules_path = pathlib.Path(__file__).parent / "data" / "testRules.json"
         rules_files = (rules_path.open(),)
         expected_regexes = {
-            "RSA private key 2": re.compile("-----BEGIN EC PRIVATE KEY-----")
+            "RSA private key 2": Rule(
+                name="RSA private key 2",
+                pattern=re.compile("-----BEGIN EC PRIVATE KEY-----"),
+                path_pattern=None,
+            ),
+            "Complex Rule": Rule(
+                name="Complex Rule",
+                pattern=re.compile("complex-rule"),
+                path_pattern=re.compile("/tmp/[a-z0-9A-Z]+\\.(py|js|json)"),
+            ),
         }
 
         actual_regexes = config.configure_regexes(
@@ -35,8 +45,15 @@ class ConfigureRegexTests(unittest.TestCase):
         rules_path = pathlib.Path(__file__).parent / "data" / "testRules.json"
         rules_files = (rules_path.open(),)
         expected_regexes = copy.copy(config.DEFAULT_REGEXES)
-        expected_regexes["RSA private key 2"] = re.compile(
-            "-----BEGIN EC PRIVATE KEY-----"
+        expected_regexes["RSA private key 2"] = Rule(
+            name="RSA private key 2",
+            pattern=re.compile("-----BEGIN EC PRIVATE KEY-----"),
+            path_pattern=None,
+        )
+        expected_regexes["Complex Rule"] = Rule(
+            name="Complex Rule",
+            pattern=re.compile("complex-rule"),
+            path_pattern=re.compile("/tmp/[a-z0-9A-Z]+\\.(py|js|json)"),
         )
 
         actual_regexes = config.configure_regexes(


### PR DESCRIPTION
This will add the ability to define rules for files that match a specific pattern. For example, YAML files might need to match without quotes, whereas JS/JSON will need to match with quotes.

Closes #88