### PR TITLE
Fix #115: Don't error out when an invalid sub-command is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ vX.Y.Z - TBD
 
 Bug fixes:
 
+* #115 - Strange behavior can manifest with invalid sub-commands
 * #117 - Ignore whitespace-only lines in exclusion files
 
 Other changes:

--- a/tests/commands/foo.py
+++ b/tests/commands/foo.py
@@ -1,0 +1,5 @@
+# pylint: skip-file
+
+
+def main():
+    pass

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,8 +6,35 @@ from unittest import mock
 from click.testing import CliRunner
 from tartufo import cli, scanner, types
 
+from tests.commands import foo as command_foo
+
 
 FakeFile = namedtuple("FakeFile", ["name"])
+
+
+class GetCommandsTests(unittest.TestCase):
+    _original_plugin_dir: Path
+    _original_plugin_module: str
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._original_plugin_dir = cli.PLUGIN_DIR
+        cls._original_plugin_module = cli.PLUGIN_MODULE
+        cli.PLUGIN_DIR = Path(__file__).parent / "commands"
+        cli.PLUGIN_MODULE = "tests.commands"
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cli.PLUGIN_DIR = cls._original_plugin_dir
+        cli.PLUGIN_MODULE = cls._original_plugin_module
+
+    def test_get_command_returns_main_attribute_from_command_modules(self):
+        command = cli.TartufoCLI().get_command(None, "foo")  # type: ignore
+        self.assertEqual(command, command_foo.main)
+
+    def test_get_command_fails_gracefully_on_invalid_commands(self):
+        command = cli.TartufoCLI().get_command(None, "bar")  # type: ignore
+        self.assertEqual(command, None)
 
 
 class ListCommandTests(unittest.TestCase):


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [X] Tests (if applicable)
* [ ] Documentation (if applicable)
* [X] Changelog entry
* [X] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [X] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [X] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->
Fixes #115 

## What's new?

With the introduction of sub-commands in 2.0, there was no error checking around the validity of the commands. So you would see the following:

```console
> tartufo foo
Traceback (most recent call last):
  File "/Users/jwilhelm/Documents/workspace/godaddy/tartufo/.venv/bin/tartufo", line 5, in <module>
    main()
  File "/Users/jwilhelm/Documents/workspace/godaddy/tartufo/.venv/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/jwilhelm/Documents/workspace/godaddy/tartufo/.venv/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/jwilhelm/Documents/workspace/godaddy/tartufo/.venv/lib/python3.7/site-packages/click/core.py", line 1254, in invoke
    cmd_name, cmd, args = self.resolve_command(ctx, args)
  File "/Users/jwilhelm/Documents/workspace/godaddy/tartufo/.venv/lib/python3.7/site-packages/click/core.py", line 1297, in resolve_command
    cmd = self.get_command(ctx, cmd_name)
  File "/Users/jwilhelm/Documents/workspace/godaddy/tartufo/tartufo/cli.py", line 27, in get_command
    f".{cmd_name.replace('-', '_')}", PLUGIN_MODULE
  File "/Users/jwilhelm/.pyenv/versions/3.7.8/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 965, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'tartufo.commands.foo'
>
```

Now, it's handled much better and more explicitly:

```console
> tartufo foo
Usage: tartufo [OPTIONS] COMMAND [ARGS]...
Try 'tartufo -h' for help.

Error: No such command 'foo'.
>
```