### PR TITLE
fix(git): raise error if branch not found

### DIFF
--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -24,7 +24,7 @@ import click
 import git
 
 from tartufo import config, types, util
-from tartufo.types import Rule, TartufoException
+from tartufo.types import BranchNotException, Rule, TartufoException
 
 BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
 HEX_CHARS = "1234567890abcdefABCDEF"
@@ -609,6 +609,11 @@ class GitRepoScanner(GitScanner):
                 branches = [
                     x for x in unfiltered_branches if x.name == self.git_options.branch
                 ]
+
+                if len(branches) == 0:
+                    raise BranchNotException(
+                        f"Branch {self.git_options.branch} was not found."
+                    )
             else:
                 # Everything
                 if self.git_options.fetch:

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -24,7 +24,7 @@ import click
 import git
 
 from tartufo import config, types, util
-from tartufo.types import BranchNotException, Rule, TartufoException
+from tartufo.types import BranchNotFoundException, Rule, TartufoException
 
 BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
 HEX_CHARS = "1234567890abcdefABCDEF"
@@ -611,7 +611,7 @@ class GitRepoScanner(GitScanner):
                 ]
 
                 if len(branches) == 0:
-                    raise BranchNotException(
+                    raise BranchNotFoundException(
                         f"Branch {self.git_options.branch} was not found."
                     )
             else:

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -103,7 +103,7 @@ class ScanException(TartufoException):
     """Raised if there is a problem encountered during a scan"""
 
 
-class BranchNotException(TartufoException):
+class BranchNotFoundException(TartufoException):
     """Raised if a branch was not found"""
 
 

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -103,6 +103,10 @@ class ScanException(TartufoException):
     """Raised if there is a problem encountered during a scan"""
 
 
+class BranchNotException(TartufoException):
+    """Raised if a branch was not found"""
+
+
 class GitException(TartufoException):
     """Raised if there is a problem interacting with git"""
 

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -150,6 +150,9 @@ class ChunkGeneratorTests(ScannerTestCase):
         self.git_options.fetch = True
         mock_fetch = mock.MagicMock()
         mock_fetch.return_value = []
+        mock_branch = mock.MagicMock()
+        mock_branch.name = "foo"
+        mock_repo.return_value.branches = [mock_branch]
         mock_repo.return_value.remotes.origin.fetch = mock_fetch
         test_scanner = scanner.GitRepoScanner(
             self.global_options, self.git_options, "."
@@ -253,6 +256,27 @@ class ChunkGeneratorTests(ScannerTestCase):
         mock_iter_commits.assert_has_calls(
             (mock.call(mock_repo.return_value, mock_bar),)
         )
+
+    @mock.patch("tartufo.scanner.GitRepoScanner._iter_branch_commits")
+    @mock.patch("git.Repo")
+    def test_scan_single_branch_throws_exception_when_branch_not_found(
+        self, mock_repo: mock.MagicMock, mock_iter_commits: mock.MagicMock
+    ):
+        self.git_options.fetch = True
+        self.git_options.branch = "not-found"
+        self.global_options.entropy = True
+        mock_foo = mock.MagicMock()
+        mock_foo.name = "foo"
+        mock_bar = mock.MagicMock()
+        mock_bar.name = "bar"
+        mock_repo.return_value.remotes.origin.fetch.return_value = ["foo", "bar"]
+        mock_repo.return_value.branches = [mock_foo, mock_bar]
+
+        test_scanner = scanner.GitRepoScanner(
+            self.global_options, self.git_options, "."
+        )
+        mock_iter_commits.return_value = []
+        self.assertRaises(types.BranchNotException, test_scanner.scan)
 
     @mock.patch("tartufo.scanner.GitRepoScanner._iter_branch_commits")
     @mock.patch("git.Repo")

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -276,7 +276,7 @@ class ChunkGeneratorTests(ScannerTestCase):
             self.global_options, self.git_options, "."
         )
         mock_iter_commits.return_value = []
-        self.assertRaises(types.BranchNotException, test_scanner.scan)
+        self.assertRaises(types.BranchNotFoundException, test_scanner.scan)
 
     @mock.patch("tartufo.scanner.GitRepoScanner._iter_branch_commits")
     @mock.patch("git.Repo")


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [ ] Yes (backward compatible)
* [x] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->

## What's new?
Currently, if someone runs the tartufo CLI using the `--branch` argument and the branch does not exist, the CLI will return no secrets found. This is misleading and should fail the call. This change will fail the call if `--branch` is specified and the branch was not found.
