### PR TITLE
`--exclude-path-patterns`, now also in `tartufo.toml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dmypy.json
 *.swp
 
 .DS_Store
+
+#GH Codespaces
+pythonenv3.*

--- a/.tartufo-excludes
+++ b/.tartufo-excludes
@@ -1,8 +1,0 @@
-# This is now specified directly in `pyproject.toml` `exclude-path-patterns`,
-# but the patterns below would also work if specified with `--exclude-paths`:
-.github/workflows/(.*)\.yml
-poetry.lock
-pyproject.toml
-docs/source/(.*)\.rst
-tests/test_base_scanner\.py
-tests/test_util.py

--- a/.tartufo-excludes
+++ b/.tartufo-excludes
@@ -1,3 +1,5 @@
+# This is now specified directly in `pyproject.toml` `exclude-path-patterns`,
+# but the patterns below would also work if specified with `--exclude-paths`:
 .github/workflows/(.*)\.yml
 poetry.lock
 pyproject.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Features:
 * #119 - Added a new `--fetch`/`--no-fetch` option for local scans, controlling
   whether the local clone is refreshed before scan. (Thanks @jgowdy!)
 * #125 - Implement CODEOWNERS and auto-assignment to maintainers on PRs
+* [#145](https://github.com/godaddy/tartufo/issues/145) - Adds `--exclude-path-patterns` and `--include-path-patterns` to simplify config in a single .toml file
 
 Bugfixes:
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,20 @@ Options:
                                   applicable if --rules is also specified.
                                   [default: True]
 
+  --compact / --no-compact        Enable reduced output.  [default: False]
   --entropy / --no-entropy        Enable entropy checks.  [default: True]
   --regex / --no-regex            Enable high signal regexes checks.
                                   [default: False]
+
+  -i, --include-paths FILENAME    [DEPRECATED] Use `--include-path-patterns`.
+                                  File with regular expressions (one per
+                                  line), at least one of which must match a
+                                  Git object path in order for it to be
+                                  scanned; lines starting with '#' are treated
+                                  as comments and are ignored. If empty or not
+                                  provided (default), all Git object paths are
+                                  included unless otherwise excluded via the
+                                  --exclude-paths option.
 
   -ip, --include-path-patterns TEXT
                                   Specify a regular expression which matches
@@ -65,6 +76,16 @@ Options:
                                   provided (default), all Git object paths are
                                   included unless otherwise excluded via the
                                   --exclude-path-patterns option.
+
+  -x, --exclude-paths FILENAME    [DEPRECATED] Use `--exclude-path-patterns`.
+                                  File with regular expressions (one per
+                                  line), none of which may match a Git object
+                                  path in order for it to be scanned; lines
+                                  starting with '#' are treated as comments
+                                  and are ignored. If empty or not provided
+                                  (default), no Git object paths are excluded
+                                  unless effectively excluded via the
+                                  --include-paths option.
 
   -xp, --exclude-path-patterns TEXT
                                   Specify a regular expression which matches
@@ -105,6 +126,18 @@ Options:
 
   --config FILE                   Read configuration from specified file.
                                   [default: tartufo.toml]
+
+  -q, --quiet / --no-quiet        Quiet mode. No outputs are reported if the
+                                  scan is successful and doesn't find any
+                                  issues
+
+  -v, --verbose                   Display more verbose output. Specifying this
+                                  option multiple times will incrementally
+                                  increase the amount of output.
+
+  --log-timestamps / --no-log-timestamps
+                                  Enable or disable timestamps in logging
+                                  messages.  [default: True]
 
   -V, --version                   Show the version and exit.
   -h, --help                      Show this message and exit.

--- a/README.md
+++ b/README.md
@@ -57,41 +57,23 @@ Options:
   --regex / --no-regex            Enable high signal regexes checks.
                                   [default: False]
 
-  -i, --include-paths FILENAME    File with regular expressions (one per
-                                  line), at least one of which must match a
-                                  Git object path in order for it to be
-                                  scanned; lines starting with '#' are treated
-                                  as comments and are ignored. If empty or not
-                                  provided (default), all Git object paths are
-                                  included unless otherwise excluded via the
-                                  --exclude-paths option.
-
   -ip, --include-path-patterns TEXT
                                   Specify a regular expression which matches
                                   Git object paths to include in the scan.
                                   This option can be specified multiple times
-                                  to include multiple patterns. This can be
-                                  used in conjunction with or as a replacement
-                                  for --include-paths and also defaults to an
-                                  empty list, including all Git object paths.
-
-  -x, --exclude-paths FILENAME    File with regular expressions (one per
-                                  line), none of which may match a Git object
-                                  path in order for it to be scanned; lines
-                                  starting with '#' are treated as comments
-                                  and are ignored. If empty or not provided
-                                  (default), no Git object paths are excluded
-                                  unless effectively excluded via the
-                                  --include-paths option.
+                                  to include multiple patterns. If not
+                                  provided (default), all Git object paths are
+                                  included unless otherwise excluded via the
+                                  --exclude-path-patterns option.
 
   -xp, --exclude-path-patterns TEXT
                                   Specify a regular expression which matches
                                   Git object paths to exclude from the scan.
                                   This option can be specified multiple times
-                                  to exclude multiple patterns. This can be
-                                  used in conjunction with or as a replacement
-                                  for --exclude-paths and also defaults to an
-                                  empty list.
+                                  to exclude multiple patterns. If not
+                                  provided (default), no Git object paths are
+                                  excluded unless effectively excluded via the
+                                  --include-path-patterns option.
 
   -e, --exclude-signatures TEXT   Specify signatures of matches that you
                                   explicitly want to exclude from the scan,
@@ -122,15 +104,15 @@ Options:
                                   specified multiple times.
 
   --config FILE                   Read configuration from specified file.
-                                  [default: pyproject.toml]
+                                  [default: tartufo.toml]
 
   -V, --version                   Show the version and exit.
   -h, --help                      Show this message and exit.
 
 Commands:
   pre-commit        Scan staged changes in a pre-commit hook.
-  scan-remote-repo  Automatically clone and scan a remote git repository.
   scan-local-repo   Scan a repository already cloned to your local system.
+  scan-remote-repo  Automatically clone and scan a remote git repository.
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ Options:
                                   included unless otherwise excluded via the
                                   --exclude-paths option.
 
+  -ip, --include-path-patterns TEXT
+                                  Specify a regular expression which matches
+                                  Git object paths to include in the scan.
+                                  This option can be specified multiple times
+                                  to include multiple patterns. This can be
+                                  used in conjunction with or as a replacement
+                                  for --include-paths and also defaults to an
+                                  empty list, including all Git object paths.
+
   -x, --exclude-paths FILENAME    File with regular expressions (one per
                                   line), none of which may match a Git object
                                   path in order for it to be scanned; lines
@@ -74,6 +83,15 @@ Options:
                                   (default), no Git object paths are excluded
                                   unless effectively excluded via the
                                   --include-paths option.
+
+  -xp, --exclude-path-patterns TEXT
+                                  Specify a regular expression which matches
+                                  Git object paths to exclude from the scan.
+                                  This option can be specified multiple times
+                                  to exclude multiple patterns. This can be
+                                  used in conjunction with or as a replacement
+                                  for --exclude-paths and also defaults to an
+                                  empty list.
 
   -e, --exclude-signatures TEXT   Specify signatures of matches that you
                                   explicitly want to exclude from the scan,

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -38,6 +38,16 @@ this:
    json = false
    regex = true
    entropy = true
+   exclude-path-patterns = [
+       'poetry.lock',
+       # To not have to escape `\` in regexes, use single quoted
+       # TOML 'literal strings'
+       'docs/source/(.*)\.rst',
+   ]
+   exclude-signatures = [
+       "62f22e4500140a6ed959a6143c52b0e81c74e7491081292fce733de4ec574542",
+       "ecbbe1edd6373c7e2b88b65d24d7fe84610faafd1bc2cf6ae35b43a77183e80b",
+   ]
 
 Note that all options specified in a configuration file are treated as
 defaults, and will be overridden by any options specified on the command line.

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -269,7 +269,8 @@ Limiting Scans by Path
 
 By default ``tartufo`` will scan all objects tracked by Git. You can limit
 scanning by either including fewer paths or excluding some of them using
-Python Regular Expressions (regex).
+Python Regular Expressions (regex) and the `--include-path-patterns` and
+`--exclude-path-patterns` options.
 
 .. warning::
 
@@ -305,54 +306,6 @@ in the config file:
      --include-path-patterns 'src/' -ip 'gradle/' \
      --exclude-path-patterns '(.*/)?\.classpath$' -xp '.*\.jmx$' \
      scan-local-repo file://path/to/my/repo.git
-
-
-Limiting Scans by Path (via inclusion/exclusion files)
-++++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-.. note::
-
-   The ``--include-paths`` and ``--exclude-paths`` options are no longer
-   recommended, you can create the same filters inside your ``.toml`` config
-   file using ``include-path-patterns`` and ``exclude-path-patterns``
-   (as shown above).
-
-   We have left these options for backwards compatibility.
-
-With the ``--include-paths`` and ``--exclude-paths`` options, it is also
-possible to limit scanning to a subset of objects in the Git history by
-defining regular expressions (one per line) in a file to match the targeted
-object paths. To illustrate, see the example include and exclude files below:
-
-.. code-block:: ini
-   :caption: include-patterns.txt
-
-   src/
-   # lines beginning with "#" are treated as comments and are ignored
-   gradle/
-   # regexes must match the entire path, but can use python's regex syntax for
-   # case-insensitive matching and other advanced options
-   (?i).*\.(properties|conf|ini|txt|y(a)?ml)$
-   (.*/)?id_[rd]sa$
-
-.. code-block:: ini
-   :caption: exclude-patterns.txt
-
-   (.*/)?\.classpath$
-   .*\.jmx$
-   (.*/)?test/(.*/)?resources/
-
-These filter files could then be applied by:
-
-.. code-block:: sh
-
-   > tartufo --include-paths include-patterns.txt \
-     --exclude-paths exclude-patterns.txt \
-     scan-local-repo file://path/to/my/repo.git
-
-With these filters, issues found in files in the root-level ``src`` directory
-would be reported, unless they had the ``.classpath`` or ``.jmx`` extension, or
-if they were found in the ``src/test/dev/resources/`` directory, for example.
 
 
 Additional usage information is provided when calling ``tartufo`` with the

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -301,10 +301,9 @@ in the config file:
 
 .. code-block:: sh
 
-   # --include-path-patterns == -ip
-   # --exclude-path-patterns == -xp
-   > tartufo -ip 'src/' -ip 'gradle/' \
-     -xp '(.*/)?\.classpath$' -xp '.*\.jmx$' \
+   > tartufo \
+     --include-path-patterns 'src/' -ip 'gradle/' \
+     --exclude-path-patterns '(.*/)?\.classpath$' -xp '.*\.jmx$' \
      scan-local-repo file://path/to/my/repo.git
 
 

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -267,6 +267,59 @@ Done! This particular issue will no longer show up in your scan results.
 Limiting Scans by Path
 ++++++++++++++++++++++
 
+By default ``tartufo`` will scan all objects tracked by Git. You can limit
+scanning by either including fewer paths or excluding some of them using
+Python Regular Expressions (regex).
+
+.. warning::
+
+   Using include patterns is more dangerous, since it's easy to miss the
+   creation of new secrets if future files don't match an existing include
+   rule. We recommend only using fine-grained exclude patterns instead.
+
+.. code-block:: toml
+
+   [tool.tartufo]
+   include-path-patterns = [
+      'src/',
+      'gradle/',
+      # regexes must match the entire path, but can use python's regex syntax
+      # for case-insensitive matching and other advanced options
+      '(.*/)?id_[rd]sa$',
+      # Single quoted strings in TOML don't require escapes for `\` in regexes
+      '(?i).*\.(properties|conf|ini|txt|y(a)?ml)$',
+   ]
+   exclude-path-patterns = [
+      '(.*/)?\.classpath$',
+      '.*\.jmx$',
+      '(.*/)?test/(.*/)?resources/',
+   ]
+
+The filter expressions can also be specified as command line arguments.
+Patterns specified like this are merged with any patterns specified
+in the config file:
+
+.. code-block:: sh
+
+   # --include-path-patterns == -ip
+   # --exclude-path-patterns == -xp
+   > tartufo -ip 'src/' -ip 'gradle/' \
+     -xp '(.*/)?\.classpath$' -xp '.*\.jmx$' \
+     scan-local-repo file://path/to/my/repo.git
+
+
+Limiting Scans by Path (via inclusion/exclusion files)
+++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. note::
+
+   The ``--include-paths`` and ``--exclude-paths`` options are no longer
+   recommended, you can create the same filters inside your ``.toml`` config
+   file using ``include-path-patterns`` and ``exclude-path-patterns``
+   (as shown above).
+
+   We have left these options for backwards compatibility.
+
 With the ``--include-paths`` and ``--exclude-paths`` options, it is also
 possible to limit scanning to a subset of objects in the Git history by
 defining regular expressions (one per line) in a file to match the targeted

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ exclude-path-patterns = [
     'pyproject.toml',
     # To not have to escape `\` in regexes, use single quoted
     # TOML 'literal strings'
+    '.github/workflows/(.*)\.ymlz',
     'docs/source/(.*)\.rst',
     'tests/test_base_scanner\.py',
     'tests/test_util.py',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ exclude-path-patterns = [
     'pyproject.toml',
     # To not have to escape `\` in regexes, use single quoted
     # TOML 'literal strings'
-    '.github/workflows/(.*)\.ymlz',
+    '.github/workflows/(.*)\.yml',
     'docs/source/(.*)\.rst',
     'tests/test_base_scanner\.py',
     'tests/test_util.py',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,17 @@ docs = ["recommonmark", "sphinx", "sphinx-click", "sphinx-rtd-theme", "sphinxcon
 [tool.tartufo]
 cleanup = true
 entropy = true
-exclude-paths = ".tartufo-excludes"
+# exclude-paths = ".tartufo-excludes"
+exclude-path-patterns = [
+    'poetry.lock',
+    'pyproject.toml',
+    # To not have to escape `\` in regexes, use single quoted
+    # TOML 'literal strings'
+    'docs/source/(.*)\.rst',
+    'tests/test_base_scanner\.py',
+    'tests/test_util.py',
+    'tests/data/testRules.json',
+]
 exclude-signatures = [
   "62f22e4500140a6ed959a6143c52b0e81c74e7491081292fce733de4ec574542",
   "ecbbe1edd6373c7e2b88b65d24d7fe84610faafd1bc2cf6ae35b43a77183e80b",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,6 @@ docs = ["recommonmark", "sphinx", "sphinx-click", "sphinx-rtd-theme", "sphinxcon
 [tool.tartufo]
 cleanup = true
 entropy = true
-# exclude-paths = ".tartufo-excludes"
 exclude-path-patterns = [
     'poetry.lock',
     'pyproject.toml',

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -86,7 +86,6 @@ class TartufoCLI(click.MultiCommand):
     "-i",
     "--include-paths",
     type=click.File("r"),
-    hidden=True,
     help="""[DEPRECATED] Use `--include-path-patterns`. File with regular
     expressions (one per line), at least one of which must match a Git object
     path in order for it to be scanned; lines starting with '#' are treated as
@@ -108,7 +107,6 @@ class TartufoCLI(click.MultiCommand):
     "-x",
     "--exclude-paths",
     type=click.File("r"),
-    hidden=True,
     help="""[DEPRECATED] Use `--exclude-path-patterns`. File with regular
     expressions (one per line), none of which may match a Git object path in
     order for it to be scanned; lines starting with '#' are treated as comments
@@ -228,8 +226,11 @@ def main(ctx: click.Context, **kwargs: config.OptionTypes) -> None:
     else:
         excess_verbosity = 0
 
+    # Log warnings by default, unless quiet
+    default_level = 1 if not options.quiet else 0
     # Translate the number of "verbose" arguments, to an actual logging level
-    logger.setLevel(getattr(logging, types.LogLevel(options.verbose).name))
+    level_name = types.LogLevel(max(options.verbose, default_level)).name
+    logger.setLevel(getattr(logging, level_name))
     # Pass any excess verbosity down to the git logger, for extreme debugging needs
     git_logger.setLevel(getattr(logging, types.LogLevel(excess_verbosity).name))
 

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -85,6 +85,16 @@ class TartufoCLI(click.MultiCommand):
     "included unless otherwise excluded via the --exclude-paths option.",
 )
 @click.option(
+    "-ip",
+    "--include-path-patterns",
+    multiple=True,
+    help="""Specify a regular expression which matches Git object paths
+    to include in the scan. This option can be specified multiple
+    times to include multiple patterns. This can be used in
+    conjunction with or as a replacement for --include-paths and
+    also defaults to an empty list, including all Git object paths.""",
+)
+@click.option(
     "-x",
     "--exclude-paths",
     type=click.File("r"),
@@ -93,6 +103,16 @@ class TartufoCLI(click.MultiCommand):
     "starting with '#' are treated as comments and are ignored. If "
     "empty or not provided (default), no Git object paths are excluded "
     "unless effectively excluded via the --include-paths option.",
+)
+@click.option(
+    "-xp",
+    "--exclude-path-patterns",
+    multiple=True,
+    help="""Specify a regular expression which matches Git object paths
+    to exclude from the scan. This option can be specified multiple
+    times to exclude multiple patterns. This can be used in conjunction
+    with or as a replacement for --exclude-paths and also defaults to an
+    empty list.""",
 )
 @click.option(
     "-e",

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -78,41 +78,44 @@ class TartufoCLI(click.MultiCommand):
     "-i",
     "--include-paths",
     type=click.File("r"),
-    help="File with regular expressions (one per line), at least one of "
-    "which must match a Git object path in order for it to be scanned; "
-    "lines starting with '#' are treated as comments and are ignored. "
-    "If empty or not provided (default), all Git object paths are "
-    "included unless otherwise excluded via the --exclude-paths option.",
+    hidden=True,
+    help="""[DEPRECATED] Use `--include-path-patterns`. File with regular
+    expressions (one per line), at least one of which must match a Git object
+    path in order for it to be scanned; lines starting with '#' are treated as
+    comments and are ignored. If empty or not provided (default), all Git object
+    paths are included unless otherwise excluded via the --exclude-paths
+    option.""",
 )
 @click.option(
     "-ip",
     "--include-path-patterns",
     multiple=True,
-    help="""Specify a regular expression which matches Git object paths
-    to include in the scan. This option can be specified multiple
-    times to include multiple patterns. This can be used in
-    conjunction with or as a replacement for --include-paths and
-    also defaults to an empty list, including all Git object paths.""",
+    help="""Specify a regular expression which matches Git object paths to
+    include in the scan. This option can be specified multiple times to include
+    multiple patterns. If not provided (default), all Git object paths are
+    included unless otherwise excluded via the --exclude-path-patterns
+    option.""",
 )
 @click.option(
     "-x",
     "--exclude-paths",
     type=click.File("r"),
-    help="File with regular expressions (one per line), none of which may "
-    "match a Git object path in order for it to be scanned; lines "
-    "starting with '#' are treated as comments and are ignored. If "
-    "empty or not provided (default), no Git object paths are excluded "
-    "unless effectively excluded via the --include-paths option.",
+    hidden=True,
+    help="""[DEPRECATED] Use `--exclude-path-patterns`. File with regular
+    expressions (one per line), none of which may match a Git object path in
+    order for it to be scanned; lines starting with '#' are treated as comments
+    and are ignored. If empty or not provided (default), no Git object paths are
+    excluded unless effectively excluded via the --include-paths option.""",
 )
 @click.option(
     "-xp",
     "--exclude-path-patterns",
     multiple=True,
-    help="""Specify a regular expression which matches Git object paths
-    to exclude from the scan. This option can be specified multiple
-    times to exclude multiple patterns. This can be used in conjunction
-    with or as a replacement for --exclude-paths and also defaults to an
-    empty list.""",
+    help="""Specify a regular expression which matches Git object paths to
+    exclude from the scan. This option can be specified multiple times to
+    exclude multiple patterns. If not provided (default), no Git object paths
+    are excluded unless effectively excluded via the --include-path-patterns
+    option.""",
 )
 @click.option(
     "-e",

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -237,8 +237,9 @@ def compile_path_rules(patterns: Iterable[str]) -> List[Pattern]:
 
     :param patterns: The list of patterns to be compiled
     """
+    stripped = (p.strip() for p in patterns)
     return [
-        re.compile(pattern.strip())
-        for pattern in patterns
-        if pattern.strip() and not pattern.startswith("#")
+        re.compile(pattern)
+        for pattern in stripped
+        if pattern and not pattern.startswith("#")
     ]

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -149,7 +149,7 @@ class ScannerBase(abc.ABC):
             self.logger.info("Initializing included paths")
             patterns = list(self.global_options.include_path_patterns or ())
             if self.global_options.include_paths:
-                self.logger.warn(
+                self.logger.warning(
                     "DEPRECATED --include-paths, use --include-path-patterns"
                 )
                 patterns += self.global_options.include_paths.readlines()
@@ -172,7 +172,7 @@ class ScannerBase(abc.ABC):
             self.logger.info("Initializing excluded paths")
             patterns = list(self.global_options.exclude_path_patterns or ())
             if self.global_options.exclude_paths:
-                self.logger.warn(
+                self.logger.warning(
                     "DEPRECATED --exclude-paths, use --exclude-path-patterns"
                 )
                 patterns += self.global_options.exclude_paths.readlines()

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -136,13 +136,13 @@ class ScannerBase(abc.ABC):
         :rtype: List[Pattern]
         """
         if self._included_paths is None:
+            patterns = self.global_options.include_path_patterns or ()
             if self.global_options.include_paths:
-                self._included_paths = config.compile_path_rules(
-                    self.global_options.include_paths.readlines()
-                )
+                patterns += tuple(self.global_options.include_paths.readlines())
                 self.global_options.include_paths.close()
-            else:
-                self._included_paths = []
+            self._included_paths = (
+                config.compile_path_rules(set(patterns)) if patterns else []
+            )
         return self._included_paths
 
     @property
@@ -152,13 +152,13 @@ class ScannerBase(abc.ABC):
         :rtype: List[Pattern]
         """
         if self._excluded_paths is None:
+            patterns = self.global_options.exclude_path_patterns or ()
             if self.global_options.exclude_paths:
-                self._excluded_paths = config.compile_path_rules(
-                    self.global_options.exclude_paths.readlines()
-                )
+                patterns += tuple(self.global_options.exclude_paths.readlines())
                 self.global_options.exclude_paths.close()
-            else:
-                self._excluded_paths = []
+            self._excluded_paths = (
+                config.compile_path_rules(set(patterns)) if patterns else []
+            )
         return self._excluded_paths
 
     @property
@@ -403,22 +403,28 @@ class GitRepoScanner(GitScanner):
                 self.global_options.exclude_signatures = tuple(
                     set(self.global_options.exclude_signatures + tuple(signatures))
                 )
-            extras_path = data.get("include_paths", None)
-            if extras_path:
-                extras_file = pathlib.Path(repo_path, extras_path)
-                if extras_file.exists():
-                    includes = self.included_paths
-                    with extras_file.open() as handle:
-                        includes += config.compile_path_rules(handle.readlines())
-                    self._included_paths = includes
-            extras_path = data.get("exclude_paths", None)
-            if extras_path:
-                extras_file = pathlib.Path(repo_path, extras_path)
-                if extras_file.exists():
-                    excludes = self.excluded_paths
-                    with extras_file.open() as handle:
-                        excludes += config.compile_path_rules(handle.readlines())
-                    self._excluded_paths = excludes
+
+            include_patterns = data.get("include_path_patterns", ())
+            repo_include_file = data.get("include_paths", None)
+            if repo_include_file:
+                repo_include_file = pathlib.Path(repo_path, repo_include_file)
+                if repo_include_file.exists():
+                    with repo_include_file.open() as handle:
+                        include_patterns += tuple(handle.readlines())
+            if include_patterns:
+                include_patterns = config.compile_path_rules(include_patterns)
+                self._included_paths = list(set(self.included_paths + include_patterns))
+
+            exclude_patterns = data.get("exclude_path_patterns", ())
+            repo_exclude_file = data.get("exclude_paths", None)
+            if repo_exclude_file:
+                repo_exclude_file = pathlib.Path(repo_path, repo_exclude_file)
+                if repo_exclude_file.exists():
+                    with repo_exclude_file.open() as handle:
+                        exclude_patterns += tuple(handle.readlines())
+            if exclude_patterns:
+                exclude_patterns = config.compile_path_rules(exclude_patterns)
+                self._excluded_paths = list(set(self.excluded_paths + exclude_patterns))
         try:
             return git.Repo(repo_path)
         except git.GitError as exc:

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -149,6 +149,9 @@ class ScannerBase(abc.ABC):
             self.logger.info("Initializing included paths")
             patterns = list(self.global_options.include_path_patterns or ())
             if self.global_options.include_paths:
+                self.logger.warn(
+                    "DEPRECATED --include-paths, use --include-path-patterns"
+                )
                 patterns += self.global_options.include_paths.readlines()
                 self.global_options.include_paths.close()
             self._included_paths = (
@@ -169,6 +172,9 @@ class ScannerBase(abc.ABC):
             self.logger.info("Initializing excluded paths")
             patterns = list(self.global_options.exclude_path_patterns or ())
             if self.global_options.exclude_paths:
+                self.logger.warn(
+                    "DEPRECATED --exclude-paths, use --exclude-path-patterns"
+                )
                 patterns += self.global_options.exclude_paths.readlines()
                 self.global_options.exclude_paths.close()
             self._excluded_paths = (

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -136,9 +136,9 @@ class ScannerBase(abc.ABC):
         :rtype: List[Pattern]
         """
         if self._included_paths is None:
-            patterns = self.global_options.include_path_patterns or ()
+            patterns = list(self.global_options.include_path_patterns or ())
             if self.global_options.include_paths:
-                patterns += tuple(self.global_options.include_paths.readlines())
+                patterns += self.global_options.include_paths.readlines()
                 self.global_options.include_paths.close()
             self._included_paths = (
                 config.compile_path_rules(set(patterns)) if patterns else []
@@ -152,9 +152,9 @@ class ScannerBase(abc.ABC):
         :rtype: List[Pattern]
         """
         if self._excluded_paths is None:
-            patterns = self.global_options.exclude_path_patterns or ()
+            patterns = list(self.global_options.exclude_path_patterns or ())
             if self.global_options.exclude_paths:
-                patterns += tuple(self.global_options.exclude_paths.readlines())
+                patterns += self.global_options.exclude_paths.readlines()
                 self.global_options.exclude_paths.close()
             self._excluded_paths = (
                 config.compile_path_rules(set(patterns)) if patterns else []
@@ -404,24 +404,24 @@ class GitRepoScanner(GitScanner):
                     set(self.global_options.exclude_signatures + tuple(signatures))
                 )
 
-            include_patterns = data.get("include_path_patterns", ())
+            include_patterns = list(data.get("include_path_patterns", ()))
             repo_include_file = data.get("include_paths", None)
             if repo_include_file:
                 repo_include_file = pathlib.Path(repo_path, repo_include_file)
                 if repo_include_file.exists():
                     with repo_include_file.open() as handle:
-                        include_patterns += tuple(handle.readlines())
+                        include_patterns += handle.readlines()
             if include_patterns:
                 include_patterns = config.compile_path_rules(include_patterns)
                 self._included_paths = list(set(self.included_paths + include_patterns))
 
-            exclude_patterns = data.get("exclude_path_patterns", ())
+            exclude_patterns = list(data.get("exclude_path_patterns", ()))
             repo_exclude_file = data.get("exclude_paths", None)
             if repo_exclude_file:
                 repo_exclude_file = pathlib.Path(repo_path, repo_exclude_file)
                 if repo_exclude_file.exists():
                     with repo_exclude_file.open() as handle:
-                        exclude_patterns += tuple(handle.readlines())
+                        exclude_patterns += handle.readlines()
             if exclude_patterns:
                 exclude_patterns = config.compile_path_rules(exclude_patterns)
                 self._excluded_paths = list(set(self.excluded_paths + exclude_patterns))

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -13,7 +13,9 @@ class GlobalOptions:
         "entropy",
         "regex",
         "include_paths",
+        "include_path_patterns",
         "exclude_paths",
+        "exclude_path_patterns",
         "exclude_signatures",
         "output_dir",
         "git_rules_repo",
@@ -28,7 +30,9 @@ class GlobalOptions:
     entropy: bool
     regex: bool
     include_paths: Optional[TextIO]
+    include_path_patterns: Tuple[str, ...]
     exclude_paths: Optional[TextIO]
+    exclude_path_patterns: Tuple[str, ...]
     exclude_signatures: Tuple[str, ...]
     output_dir: Optional[str]
     git_rules_repo: Optional[str]

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -117,10 +117,12 @@ class IncludeExcludePathsTests(ScannerTestCase):
         self, mock_compile: mock.MagicMock
     ):
         mock_include = mock.MagicMock()
+        mock_include.readlines.return_value = ["bar"]
         self.options.include_paths = mock_include
+        self.options.include_path_patterns = ("foo",)
         test_scanner = TestScanner(self.options)
         test_scanner.included_paths  # pylint: disable=pointless-statement
-        mock_compile.assert_called_once_with(mock_include.readlines.return_value)
+        mock_compile.assert_called_once_with({"foo", "bar"})
 
     @mock.patch("tartufo.config.compile_path_rules")
     def test_populated_excluded_paths_list_does_not_recompute(
@@ -140,10 +142,12 @@ class IncludeExcludePathsTests(ScannerTestCase):
         self, mock_compile: mock.MagicMock
     ):
         mock_exclude = mock.MagicMock()
+        mock_exclude.readlines.return_value = ["Pipfile.lock\n"]
         self.options.exclude_paths = mock_exclude
+        self.options.exclude_path_patterns = ("foo",)
         test_scanner = TestScanner(self.options)
         test_scanner.excluded_paths  # pylint: disable=pointless-statement
-        mock_compile.assert_called_once_with(mock_exclude.readlines.return_value)
+        mock_compile.assert_called_once_with({"foo", "Pipfile.lock\n"})
 
     def test_should_scan_treats_included_paths_as_exclusive(self):
         test_scanner = TestScanner(self.options)

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -41,15 +41,15 @@ class RepoLoadTests(ScannerTestCase):
     def test_extra_inclusions_get_added(self, mock_load: mock.MagicMock):
         mock_load.return_value = (
             self.data_dir / "pyproject.toml",
-            {"include_paths": "include-files"},
+            {"include_paths": "include-files", "include_path_patterns": ("foo/",)},
         )
         test_scanner = scanner.GitRepoScanner(
             self.global_options, self.git_options, str(self.data_dir)
         )
         test_scanner.load_repo("../tartufo")
-        self.assertEqual(
+        self.assertCountEqual(
             test_scanner.included_paths,
-            [re.compile("tartufo/"), re.compile("scripts/")],
+            [re.compile("foo/"), re.compile("tartufo/"), re.compile("scripts/")],
         )
 
     @mock.patch("git.Repo", new=mock.MagicMock())
@@ -57,15 +57,16 @@ class RepoLoadTests(ScannerTestCase):
     def test_extra_exclusions_get_added(self, mock_load: mock.MagicMock):
         mock_load.return_value = (
             self.data_dir / "pyproject.toml",
-            {"exclude_paths": "exclude-files"},
+            {"exclude_paths": "exclude-files", "exclude_path_patterns": ("bar/",)},
         )
         test_scanner = scanner.GitRepoScanner(
             self.global_options, self.git_options, str(self.data_dir)
         )
         test_scanner.load_repo("../tartufo")
-        self.assertEqual(
+        self.assertCountEqual(
             test_scanner.excluded_paths,
             [
+                re.compile("bar/"),
                 re.compile("tests/"),
                 re.compile(r"\.venv/"),
                 re.compile(r".*\.egg-info/"),


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [x] Documentation (if applicable)
* [x] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
closes #145 

## What's new?
- Creates and documents new parameters to include and exclude paths directly in the command line args and TOML config blocks without relying on separate inclusion/exclusion files.
