### PR TITLE
Fix scan-remote-repo --branch logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+vx.y.z - TBD
+------------
+
+Bug fixes:
+
+* [#247](https://github.com/godaddy/tartufo/issues/247) -- the `--branch` option
+  for `scan-remote-repo` has not worked since v2.0.2. Versions v2.2.0 through
+  v2.7.0 failed silently (not scanning the branch, and returning no error).
+  Versions v2.8.0 and later claimed the branch did not exist, even if it did.
+  This option now works correctly.
+
 v2.9.0 - 19 October 2021
 ------------------------
 

--- a/tartufo/commands/scan_local_repo.py
+++ b/tartufo/commands/scan_local_repo.py
@@ -52,6 +52,7 @@ def main(
         branch=branch,
         fetch=fetch,
         include_submodules=include_submodules,
+        is_remote=False,
     )
     scanner = None
     try:

--- a/tartufo/commands/scan_remote_repo.py
+++ b/tartufo/commands/scan_remote_repo.py
@@ -59,6 +59,7 @@ def main(
         branch=branch,
         fetch=False,
         include_submodules=include_submodules,
+        is_remote=True,
     )
     repo_path: Optional[Path] = None
     if work_dir:

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -54,12 +54,20 @@ class GlobalOptions:
 
 @dataclass
 class GitOptions:
-    __slots__ = ("since_commit", "max_depth", "branch", "fetch", "include_submodules")
+    __slots__ = (
+        "since_commit",
+        "max_depth",
+        "branch",
+        "fetch",
+        "include_submodules",
+        "is_remote",
+    )
     since_commit: Optional[str]
     max_depth: int
     branch: Optional[str]
     fetch: bool
     include_submodules: bool
+    is_remote: bool
 
 
 class IssueType(enum.Enum):

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -264,28 +264,6 @@ class ChunkGeneratorTests(ScannerTestCase):
 
     @mock.patch("tartufo.scanner.GitRepoScanner._iter_branch_commits")
     @mock.patch("git.Repo")
-    def test_scan_all_local_branches_fetch_false(
-        self, mock_repo: mock.MagicMock, mock_iter_commits: mock.MagicMock
-    ):
-        self.git_options.fetch = False
-        self.git_options.is_remote = False
-        mock_repo.return_value.remotes.origin.fetch.return_value = ["foo", "bar"]
-        mock_repo.return_value.branches = ["foo", "bar"]
-        test_scanner = scanner.GitRepoScanner(
-            self.global_options, self.git_options, "."
-        )
-        mock_iter_commits.return_value = []
-        for _ in test_scanner.chunks:
-            pass
-        mock_iter_commits.assert_has_calls(
-            (
-                mock.call(mock_repo.return_value, "foo"),
-                mock.call(mock_repo.return_value, "bar"),
-            )
-        )
-
-    @mock.patch("tartufo.scanner.GitRepoScanner._iter_branch_commits")
-    @mock.patch("git.Repo")
     def test_scan_single_branch_fetch_false(
         self, mock_repo: mock.MagicMock, mock_iter_commits: mock.MagicMock
     ):


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [X] Tests (if applicable)
* [ ] Documentation (if applicable)
* [X] Changelog entry
* [X] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [X] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [X] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
fixes #247

## What's new?
- A fresh-cloned repository does not have branch information for remote branches. We must follow the information in `remotes.origin.refs` instead of `branches` (which will have only the main/master branch).
- We add a new `is_remote` flag so the common code knows which strategy to employ.
- A side-effect appears to be that because `HEAD` appears in the reference list, we'll scan the default branch twice, but I can live with this.