### PR TITLE
Fixes #211 - Fix windows encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+vX.Y.Z - TBD
+------------
+
+* [#211](https://github.com/godaddy/tartufo/issues/211) - Attempt to fix a case
+  where output encoding could be set to cp1252 on Windows, which would cause a
+  crash if unicode characters were printed. Now issues are output as utf-8
+  encoded bytestreams instead.
+
 v2.7.0 - 10 August 2021
 -----------------------
 

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -2,20 +2,27 @@ backport
 backported
 bugfix
 bugfixes
+bytestreams
 codebase
+codecov
 config
+cp
 cryptographic
+dclayton
 devops
 dir
 doesn
+envs
 filename
 filesystem
 github
+godaddy
 hexidecimal
 # For "isn't"
 isn
 jgowdy
 json
+md
 metadata
 param
 pre
@@ -27,12 +34,17 @@ runtime
 serializable
 shannon
 subdomain
+Submodule
+submodules
 tartufo
 toml
+toolchain
 triaging
 tuple
 twilio
 txt
+unicode
+utf
 util
 # For contractions: you've, we've, I've
 ve

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -102,6 +102,9 @@ class Issue:
         output.append(self.OUTPUT_SEPARATOR)
         return "\n".join(output)
 
+    def __bytes__(self) -> bytes:
+        return self.__str__().encode("utf8")
+
 
 class ScannerBase(abc.ABC):
     """Provide the base, generic functionality needed by all scanners.

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -86,7 +86,7 @@ def echo_result(
             if not options.quiet:
                 click.echo(f"Time: {now}\nAll clear. No secrets detected.")
         else:
-            click.echo("\n".join([str(issue) for issue in scanner.issues]))
+            click.echo(b"\n".join([bytes(issue) for issue in scanner.issues]))
         if options.verbose > 0:
             click.echo("\nExcluded paths:")
             click.echo("\n".join([path.pattern for path in scanner.excluded_paths]))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -78,9 +78,9 @@ class OutputTests(unittest.TestCase):
         mock_scanner.exclude_signatures = []
         mock_scanner.issues = [1, 2, 3, 4]
         util.echo_result(options, mock_scanner, "", "")
-        # This is the result of calling `bytes()` on integers.
+        # Ensure that the issues are output as a byte stream
         mock_click.echo.assert_called_once_with(
-            b"\x00\n\x00\x00\n\x00\x00\x00\n\x00\x00\x00\x00"
+            bytes(1) + b"\n" + bytes(2) + b"\n" + bytes(3) + b"\n" + bytes(4)
         )
 
     @mock.patch("tartufo.scanner.ScannerBase")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -78,7 +78,10 @@ class OutputTests(unittest.TestCase):
         mock_scanner.exclude_signatures = []
         mock_scanner.issues = [1, 2, 3, 4]
         util.echo_result(options, mock_scanner, "", "")
-        mock_click.echo.assert_called_once_with("1\n2\n3\n4")
+        # This is the result of calling `bytes()` on integers.
+        mock_click.echo.assert_called_once_with(
+            b"\x00\n\x00\x00\n\x00\x00\x00\n\x00\x00\x00\x00"
+        )
 
     @mock.patch("tartufo.scanner.ScannerBase")
     @mock.patch("tartufo.util.click")


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [ ] Documentation (if applicable)
* [X] Changelog entry
* [X] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [X] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [X] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->
Fixes #211

## What's new?

There's a strange case when using git bash on Windows where stdout will be opened with a CP-1252 encoding, as opposed to UTF-8, when it's opened as a text stream. This would cause problems with scanned failed contained Unicode characters adjacent to or as part of matched strings, because CP-1252 can't handle outputting those characters. So now we output the issues as UTF-8 encoded bytestreams, which means that the output is handled in pure binary and we no longer have to worry about the output encoding.

This should be fully backward compatible and theoretically allow proper Unicode output across all environments.
