### PR TITLE
Add --no-fetch to all scan-local-repo examples

### DIFF
--- a/docs/source/examplecleanup.rst
+++ b/docs/source/examplecleanup.rst
@@ -123,7 +123,7 @@ More on this later!)
       mv tartufo.toml tartufo.toml_bak
       mv tartufo.toml_new tartufo.toml
       # one final run to make sure your signatures are all set
-      tartufo --regex scan-local-repo ${gitrepo}
+      tartufo --regex scan-local-repo --no-fetch ${gitrepo}
 
 #. Once you are happy with the data that is being stored, time to commit the
    changes back up!

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -23,14 +23,14 @@ Scanning a Local Repository
 
 .. code-block:: sh
 
-   $ tartufo scan-local-repo /path/to/my/repo
+   $ tartufo scan-local-repo --no-fetch /path/to/my/repo
 
 To use ``docker``, mount the local clone to the ``/git`` folder in the docker
 image:
 
 .. code-block:: sh
 
-   $ docker run --rm -v "/path/to/my/repo:/git" godaddy/tartufo scan-local-repo /git
+   $ docker run --rm -v "/path/to/my/repo:/git" godaddy/tartufo scan-local-repo --no-fetch /git
 
 .. note::
 
@@ -95,7 +95,7 @@ Using Docker for Linux, that will look something like this:
 
     $ docker run --rm -v "/path/to/my/repo:/git" \
       -v $SSH_AUTH_SOCK:/agent -e SSH_AUTH_SOCK=/agent \
-      godaddy/tartufo scan-local-repo /git
+      godaddy/tartufo scan-local-repo --no-fetch /git
 
 
 When using Docker Desktop for Mac, use ``/run/host-services/ssh-auth.sock`` as
@@ -414,7 +414,7 @@ in the config file:
    > tartufo \
      --include-path-patterns 'src/' -ip 'gradle/' \
      --exclude-path-patterns '(.*/)?\.classpath$' -xp '.*\.jmx$' \
-     scan-local-repo file://path/to/my/repo.git
+     scan-local-repo --no-fetch file://path/to/my/repo.git
 
 
 Additional usage information is provided when calling ``tartufo`` with the

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,7 +50,7 @@ Getting started is easy!
       $ tartufo scan-remote-repo git@github.com:my_user/my_repo.git
 
       # Or, scan a local clone of a repo!
-      $ tartufo scan-local-repo /path/to/your/git/repo
+      $ tartufo scan-local-repo --no-fetch /path/to/your/git/repo
 
    .. code-block:: console
 
@@ -58,7 +58,7 @@ Getting started is easy!
       $ docker run --rm godaddy/tartufo scan-remote-repo https://github.com/my_user/my_repo.git
 
       # Mount a local clone of a repo and scan it using docker!
-      $ docker run --rm -v "/path/to/your/git/repo:/git" godaddy/tartufo scan-local-repo /git
+      $ docker run --rm -v "/path/to/your/git/repo:/git" godaddy/tartufo scan-local-repo --no-fetch /git
 
    For more detail on usage and options, see :doc:`usage` and :doc:`features`.
 


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [x] Documentation (if applicable)
* [ ] Changelog entry
* [ ] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
Closes #251 

## What's new?
This PR adds the `--no-fetch` flag to all scan-local-repo examples.
