### PR TITLE
fix: write debug log for binary files

### DIFF
--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -391,7 +391,7 @@ class GitScanner(ScannerBase, abc.ABC):
             file_path = diff.b_path if diff.b_path else diff.a_path
             printable_diff: str = diff.diff.decode("utf-8", errors="replace")
             if printable_diff.startswith("Binary files"):
-                self.logger.debug('Binary file skipped: %s', file_path)
+                self.logger.debug("Binary file skipped: %s", file_path)
                 continue
             if self.should_scan(file_path):
                 yield (printable_diff, file_path)

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -388,10 +388,11 @@ class GitScanner(ScannerBase, abc.ABC):
         """
         diff: git.Diff
         for diff in diff_index:
+            file_path = diff.b_path if diff.b_path else diff.a_path
             printable_diff: str = diff.diff.decode("utf-8", errors="replace")
             if printable_diff.startswith("Binary files"):
+                self.logger.debug('Binary file skipped: %s', file_path)
                 continue
-            file_path = diff.b_path if diff.b_path else diff.a_path
             if self.should_scan(file_path):
                 yield (printable_diff, file_path)
 


### PR DESCRIPTION
It took several hours to find out why package-lock.json file was not being scanned. Turns out it was marked as binary and therefore was skipped. Verbose logging would have saved tons of time.

To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] Changelog entry
* [ ] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [ ] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->

## What's new?
- Added debug logging for skipped binary files
