### PR TITLE
Fix #140: Ensure a valid output folder name in Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   tox:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8, 3.9, pypy3]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       uses: actions/setup-python@41b7212
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install Enchant
+      run: brew install enchant
+      if: ${{ matrix.os == 'macos-latest' && matrix.python-version == '3.7' }}
     - name: Install dependencies
       run:  pip install poetry tox codecov tox-gh-actions
     - name: Run tox environments

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,14 @@ on:
 
 jobs:
   tox:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+    runs-on: ${{ matrix.os }}
     env:
       PYTHON: ${{ matrix.python-version }}
+      OS: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@5a4ac90
     - name: Set up Python ${{ matrix.python-version }}
@@ -28,4 +30,4 @@ jobs:
       uses: codecov/codecov-action@07127fd
       with:
         file: coverage.xml
-        env_vars: PYTHON
+        env_vars: OS,PYTHON

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        exclude:
+          # https://github.com/tox-dev/tox/issues/1704
+          - os: windows-latest
+            python-version: pypy3
     runs-on: ${{ matrix.os }}
     env:
       PYTHON: ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ Bugfixes:
 * #115 - Strange behavior can manifest with invalid sub-commands
 * #117 - Ignore whitespace-only lines in exclusion files
 * #121 - Match rules specified with --git-rules-repo were not included in scans
+* #140 - Ensure a valid output folder name in Windows
 
 Other changes:
 
+* #95 - Run CI across Linux, Windows, and MacOS
 * #130 - Added references to Tartufo GoogleGroups mailing list to docs
 * Fixed testing in Pypy3 and explicitly added Python 3.9 support
 * #143 - Updated GitHub Action hashes to newest rev to address https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ where possible

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -15,6 +15,7 @@ hexidecimal
 json
 metadata
 pre
+Pypy
 refactored
 regexes
 repo

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -2,6 +2,7 @@
 
 import importlib
 import pathlib
+import platform
 from datetime import datetime
 from typing import List, Optional, Tuple
 
@@ -172,6 +173,9 @@ def process_issues(
     output_dir = None
     if options.output_dir:
         now = datetime.now().isoformat("T", "microseconds")
+        if platform.system().lower() == "windows":
+            # Make sure we aren't using illegal characters for Windows folder names
+            now = now.replace(":", "")
         output_dir = pathlib.Path(options.output_dir) / f"tartufo-scan-results-{now}"
         output_dir.mkdir(parents=True)
 

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -196,7 +196,7 @@ def configure_regexes(
                 rules.update(loaded)
     finally:
         if cloned_repo:
-            shutil.rmtree(repo_path)  # type: ignore
+            shutil.rmtree(repo_path, onerror=util.del_rw)  # type: ignore
 
     return rules
 

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -172,9 +172,15 @@ def configure_regexes(
         repo_path = None
         if rules_repo:
             repo_path = pathlib.Path(rules_repo)
-            if not repo_path.is_dir():
+            try:
+                if not repo_path.is_dir():
+                    cloned_repo = True
+            except OSError:
+                # If a git URL is passed in, Windows will raise an OSError on `is_dir()`
                 cloned_repo = True
-                repo_path = pathlib.Path(util.clone_git_repo(rules_repo))
+            finally:
+                if cloned_repo:
+                    repo_path = pathlib.Path(util.clone_git_repo(rules_repo))
             if not rules_repo_files:
                 rules_repo_files = ("*.json",)
             for repo_file in rules_repo_files:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,13 @@
+import platform
 from dataclasses import fields
 from typing import Type, TypeVar
+
+WINDOWS = platform.system().lower() == "windows"
+PY_VERSION = platform.python_version_tuple()
+PY_36 = ("3", "6", "0") <= PY_VERSION < ("3", "7", "0")
+PY_37 = ("3", "7", "0") <= PY_VERSION < ("3", "8", "0")
+BROKEN_USER_PATHS = WINDOWS and (PY_36 or PY_37)
+
 
 OptionsType = TypeVar("OptionsType")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import platform
 import unittest
 from collections import namedtuple
 from pathlib import Path
@@ -93,6 +94,30 @@ class ProcessIssuesTest(unittest.TestCase):
             )
         ]
         mock_dt.now.return_value.isoformat.return_value = "nownownow"
+        runner = CliRunner()
+        with runner.isolated_filesystem() as dirname:
+            result = runner.invoke(
+                cli.main, ["--output-dir", "./foo", "scan-local-repo", "."]
+            )
+        self.assertEqual(
+            result.output,
+            f"Results have been saved in {Path(dirname).resolve()}/foo/tartufo-scan-results-nownownow\n",
+        )
+
+    @unittest.skipUnless(platform.system().lower() == "windows", "Test is Windows-only")
+    @mock.patch("tartufo.cli.datetime")
+    @mock.patch("tartufo.commands.scan_local_repo.GitRepoScanner")
+    @mock.patch("tartufo.util.echo_issues", new=mock.MagicMock())
+    @mock.patch("tartufo.util.write_outputs", new=mock.MagicMock())
+    def test_output_dir_is_valid_name_in_windows(
+        self, mock_scanner: mock.MagicMock, mock_dt: mock.MagicMock
+    ):
+        mock_scanner.return_value.scan.return_value = [
+            scanner.Issue(
+                types.IssueType.Entropy, "foo", types.Chunk("foo", "/bar", {})
+            )
+        ]
+        mock_dt.now.return_value.isoformat.return_value = "now:now:now"
         runner = CliRunner()
         with runner.isolated_filesystem() as dirname:
             result = runner.invoke(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -125,9 +125,11 @@ class ProcessIssuesTest(unittest.TestCase):
             result = runner.invoke(
                 cli.main, ["--output-dir", "./foo", "scan-local-repo", "."]
             )
+        output_dir = (
+            Path(dirname) / "foo" / "tartufo-scan-results-nownownow"
+        ).resolve()
         self.assertEqual(
-            result.output,
-            f"Results have been saved in {Path(dirname).resolve()}/foo/tartufo-scan-results-nownownow\n",
+            result.output, f"Results have been saved in {output_dir}\n",
         )
 
     @mock.patch("tartufo.commands.scan_local_repo.GitRepoScanner")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,3 @@
-import platform
 import unittest
 from collections import namedtuple
 from pathlib import Path
@@ -7,6 +6,7 @@ from unittest import mock
 from click.testing import CliRunner
 from tartufo import cli, scanner, types
 
+from tests import helpers
 from tests.commands import foo as command_foo
 
 
@@ -81,6 +81,9 @@ class ListCommandTests(unittest.TestCase):
 
 
 class ProcessIssuesTest(unittest.TestCase):
+    @unittest.skipIf(
+        helpers.BROKEN_USER_PATHS, "Skipping due to truncated Windows usernames"
+    )
     @mock.patch("tartufo.cli.datetime")
     @mock.patch("tartufo.commands.scan_local_repo.GitRepoScanner")
     @mock.patch("tartufo.util.echo_issues", new=mock.MagicMock())
@@ -106,7 +109,10 @@ class ProcessIssuesTest(unittest.TestCase):
             result.output, f"Results have been saved in {output_dir}\n",
         )
 
-    @unittest.skipUnless(platform.system().lower() == "windows", "Test is Windows-only")
+    @unittest.skipUnless(helpers.WINDOWS, "Test is Windows-only")
+    @unittest.skipIf(
+        helpers.BROKEN_USER_PATHS, "Skipping due to truncated Windows usernames"
+    )
     @mock.patch("tartufo.cli.datetime")
     @mock.patch("tartufo.commands.scan_local_repo.GitRepoScanner")
     @mock.patch("tartufo.util.echo_issues", new=mock.MagicMock())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,9 +99,11 @@ class ProcessIssuesTest(unittest.TestCase):
             result = runner.invoke(
                 cli.main, ["--output-dir", "./foo", "scan-local-repo", "."]
             )
+        output_dir = (
+            Path(dirname) / "foo" / "tartufo-scan-results-nownownow"
+        ).resolve()
         self.assertEqual(
-            result.output,
-            f"Results have been saved in {Path(dirname).resolve()}/foo/tartufo-scan-results-nownownow\n",
+            result.output, f"Results have been saved in {output_dir}\n",
         )
 
     @unittest.skipUnless(platform.system().lower() == "windows", "Test is Windows-only")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,6 @@
 import copy
 import os
 import pathlib
-import platform
 import re
 import unittest
 from unittest import mock
@@ -12,6 +11,8 @@ from click.testing import CliRunner
 
 from tartufo import config, types
 from tartufo.types import Rule
+
+from tests import helpers
 
 
 class ConfigureRegexTests(unittest.TestCase):
@@ -87,8 +88,7 @@ class ConfigureRegexTests(unittest.TestCase):
         mock_clone.assert_not_called()
 
     @unittest.skipIf(
-        platform.system().lower() == "windows",
-        "Avoiding a race condition/permission error in Windows",
+        helpers.WINDOWS, "Avoiding a race condition/permission error in Windows",
     )
     @mock.patch("tartufo.config.util.clone_git_repo")
     def test_configure_regexes_clones_git_rules_repo(self, mock_clone):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -183,7 +183,7 @@ class LoadConfigFromPathTests(unittest.TestCase):
     def test_parent_directory_not_checked_if_traverse_is_false(self):
         with self.assertRaisesRegex(
             FileNotFoundError,
-            f"Could not find config file in {self.data_dir / 'config'}.",
+            rf"Could not find config file in {self.data_dir / 'config'}.",
         ):
             config.load_config_from_path(
                 self.data_dir / "config", "pyproject.toml", False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 import copy
 import os
 import pathlib
+import platform
 import re
 import unittest
 from unittest import mock
@@ -85,6 +86,10 @@ class ConfigureRegexTests(unittest.TestCase):
             config.configure_regexes(rules_repo=".")
         mock_clone.assert_not_called()
 
+    @unittest.skipIf(
+        platform.system().lower() == "windows",
+        "Avoiding a race condition/permission error in Windows",
+    )
     @mock.patch("tartufo.config.util.clone_git_repo")
     def test_configure_regexes_clones_git_rules_repo(self, mock_clone):
         runner = CliRunner()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -183,7 +183,9 @@ class LoadConfigFromPathTests(unittest.TestCase):
     def test_parent_directory_not_checked_if_traverse_is_false(self):
         with self.assertRaisesRegex(
             FileNotFoundError,
-            rf"Could not find config file in {self.data_dir / 'config'}.",
+            f"Could not find config file in {self.data_dir / 'config'}.".replace(
+                "\\", "\\\\"
+            ),
         ):
             config.load_config_from_path(
                 self.data_dir / "config", "pyproject.toml", False

--- a/tests/test_scan_local_repo.py
+++ b/tests/test_scan_local_repo.py
@@ -6,6 +6,8 @@ from click.testing import CliRunner
 
 from tartufo import cli, types
 
+from tests import helpers
+
 
 class ScanLocalRepoTests(unittest.TestCase):
     @mock.patch("tartufo.commands.scan_local_repo.GitRepoScanner")
@@ -19,6 +21,9 @@ class ScanLocalRepoTests(unittest.TestCase):
         self.assertGreater(result.exit_code, 0)
         self.assertEqual(result.output, "Scan failed!\n")
 
+    @unittest.skipIf(
+        helpers.BROKEN_USER_PATHS, "Skipping due to truncated Windows usernames"
+    )
     def test_scan_exits_gracefully_when_target_is_not_git_repo(self):
         runner = CliRunner()
         with runner.isolated_filesystem() as dirname:

--- a/tests/test_scan_remote_repo.py
+++ b/tests/test_scan_remote_repo.py
@@ -6,6 +6,8 @@ from click.testing import CliRunner
 
 from tartufo import cli, types
 
+from tests import helpers
+
 
 class ScanRemoteRepoTests(unittest.TestCase):
     @mock.patch("tartufo.commands.scan_remote_repo.util.clone_git_repo")
@@ -90,6 +92,9 @@ class ScanRemoteRepoTests(unittest.TestCase):
             )
         self.assertEqual(result.output, "Scan failed!\n")
 
+    @unittest.skipIf(
+        helpers.BROKEN_USER_PATHS, "Skipping due to truncated Windows usernames"
+    )
     @mock.patch("tartufo.commands.scan_remote_repo.util.clone_git_repo")
     @mock.patch("tartufo.commands.scan_remote_repo.GitRepoScanner")
     @mock.patch("tartufo.commands.scan_remote_repo.rmtree", new=mock.MagicMock())

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -48,7 +48,8 @@ class GitTests(unittest.TestCase):
         )
         mock_temp.assert_not_called()
         mock_clone.assert_called_once_with(
-            "https://github.com/godaddy/tartufo.git", "/foo/tartufo.git"
+            "https://github.com/godaddy/tartufo.git",
+            str(Path("/foo/tartufo.git").resolve()),
         )
 
     @mock.patch("git.Repo.clone_from")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -48,8 +48,7 @@ class GitTests(unittest.TestCase):
         )
         mock_temp.assert_not_called()
         mock_clone.assert_called_once_with(
-            "https://github.com/godaddy/tartufo.git",
-            str(Path("/foo/tartufo.git").resolve()),
+            "https://github.com/godaddy/tartufo.git", str(Path("/foo/tartufo.git")),
         )
 
     @mock.patch("git.Repo.clone_from")
@@ -122,7 +121,7 @@ class OutputTests(unittest.TestCase):
         mock_json.dumps.assert_called_once_with(
             {
                 "project_path": "/repo",
-                "output_dir": "/tmp",
+                "output_dir": str(Path("/tmp")),
                 "found_issues": [
                     {
                         "issue_type": "High Entropy",


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [X] Tests (if applicable)
* [ ] Documentation (if applicable)
* [X] Changelog entry
* [X] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [X] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [X] CI related changes
* [ ] Documentation content changes
* [X] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [X] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->
Fixes #140, #95 

## What's new?

* Fixed an issue where using the `--output-dir` option would error our in Windows due to a `:` in the folder name
* Expanded CI to run across Linux, Windows, and MacOS

