### PR TITLE
fix(git): Fix git-rules-repo argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ vX.Y.Z - TBD
 Bug fixes:
 
 * #117 - Ignore whitespace-only lines in exclusion files
+* #121 - Match rules specified with --git-rules-repo were not included in scans
 
 Other changes:
 

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -7,7 +7,6 @@ import shutil
 from typing import (
     Any,
     Dict,
-    IO,
     Iterable,
     List,
     MutableMapping,
@@ -166,7 +165,7 @@ def configure_regexes(
         rules = {}
 
     if rules_files:
-        all_files: List[IO[Any]] = list(rules_files)
+        all_files: List[TextIO] = list(rules_files)
     else:
         all_files = []
     try:
@@ -175,13 +174,14 @@ def configure_regexes(
         if rules_repo:
             repo_path = pathlib.Path(rules_repo)
             if not repo_path.is_dir():
+                cloned_repo = True
                 repo_path = pathlib.Path(util.clone_git_repo(rules_repo))
             if not rules_repo_files:
                 rules_repo_files = ("*.json",)
             for repo_file in rules_repo_files:
                 all_files.extend([path.open("r") for path in repo_path.glob(repo_file)])
-        if rules_files:
-            for rules_file in rules_files:
+        if all_files:
+            for rules_file in all_files:
                 loaded = load_rules_from_file(rules_file)
                 dupes = set(loaded.keys()).intersection(rules.keys())
                 if dupes:

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -470,6 +470,7 @@ class GitRepoScanner(GitScanner):
             raise types.GitRemoteException(exc.stderr.strip()) from exc
 
         for remote_branch in branches:
+            diff_index: git.DiffIndex = None
             diff_hash: bytes
             curr_commit: git.Commit = None
             prev_commit: git.Commit = None

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -470,7 +470,6 @@ class GitRepoScanner(GitScanner):
             raise types.GitRemoteException(exc.stderr.strip()) from exc
 
         for remote_branch in branches:
-            diff_index: git.DiffIndex = None
             diff_hash: bytes
             curr_commit: git.Commit = None
             prev_commit: git.Commit = None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -117,6 +117,31 @@ class ConfigureRegexTests(unittest.TestCase):
             config.configure_regexes(rules_repo=".", rules_repo_files=("tartufo.json",))
             repo_path.glob.assert_called_once_with("tartufo.json")
 
+    def test_configure_regexes_includes_rules_from_rules_repo(self):
+        rules_path = pathlib.Path(__file__).parent / "data"
+        actual_regexes = config.configure_regexes(
+            include_default=False, rules_repo=str(rules_path)
+        )
+        expected_regexes = {
+            "RSA private key 2": Rule(
+                name="RSA private key 2",
+                pattern=re.compile("-----BEGIN EC PRIVATE KEY-----"),
+                path_pattern=None,
+            ),
+            "Complex Rule": Rule(
+                name="Complex Rule",
+                pattern=re.compile("complex-rule"),
+                path_pattern=re.compile("/tmp/[a-z0-9A-Z]+\\.(py|js|json)"),
+            ),
+        }
+
+        self.assertEqual(
+            expected_regexes,
+            actual_regexes,
+            "The regexes dictionary should match the test rules "
+            "(expected: {}, actual: {})".format(expected_regexes, actual_regexes),
+        )
+
 
 class LoadConfigFromPathTests(unittest.TestCase):
     def setUp(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -120,7 +120,9 @@ class ConfigureRegexTests(unittest.TestCase):
     def test_configure_regexes_includes_rules_from_rules_repo(self):
         rules_path = pathlib.Path(__file__).parent / "data"
         actual_regexes = config.configure_regexes(
-            include_default=False, rules_repo=str(rules_path)
+            include_default=False,
+            rules_repo=str(rules_path),
+            rules_repo_files=["testRules.json"],
         )
         expected_regexes = {
             "RSA private key 2": Rule(


### PR DESCRIPTION
This fixes the git repo rules feature of tartufo as well as cleanup the repo clone files.

Closes #121 