### PR TITLE
Fix #158: scanning a single branch scanned nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+vX.Y.Z - TBD
+------------
+
+Bug fixes:
+
+* #158 - The `--branch` option was broken and would not actually scan anything
+
 v2.3.1 - 16 February 2021
 -------------------------
 
@@ -8,7 +15,6 @@ Bug fixes:
 Other changes:
 
 * Added no-fetch to code snippets and note about what it does
-
 
 v2.3.0 - 04 February 2021
 -------------------------

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -468,7 +468,7 @@ class GitRepoScanner(GitScanner):
                     self._repo.remotes.origin.fetch(self.git_options.branch)
                 unfiltered_branches = list(self._repo.branches)
                 branches = [
-                    x for x in unfiltered_branches if x == self.git_options.branch
+                    x for x in unfiltered_branches if x.name == self.git_options.branch
                 ]
             else:
                 # Everything

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -48,8 +48,8 @@ class GitOptions:
 
 
 class IssueType(enum.Enum):
-    Entropy = "High Entropy"
-    RegEx = "Regular Expression Match"
+    Entropy = "High Entropy"  # pylint: disable=invalid-name
+    RegEx = "Regular Expression Match"  # pylint: disable=invalid-name
 
 
 @dataclass

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -183,8 +183,12 @@ class ChunkGeneratorTests(ScannerTestCase):
     ):
         self.git_options.fetch = False
         self.git_options.branch = "bar"
+        mock_foo = mock.MagicMock()
+        mock_foo.name = "foo"
+        mock_bar = mock.MagicMock()
+        mock_bar.name = "bar"
         mock_repo.return_value.remotes.origin.fetch.return_value = ["foo", "bar"]
-        mock_repo.return_value.branches = ["foo", "bar"]
+        mock_repo.return_value.branches = [mock_foo, mock_bar]
         test_scanner = scanner.GitRepoScanner(
             self.global_options, self.git_options, "."
         )
@@ -192,7 +196,9 @@ class ChunkGeneratorTests(ScannerTestCase):
         for _ in test_scanner.chunks:
             pass
         mock_repo.return_value.remotes.origin.fetch.assert_not_called()
-        mock_iter_commits.assert_has_calls((mock.call(mock_repo.return_value, "bar"),))
+        mock_iter_commits.assert_has_calls(
+            (mock.call(mock_repo.return_value, mock_bar),)
+        )
 
     @mock.patch("tartufo.scanner.GitRepoScanner._iter_branch_commits")
     @mock.patch("git.Repo")
@@ -201,8 +207,12 @@ class ChunkGeneratorTests(ScannerTestCase):
     ):
         self.git_options.fetch = True
         self.git_options.branch = "bar"
+        mock_foo = mock.MagicMock()
+        mock_foo.name = "foo"
+        mock_bar = mock.MagicMock()
+        mock_bar.name = "bar"
         mock_repo.return_value.remotes.origin.fetch.return_value = ["foo", "bar"]
-        mock_repo.return_value.branches = ["foo", "bar"]
+        mock_repo.return_value.branches = [mock_foo, mock_bar]
         test_scanner = scanner.GitRepoScanner(
             self.global_options, self.git_options, "."
         )
@@ -210,7 +220,9 @@ class ChunkGeneratorTests(ScannerTestCase):
         for _ in test_scanner.chunks:
             pass
         mock_repo.return_value.remotes.origin.fetch.assert_called()
-        mock_iter_commits.assert_has_calls((mock.call(mock_repo.return_value, "bar"),))
+        mock_iter_commits.assert_has_calls(
+            (mock.call(mock_repo.return_value, mock_bar),)
+        )
 
     @mock.patch("tartufo.scanner.GitRepoScanner._iter_branch_commits")
     @mock.patch("tartufo.scanner.GitRepoScanner._iter_diff_index")


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [ ] Documentation (if applicable)
* [X] Changelog entry
* [X] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [X] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [X] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->
Fixes #158

## What's new?

- Selecting a single branch for scans was failing, because the branch filter was TOO effective. I made it slightly less effective, so that it actually matches the intended branch.
