### PR TITLE
allow exclude-entropy-patterns to match lines containing partial matches

### DIFF
--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -352,6 +352,13 @@ class EntropyTests(ScannerTestCase):
         excluded = self.scanner.entropy_string_is_excluded("foo", "docs/README.md")
         self.assertEqual(True, excluded)
 
+    def test_entropy_string_is_excluded_given_partial_line_match(self):
+        self.options.exclude_entropy_patterns = [r"docs/.*\.md::line.+?foo"]
+        excluded = self.scanner.entropy_string_is_excluded(
+            "+a line that contains foo", "docs/README.md"
+        )
+        self.assertEqual(True, excluded)
+
     def test_entropy_string_is_not_excluded(self):
         self.options.exclude_entropy_patterns = [r"foo\..*::f.*"]
         excluded = self.scanner.entropy_string_is_excluded("bar", "foo.py")


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [X] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] Changelog entry
* [X] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [X] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [X] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->

fixes #217 

## What's new?
- `ScannerBase.evaluate_entropy_string` now evaluates the entire line and uses `re.search()` when determining if an entropy string is included, so that false positives can be excluded based on their context.

   For example, `--exclude-entropy-patterns 'file.txt::falsePositive: [a-f0-9]{40}'` will exclude line 1 of this file but not line 2:

   ```yaml
   falsePositive: abcdef0123456789abcdef0123456789abcdef01
   realSecret: abcdef0123456789abcdef0123456789abcdef01
   ```
