### PR TITLE
feat: add exclude-entropy-patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ Options:
                                   excluded unless effectively excluded via the
                                   --include-path-patterns option.
 
+  -xe, --exclude-entropy-patterns TEXT
+                                  Specify a regular expression which matches
+                                  entropy strings to exclude from the scan.
+                                  This option can be specified multiple times
+                                  to exclude multiple patterns. If not
+                                  provided (default), no entropy strings will
+                                  be excluded ({path regex}::{pattern regex}).
+
   -e, --exclude-signatures TEXT   Specify signatures of matches that you
                                   explicitly want to exclude from the scan,
                                   and mark as okay. These signatures are

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -227,6 +227,28 @@ thing, there needs to be a way to tell ``tartufo`` to ignore those things, and
 not report them out as issues. For this reason, we provide multiple methods for
 excluding these items.
 
+Entropy Limiting
+++++++++++++++++
+
+Entropy scans can produce a high number of false positives such as git SHAs or md5
+digests. To avoid these false positives, enable ``exclude-entropy-patterns``. Exclusions
+apply to any strings flagged by entropy checks.
+
+For example, if ``docs/README.md`` contains a git SHA, this would be flagged by entropy.
+To exclude this, add ``docs/.*\.md$::^[a-zA-Z0-9]{40}$`` to ``exclude-entropy-patterns``.
+
+.. code-block:: sh
+
+    > tartufo ... --exclude-entropy-patterns "docs/.*\.md$::^[a-zA-Z0-9]{40}$"
+
+.. code-block:: toml
+
+    [tool.tartufo]
+    exclude-entropy-patterns = [
+      # format: "{file regex}::{entropy pattern}"
+      "docs/.*\.md$::^[a-zA-Z0-9]{40}$", # exclude all git SHAs in the docs directory
+    ]
+
 Limiting by Signature
 +++++++++++++++++++++
 

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -124,6 +124,15 @@ class TartufoCLI(click.MultiCommand):
     option.""",
 )
 @click.option(
+    "-xe",
+    "--exclude-entropy-patterns",
+    multiple=True,
+    help="""Specify a regular expression which matches entropy strings to
+    exclude from the scan. This option can be specified multiple times to
+    exclude multiple patterns. If not provided (default), no entropy strings
+    will be excluded ({path regex}::{pattern regex}).""",
+)
+@click.option(
     "-e",
     "--exclude-signatures",
     multiple=True,

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -243,3 +243,36 @@ def compile_path_rules(patterns: Iterable[str]) -> List[Pattern]:
         for pattern in stripped
         if pattern and not pattern.startswith("#")
     ]
+
+
+def compile_rule(pattern: str) -> Rule:
+    """
+    Compile pattern string to Rule.
+
+    :param pattern: Rule pattern with {path_pattern}::{pattern}
+    :return Rule: Rule object with pattern and path_pattern
+    """
+    parts = pattern.split("::")
+    if len(parts) == 1:
+        parts = [".*", parts[0]]
+    return Rule(
+        name=None,
+        pattern=re.compile("::".join(parts[1:])),
+        path_pattern=re.compile(parts[0]),
+    )
+
+
+def compile_rules(patterns: Iterable[str]) -> List[Rule]:
+    """Take a list of regex string with paths and compile them into a List of Rule.
+
+    Any line starting with `#` will be ignored.
+
+    :param patterns: The list of patterns to be compiled
+    :return: List of Rule objects
+    """
+    stripped = (p.strip() for p in patterns)
+    return [
+        compile_rule(pattern)
+        for pattern in stripped
+        if pattern and not pattern.startswith("#")
+    ]

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -252,14 +252,11 @@ def compile_rule(pattern: str) -> Rule:
     :param pattern: Rule pattern with {path_pattern}::{pattern}
     :return Rule: Rule object with pattern and path_pattern
     """
-    parts = pattern.split("::")
-    if len(parts) == 1:
-        parts = [".*", parts[0]]
-    return Rule(
-        name=None,
-        pattern=re.compile("::".join(parts[1:])),
-        path_pattern=re.compile(parts[0]),
-    )
+    try:
+        path, pattern = pattern.split("::", 1)
+    except ValueError:  # Raised when the split separator is not found
+        path = ".*"
+    return Rule(name=None, pattern=re.compile(pattern), path_pattern=re.compile(path))
 
 
 def compile_rules(patterns: Iterable[str]) -> List[Rule]:

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -358,19 +358,18 @@ class ScannerBase(abc.ABC):
                 hex_strings = util.get_strings_of_set(word, HEX_CHARS)
 
                 for string in b64_strings:
-                    self.evaluate_entropy_string(
-                        chunk, issues, string, BASE64_CHARS, 4.5
+                    issues += self.evaluate_entropy_string(
+                        chunk, string, BASE64_CHARS, 4.5
                     )
 
                 for string in hex_strings:
-                    self.evaluate_entropy_string(chunk, issues, string, HEX_CHARS, 3)
+                    issues += self.evaluate_entropy_string(chunk, string, HEX_CHARS, 3)
 
         return issues
 
     def evaluate_entropy_string(
         self,
         chunk: types.Chunk,
-        issues: List[Issue],
         string: str,
         chars: str,
         min_entropy_score: float,
@@ -383,6 +382,7 @@ class ScannerBase(abc.ABC):
         :param string: String to check
         :param chars: Characters to calculate score
         :param min_entropy_score: Minimum entropy score to flag
+        return: List of issues flagged
         """
         if not self.signature_is_excluded(string, chunk.file_path):
             entropy_score = self.calculate_entropy(string, chars)
@@ -390,7 +390,8 @@ class ScannerBase(abc.ABC):
                 if self.entropy_string_is_excluded(string, chunk.file_path):
                     self.logger.debug("entropy string %s was excluded", string)
                 else:
-                    issues.append(Issue(types.IssueType.Entropy, string, chunk))
+                    return [Issue(types.IssueType.Entropy, string, chunk)]
+        return []
 
     def scan_regex(self, chunk: types.Chunk) -> List[Issue]:
         """Scan a chunk of data for matches against the configured regexes.

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -266,6 +266,7 @@ class ScannerBase(abc.ABC):
         )
 
     @staticmethod
+    @lru_cache(maxsize=None)
     def rule_matches(rule: Rule, string: str, path: str) -> bool:
         """
         Match string and path against rule.

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -374,7 +374,7 @@ class ScannerBase(abc.ABC):
         string: str,
         chars: str,
         min_entropy_score: float,
-    ):
+    ) -> List[Issue]:
         """
         Check entropy string using entropy characters and score.
 

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -79,7 +79,7 @@ class Rule:
 
     def __hash__(self) -> int:
         if self.path_pattern:
-            return hash(self.pattern.pattern + self.path_pattern.pattern)
+            return hash(f"{self.pattern.pattern}::{self.path_pattern.pattern}")
         return hash(self.pattern.pattern)
 
 

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -77,6 +77,11 @@ class Rule:
     pattern: Pattern
     path_pattern: Optional[Pattern]
 
+    def __hash__(self) -> int:
+        if self.path_pattern:
+            return hash(self.pattern.pattern + self.path_pattern.pattern)
+        return hash(self.pattern.pattern)
+
 
 class LogLevel(enum.IntEnum):
     ERROR = 0

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -16,6 +16,7 @@ class GlobalOptions:
         "include_path_patterns",
         "exclude_paths",
         "exclude_path_patterns",
+        "exclude_entropy_patterns",
         "exclude_signatures",
         "output_dir",
         "git_rules_repo",
@@ -35,6 +36,7 @@ class GlobalOptions:
     include_path_patterns: Tuple[str, ...]
     exclude_paths: Optional[TextIO]
     exclude_path_patterns: Tuple[str, ...]
+    exclude_entropy_patterns: Tuple[str, ...]
     exclude_signatures: Tuple[str, ...]
     output_dir: Optional[str]
     git_rules_repo: Optional[str]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -290,5 +290,52 @@ class CompilePathRulesTests(unittest.TestCase):
         )
 
 
+class CompileRulesTests(unittest.TestCase):
+    def test_commented_lines_are_ignored(self):
+        rules = config.compile_rules(["# Poetry lock file", r"^[a-zA-Z0-9]{26}$"])
+        self.assertEqual(
+            rules, [Rule(None, re.compile(r"^[a-zA-Z0-9]{26}$"), re.compile(r".*"))]
+        )
+
+    def test_whitespace_lines_are_ignored(self):
+        rules = config.compile_rules(
+            [
+                "# Poetry lock file",
+                r"poetry\.lock::^[a-zA-Z0-9]{40}$",
+                "",
+                "\t\n",
+                "# NPM files",
+                r"^[a-zA-Z0-9]{26}$",
+            ]
+        )
+        self.assertEqual(
+            rules,
+            [
+                Rule(
+                    None, re.compile(r"^[a-zA-Z0-9]{40}$"), re.compile(r"poetry\.lock")
+                ),
+                Rule(None, re.compile(r"^[a-zA-Z0-9]{26}$"), re.compile(r".*")),
+            ],
+        )
+
+    def test_path_is_used(self):
+        rules = config.compile_rules(
+            [r"src/.*::^[a-zA-Z0-9]{26}$", r"^[a-zA-Z0-9]test$"]
+        )
+        self.assertEqual(
+            rules,
+            [
+                Rule(None, re.compile(r"^[a-zA-Z0-9]{26}$"), re.compile(r"src/.*")),
+                Rule(None, re.compile(r"^[a-zA-Z0-9]test$"), re.compile(r".*")),
+            ],
+        )
+
+    def test_match_can_contain_delimiter(self):
+        rules = config.compile_rules([r".*::^[a-zA-Z0-9]::test$"])
+        self.assertEqual(
+            rules, [Rule(None, re.compile(r"^[a-zA-Z0-9]::test$"), re.compile(r".*"))]
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -320,13 +320,20 @@ class CompileRulesTests(unittest.TestCase):
 
     def test_path_is_used(self):
         rules = config.compile_rules(
-            [r"src/.*::^[a-zA-Z0-9]{26}$", r"^[a-zA-Z0-9]test$"]
+            [
+                r"src/.*::^[a-zA-Z0-9]{26}$",
+                r"^[a-zA-Z0-9]test$",
+                r"src/.*::^[a-zA-Z0-9]{26}::test$",
+            ]
         )
         self.assertEqual(
             rules,
             [
                 Rule(None, re.compile(r"^[a-zA-Z0-9]{26}$"), re.compile(r"src/.*")),
                 Rule(None, re.compile(r"^[a-zA-Z0-9]test$"), re.compile(r".*")),
+                Rule(
+                    None, re.compile(r"^[a-zA-Z0-9]{26}::test$"), re.compile(r"src/.*")
+                ),
             ],
         )
 


### PR DESCRIPTION
Add the ability to exclude entropy patterns. This will allow flagged entropy rules using regular expressions for all files or specific files.

To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [x] Documentation (if applicable)
* [ ] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->

## What's new?
- added `exclude-entropy-patterns` option
