### PR TITLE
Fixes #194 - Ignore signatures as matches

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
   rev: v0.901
   hooks:
   - id: mypy
+    args: [--ignore-missing-imports, --follow-imports=silent]
 - repo: https://github.com/psf/black
   rev: 21.5b2
   hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+vX.Y.Z - TBD
+------------
+
+Features:
+
+* [#194](https://github.com/godaddy/tartufo/issues/194) - Half bugfix, half
+  feature. Now when an excluded signature in your config file is found as an
+  entropy match, tartufo will realize that and no longer report it as an issue.
+
 v2.5.0 - 15 June 2021
 ---------------------
 

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -261,7 +261,9 @@ class ScannerBase(abc.ABC):
         :param file_path: The path and file name for the data being scanned
         """
         return (
-            util.generate_signature(blob, file_path)
+            blob
+            in self.global_options.exclude_signatures  # Signatures themselves pop up as entropy matches
+            or util.generate_signature(blob, file_path)
             in self.global_options.exclude_signatures
         )
 

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -265,6 +265,11 @@ class SignatureTests(ScannerTestCase):
         test_scanner = TestScanner(self.options)
         self.assertFalse(test_scanner.signature_is_excluded("blah", "stuff"))
 
+    def test_signature_found_as_scan_match_is_excluded(self):
+        self.options.exclude_signatures = ("ford_prefect",)
+        test_scanner = TestScanner(self.options)
+        self.assertTrue(test_scanner.signature_is_excluded("ford_prefect", "/earth"))
+
 
 class RegexScanTests(ScannerTestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [X] Tests (if applicable)
* [ ] Documentation (if applicable)
* [X] Changelog entry
* [X] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [X] Bugfix
* [X] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [X] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->

Fixes #194 

## What's new?

- Half bugfix, half feature. Now when an excluded signature in your config file is found as an entropy match, tartufo will realize that and no longer report it as an issue.
