### PR TITLE
Disable codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,14 @@ jobs:
       run: brew install enchant
       if: ${{ matrix.os == 'macos-latest' && matrix.python-version == '3.7' }}
     - name: Install dependencies
-      run:  pip install poetry tox codecov tox-gh-actions
+      run:  pip install poetry tox tox-gh-actions
+      # run:  pip install poetry tox codecov tox-gh-actions
     - name: Run tox environments
       run: tox
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@e156083f13aff6830c92fc5faa23505779fbf649
-      with:
-        file: coverage.xml
-        env_vars: OS,PYTHON
+    - name: Dump env
+      run: env
+    # - name: Upload coverage to Codecov
+    #   uses: codecov/codecov-action@e156083f13aff6830c92fc5faa23505779fbf649
+    #   with:
+    #     file: coverage.xml
+    #     env_vars: OS,PYTHON

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,6 @@ jobs:
       # run:  pip install poetry tox codecov tox-gh-actions
     - name: Run tox environments
       run: tox
-    - name: Dump env
-      run: env
     # - name: Upload coverage to Codecov
     #   uses: codecov/codecov-action@e156083f13aff6830c92fc5faa23505779fbf649
     #   with:


### PR DESCRIPTION
Disabling codecov due to https://about.codecov.io/security-update/

First commit has an additional CI step of running `env` to show us a list of what may have been exposed. This step will be removed before merge.