### PR TITLE
Fix failing `scan-remote-repo` command 

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -102,6 +102,14 @@ python2 = ["typed-ast (>=1.4.2)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "cached-property"
+version = "1.5.2"
+description = "A decorator for caching properties in classes."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "certifi"
 version = "2021.10.8"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -955,7 +963,7 @@ docs = ["recommonmark", "sphinx", "sphinx-click", "sphinx-rtd-theme", "sphinxcon
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "ef68d532a751442e639df2b0e1a069321ec95ea095337bfaf4afbf9f2eed86a6"
+content-hash = "9f04bb49f0605b7c6606f6f15640a2d3231eaa01506afbe253f32521b5a669b5"
 
 [metadata.files]
 alabaster = [
@@ -989,6 +997,10 @@ babel = [
 black = [
     {file = "black-21.5b2-py3-none-any.whl", hash = "sha256:e5cf21ebdffc7a9b29d73912b6a6a9a4df4ce70220d523c21647da2eae0751ef"},
     {file = "black-21.5b2.tar.gz", hash = "sha256:1fc0e0a2c8ae7d269dfcf0c60a89afa299664f3e811395d40b1922dff8f854b5"},
+]
+cached-property = [
+    {file = "cached-property-1.5.2.tar.gz", hash = "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130"},
+    {file = "cached_property-1.5.2-py2.py3-none-any.whl", hash = "sha256:df4f613cf7ad9a588cc381aaf4a512d26265ecebd5eb9e1ba12f1319eb85a6a0"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ tox = "^3.21.4"
 vulture = "^2.3"
 types-requests = "^2.25.2"
 types-click = "^7.1.2"
+cached-property = "^1.5.2"
 
 [tool.poetry.extras]
 docs = ["recommonmark", "sphinx", "sphinx-click", "sphinx-rtd-theme", "sphinxcontrib-spelling"]

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -278,7 +278,7 @@ def main(ctx: click.Context, **kwargs: config.OptionTypes) -> None:
 
 @main.resultcallback()  # type: ignore
 @click.pass_context
-def process_issues(
+def process_exit(
     ctx: click.Context,
     scan: scanner.ScannerBase,
     **_kwargs: config.OptionTypes,

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -3,14 +3,12 @@
 import importlib
 import logging
 import pathlib
-import platform
 import warnings
-from datetime import datetime
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import click
 
-from tartufo import config, scanner, types, util
+from tartufo import config, scanner, types
 
 
 PLUGIN_DIR = pathlib.Path(__file__).parent / "commands"
@@ -282,26 +280,9 @@ def main(ctx: click.Context, **kwargs: config.OptionTypes) -> None:
 @click.pass_context
 def process_issues(
     ctx: click.Context,
-    result: Tuple[str, scanner.ScannerBase],
-    **kwargs: config.OptionTypes,
+    scan: scanner.ScannerBase,
+    **_kwargs: config.OptionTypes,
 ):
-    repo_path, scan = result
-    options = types.GlobalOptions(**kwargs)  # type: ignore
-    now = datetime.now().isoformat("T", "microseconds")
-    output_dir = None
-    if options.output_dir:
-        if platform.system().lower() == "windows":  # pragma: no cover
-            # Make sure we aren't using illegal characters for Windows folder names
-            now = now.replace(":", "")
-        output_dir = pathlib.Path(options.output_dir) / f"tartufo-scan-results-{now}"
-        output_dir.mkdir(parents=True)
-
-    util.echo_result(options, scan, repo_path, output_dir)
-    if output_dir:
-        util.write_outputs(scan.issues, output_dir)
-        if not options.json:
-            click.echo(f"Results have been saved in {output_dir}")
-
     if scan.issues:
         ctx.exit(1)
 

--- a/tartufo/commands/pre_commit.py
+++ b/tartufo/commands/pre_commit.py
@@ -25,7 +25,7 @@ def main(
     scanner = None
     try:
         scanner = GitPreCommitScanner(options, str(repo_path), include_submodules)
-        util.process_issues(repo_path, scanner, options)
+        util.process_issues(str(repo_path), scanner, options)
     except types.ScanException as exc:
         util.fail(str(exc), ctx)
-    return scanner # type: ignore
+    return scanner  # type: ignore

--- a/tartufo/commands/pre_commit.py
+++ b/tartufo/commands/pre_commit.py
@@ -1,5 +1,4 @@
 import pathlib
-from typing import Tuple
 
 import click
 
@@ -19,14 +18,14 @@ from tartufo.scanner import GitPreCommitScanner
 @click.pass_context
 def main(
     ctx: click.Context, options: types.GlobalOptions, include_submodules: bool
-) -> Tuple[str, GitPreCommitScanner]:
+) -> GitPreCommitScanner:
     """Scan staged changes in a pre-commit hook."""
     # Assume that the current working directory is the appropriate git repo
     repo_path = pathlib.Path.cwd()
     scanner = None
     try:
         scanner = GitPreCommitScanner(options, str(repo_path), include_submodules)
-        scanner.scan()
+        util.process_issues(repo_path, scanner, options)
     except types.ScanException as exc:
         util.fail(str(exc), ctx)
-    return (str(repo_path), scanner)  # type: ignore
+    return scanner # type: ignore

--- a/tartufo/commands/scan_folder.py
+++ b/tartufo/commands/scan_folder.py
@@ -1,7 +1,5 @@
 import sys
 
-from typing import Tuple
-
 import click
 
 from tartufo import types, util
@@ -17,7 +15,7 @@ from tartufo.scanner import FolderScanner
 @click.pass_context
 def main(
     ctx: click.Context, options: types.GlobalOptions, target: str
-) -> Tuple[str, FolderScanner]:
+) -> FolderScanner:
     """Scan a folder."""
     try:
         resume: bool = True
@@ -29,7 +27,7 @@ def main(
         if resume is False:
             sys.exit(0)
         scanner = FolderScanner(options, target)
-        scanner.scan()
+        util.process_issues(target, scanner, options)
     except types.TartufoException as exc:
         util.fail(str(exc), ctx)
-    return target, scanner
+    return scanner  # type: ignore

--- a/tartufo/commands/scan_local_repo.py
+++ b/tartufo/commands/scan_local_repo.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Optional
 
 import click
 
@@ -44,7 +44,7 @@ def main(
     branch: Optional[str],
     fetch: bool,
     include_submodules: bool,
-) -> Tuple[str, GitRepoScanner]:
+) -> GitRepoScanner:
     """Scan a repository already cloned to your local system."""
     git_options = types.GitOptions(
         since_commit=since_commit,
@@ -56,11 +56,11 @@ def main(
     scanner = None
     try:
         scanner = GitRepoScanner(options, git_options, str(repo_path))
-        scanner.scan()
+        util.process_issues(repo_path, scanner, options)
     except types.GitLocalException:
         util.fail(f"{repo_path} is not a valid git repository.", ctx)
     except types.GitRemoteException as exc:
         util.fail(f"There was an error fetching from the remote repository: {exc}", ctx)
     except types.TartufoException as exc:
         util.fail(str(exc), ctx)
-    return (str(repo_path), scanner)  # type: ignore
+    return scanner  # type: ignore

--- a/tartufo/commands/scan_remote_repo.py
+++ b/tartufo/commands/scan_remote_repo.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from shutil import rmtree
-from typing import Optional, Tuple
+from typing import Optional
 from urllib.parse import urlparse
 
 import click
@@ -51,7 +51,7 @@ def main(
     branch: Optional[str],
     work_dir: Optional[str],
     include_submodules: bool,
-) -> Tuple[str, GitRepoScanner]:
+) -> GitRepoScanner:
     """Automatically clone and scan a remote git repository."""
     git_options = types.GitOptions(
         since_commit=since_commit,
@@ -71,7 +71,7 @@ def main(
     try:
         repo_path = util.clone_git_repo(git_url, repo_path)
         scanner = GitRepoScanner(options, git_options, str(repo_path))
-        scanner.scan()
+        util.process_issues(git_url, scanner, options)
     except types.GitException as exc:
         util.fail(f"Error cloning remote repo: {exc}", ctx)
     except types.TartufoException as exc:
@@ -79,4 +79,4 @@ def main(
     finally:
         if repo_path and repo_path.exists():
             rmtree(str(repo_path), onerror=util.del_rw)
-    return (git_url, scanner)  # type: ignore
+    return scanner  # type: ignore

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -689,7 +689,7 @@ class GitRepoScanner(GitScanner):
                     )
                     continue
                 prev_commit = curr_commit.parents[0]
-                diff: pygit2.Diff = self._repo.diff(curr_commit, prev_commit)
+                diff: pygit2.Diff = self._repo.diff(prev_commit, curr_commit)
                 diff_hash = hashlib.md5(
                     (str(prev_commit) + str(curr_commit)).encode("utf-8")
                 ).digest()
@@ -700,7 +700,7 @@ class GitRepoScanner(GitScanner):
                     yield types.Chunk(
                         blob,
                         file_path,
-                        util.extract_commit_metadata(prev_commit, branch),
+                        util.extract_commit_metadata(curr_commit, branch),
                     )
 
             # Finally, yield the first commit to the branch

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -33,7 +33,6 @@ if TYPE_CHECKING:
     from tartufo.config import OptionTypes  # pylint: disable=cyclic-import
 
 
-
 DATETIME_FORMAT: str = "%Y-%m-%d %H:%M:%S"
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,7 +85,7 @@ class ProcessIssuesTest(unittest.TestCase):
     @unittest.skipIf(
         helpers.BROKEN_USER_PATHS, "Skipping due to truncated Windows usernames"
     )
-    @mock.patch("tartufo.cli.datetime")
+    @mock.patch("tartufo.util.datetime")
     @mock.patch("tartufo.commands.scan_local_repo.GitRepoScanner")
     @mock.patch("tartufo.util.echo_result", new=mock.MagicMock())
     @mock.patch("tartufo.util.write_outputs", new=mock.MagicMock())
@@ -115,7 +115,7 @@ class ProcessIssuesTest(unittest.TestCase):
     @unittest.skipIf(
         helpers.BROKEN_USER_PATHS, "Skipping due to truncated Windows usernames"
     )
-    @mock.patch("tartufo.cli.datetime")
+    @mock.patch("tartufo.util.datetime")
     @mock.patch("tartufo.commands.scan_local_repo.GitRepoScanner")
     @mock.patch("tartufo.util.echo_result", new=mock.MagicMock())
     @mock.patch("tartufo.util.write_outputs", new=mock.MagicMock())

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -265,8 +265,8 @@ class ChunkGeneratorTests(ScannerTestCase):
             pass
         mock_repo.return_value.diff.assert_has_calls(
             (
-                mock.call(mock_commit_3, mock_commit_2),
-                mock.call(mock_commit_2, mock_commit_1),
+                mock.call(mock_commit_2, mock_commit_3),
+                mock.call(mock_commit_1, mock_commit_2),
             )
         )
         mock_iter_diff.assert_has_calls(


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)


## What's new?
The recent live-output & pygit2 changes broke existing remote repo scans because `scanner.scan` was being
called from the subcommand and the cloned directory was being deleted before the scan could actually happen.
The original process_issues callback has now been moved into util and is called from the sub-commands to
fix this issue. The main callback only handles exit status now.
