### PR TITLE
Issue #104: Update latest tag in Docker Hub only if it's a stable release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9, pypy-3.7]
         include:
           - os: ubuntu-latest
             path: ~/.cache/pypoetry
@@ -40,7 +40,7 @@ jobs:
           ${{ matrix.os }}-venvs-${{ matrix.python-version }}
           ${{ matrix.os }}-venvs
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@3105fb18c05ddd93efea5f9e0bef7a03a6e9e7df
+      uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Enchant
@@ -78,7 +78,7 @@ jobs:
         restore-keys: |
           venvs-${{ matrix.toxenv }}-
     - name: Set up Python
-      uses: actions/setup-python@3105fb18c05ddd93efea5f9e0bef7a03a6e9e7df
+      uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6
       with:
         python-version: 3.7
     - name: Install dependencies

--- a/scripts/build_and_publish_docker.sh
+++ b/scripts/build_and_publish_docker.sh
@@ -6,15 +6,18 @@ IMAGE_NAME=tartufo
 # Move into the scripts folder
 cd "$( dirname "${BASH_SOURCE[0]}" )"
 IMAGE_VERSION=$(awk -F'[ ="]+' '$1 == "version" { print $2 }' ../pyproject.toml)
+VERSION_SUFFIX=$(echo ${IMAGE_VERSION} |  awk -F '-' '{print $2}')
 IMAGE_FULL_NAME=${IMAGE_NAMESPACE}/${IMAGE_NAME}
 
 # Go back to the top level of the project
 cd ..
 # Log in to Docker Hub
 echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
-# Build and tag as the "latest" version of the image
-docker build -t ${IMAGE_FULL_NAME}:latest .
-# Give the build a more specific version tag, from the VERSION file
-docker tag ${IMAGE_FULL_NAME}:latest ${IMAGE_FULL_NAME}:${IMAGE_VERSION}
-docker push ${IMAGE_FULL_NAME}:latest
+# Build, tag & publish image with the specific version tag
+docker build -t ${IMAGE_FULL_NAME}:${IMAGE_VERSION} .
 docker push ${IMAGE_FULL_NAME}:${IMAGE_VERSION}
+# If this is a stable release(no version suffix), update latest docker image
+if [  "${VERSION_SUFFIX}" == "" ]; then
+    docker tag ${IMAGE_FULL_NAME}:${IMAGE_VERSION} ${IMAGE_FULL_NAME}:latest
+    docker push ${IMAGE_FULL_NAME}:latest
+fi


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [x] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
Fixes #104 

## What's new?
The latest image on Docker Hub is updated only if we're making a stable release. For all pre-release versions, the latest image will not be updated.
