### PR TITLE
Scan commits in topological, rather than date, order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Features:
   feature. Now when an excluded signature in your config file is found as an
   entropy match, tartufo will realize that and no longer report it as an issue.
 
+Bug fixes:
+
+* [#179](https://github.com/godaddy/tartufo/issues/179) - Iterate over commits
+  in topological order, instead of date order.
+
 v2.5.0 - 15 June 2021
 ---------------------
 

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -552,7 +552,7 @@ class GitRepoScanner(GitScanner):
         curr_commit: git.Commit = None
 
         for curr_commit in repo.iter_commits(
-            branch.name, max_count=self.git_options.max_depth
+            branch.name, max_count=self.git_options.max_depth, topo_order=True
         ):
             commit_hash = curr_commit.hexsha
             self.logger.debug("Scanning commit: %s", commit_hash)


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [ ] Documentation (if applicable)
* [X] Changelog entry
* [X] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [X] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [X] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->
Fixes #179 

## What's new?

This changes to scan commits in topological order as opposed to the default date order. Actual unit testing of this would be... sketchy, at best, so in lieu of that I present the following.

Pre-change:
```console
> tartufo -vvvvvv scan-local-repo .
...
[2021-06-28 16:25:06,298] [DEBUG] [git.cmd] - Popen(['git', 'rev-list', '--max-count=1000000', 'badges', '--'], cwd=/Users/jwilhelm/Documents/workspace/godaddy/tartufo, universal_newlines=False, shell=None, istream=None)
```

Post-change:
```console
> tartufo -vvvvvv scan-local-repo .
...
[2021-06-28 16:24:46,810] [DEBUG] [git.cmd] - Popen(['git', 'rev-list', '--max-count=1000000', '--topo-order', 'badges', '--'], cwd=/Users/jwilhelm/Documents/workspace/godaddy/tartufo, universal_newlines=False, shell=None, istream=None)
```

The difference here is the `--topo-order` flag. As documented in `man git-rev-list`:

```manpage
        --topo-order
            Show no parents before all of its children are shown, and avoid showing commits on multiple lines of history intermixed.

            For example, in a commit history like this:

                    ---1----2----4----7
                        \              \
                         3----5----6----8---

            where the numbers denote the order of commit timestamps, git rev-list and friends with --date-order show the commits in the timestamp order: 8 7 6 5 4 3 2 1.

            With --topo-order, they would show 8 6 5 3 7 4 2 1 (or 8 7 4 2 6 5 3 1); some older commits are shown before newer ones in order to avoid showing the commits from two parallel development track mixed together.
```

@rdrey Is this what you had in mind with #179?