### PR TITLE
Fix #117 - Ignore whitespace-only lines in exclusions files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
-v2.1.0 - 27 October 2020
+vX.Y.Z - TBD
 ------------------------
 
+Bug fixes:
+
+* #117 - Ignore whitespace-only lines in exclusion files
+
+Other changes:
+
 * Added references to Tartufo GoogleGroups mailing list to docs
+
 
 v2.0.1 - 09 October 2020
 ------------------------

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -236,5 +236,5 @@ def compile_path_rules(patterns: Iterable[str]) -> List[Pattern]:
     return [
         re.compile(pattern.strip())
         for pattern in patterns
-        if pattern and not pattern.startswith("#")
+        if pattern.strip() and not pattern.startswith("#")
     ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -234,5 +234,26 @@ class ReadPyprojectTomlTests(unittest.TestCase):
         self.assertEqual(result, str(self.data_dir / "config" / "tartufo.toml"))
 
 
+class CompilePathRulesTests(unittest.TestCase):
+    def test_commented_lines_are_ignored(self):
+        rules = config.compile_path_rules(["# Poetry lock file", r"poetry\.lock"])
+        self.assertEqual(rules, [re.compile(r"poetry\.lock")])
+
+    def test_whitespace_lines_are_ignored(self):
+        rules = config.compile_path_rules(
+            [
+                "# Poetry lock file",
+                r"poetry\.lock",
+                "",
+                "\t\n",
+                "# NPM files",
+                r"package-lock\.json",
+            ]
+        )
+        self.assertEqual(
+            rules, [re.compile(r"poetry\.lock"), re.compile(r"package-lock\.json")]
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [X] Tests (if applicable)
* [ ] Documentation (if applicable)
* [X] Changelog entry
* [X] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [X] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [X] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->
Fixes #117 

## What's new?
Previously, a blank line or a line containing only whitespace characters in the exclusions file would act as a wildcard and match all files, causing nothing to be scanned.

This "feature" was determined to be counter-intuitive to the purpose of this tool, and subsequently removed.
