### PR TITLE
Add a new "--scan-filename/--no-scan-filename" flag 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Features:
   thanks to @dclayton-godaddy for showing the way.
 * [#244](https://github.com/godaddy/tartufo/pull/244) - Drops support for 
   `--fetch/--no-fetch` option for local scans
+* [#259](https://github.com/godaddy/tartufo/pull/259) - Adds a new 
+  `--scan-filenames/--no-scan-filenames` flag which allows users to enable or disable file name scanning.
 
 v2.9.0 - 19 October 2021
 ------------------------

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Options:
   --regex / --no-regex            Enable high signal regexes checks.
                                   [default: False]
   --scan-filenames / --no-scan-filenames            
-                                  Enable scanning of file names.
+                                  Check the names of files being scanned as well as their contents.
                                   [default: True]
 
   -i, --include-paths FILENAME    [DEPRECATED] Use `--include-path-patterns`.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Options:
                                   [default: False]
   --scan-filenames / --no-scan-filenames            
                                   Enable scanning of file names.
-                                  [default: False]
+                                  [default: True]
 
   -i, --include-paths FILENAME    [DEPRECATED] Use `--include-path-patterns`.
                                   File with regular expressions (one per

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Options:
   --entropy / --no-entropy        Enable entropy checks.  [default: True]
   --regex / --no-regex            Enable high signal regexes checks.
                                   [default: False]
+  --scan-filenames / --no-scan-filenames            
+                                  Enable scanning of file names.
+                                  [default: False]
 
   -i, --include-paths FILENAME    [DEPRECATED] Use `--include-path-patterns`.
                                   File with regular expressions (one per

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -82,10 +82,10 @@ class TartufoCLI(click.MultiCommand):
     help="Enable high signal regexes checks.",
 )
 @click.option(
-    "--scan-filename/--no-scan-filename",
+    "--scan-filenames/--no-scan-filenames",
     is_flag=True,
-    default=False,
-    show_default="--no-scan-filename",
+    default=True,
+    show_default="--scan-filenames",
     help="Enable filename checks.",
 )
 @click.option(

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -82,6 +82,13 @@ class TartufoCLI(click.MultiCommand):
     help="Enable high signal regexes checks.",
 )
 @click.option(
+    "--scan-filename/--no-scan-filename",
+    is_flag=True,
+    default=False,
+    show_default="--no-scan-filename",
+    help="Enable filename checks.",
+)
+@click.option(
     "-i",
     "--include-paths",
     type=click.File("r"),

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -85,8 +85,8 @@ class TartufoCLI(click.MultiCommand):
     "--scan-filenames/--no-scan-filenames",
     is_flag=True,
     default=True,
-    show_default="--scan-filenames",
-    help="Enable filename checks.",
+    show_default=True,
+    help="Check the names of files being scanned as well as their contents.",
 )
 @click.option(
     "-i",

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -590,6 +590,7 @@ class GitScanner(ScannerBase, abc.ABC):
 
 
 class GitRepoScanner(GitScanner):
+
     git_options: types.GitOptions
 
     def __init__(
@@ -660,6 +661,7 @@ class GitRepoScanner(GitScanner):
         :raises types.GitRemoteException: If there was an error fetching branches
         """
         already_searched: Set[bytes] = set()
+
         try:
             if self.git_options.branch:
                 # Single branch only

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -12,7 +12,7 @@ class GlobalOptions:
         "default_regexes",
         "entropy",
         "regex",
-        "scan_filename",
+        "scan_filenames",
         "include_paths",
         "include_path_patterns",
         "exclude_paths",
@@ -35,7 +35,7 @@ class GlobalOptions:
     default_regexes: bool
     entropy: bool
     regex: bool
-    scan_filename: bool
+    scan_filenames: bool
     include_paths: Optional[TextIO]
     include_path_patterns: Tuple[str, ...]
     exclude_paths: Optional[TextIO]

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -12,6 +12,7 @@ class GlobalOptions:
         "default_regexes",
         "entropy",
         "regex",
+        "scan_filename",
         "include_paths",
         "include_path_patterns",
         "exclude_paths",
@@ -34,6 +35,7 @@ class GlobalOptions:
     default_regexes: bool
     entropy: bool
     regex: bool
+    scan_filename: bool
     include_paths: Optional[TextIO]
     include_path_patterns: Tuple[str, ...]
     exclude_paths: Optional[TextIO]

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -249,9 +249,18 @@ class ChunkGeneratorTests(ScannerTestCase):
         )
         mock_iter_diff.assert_has_calls(
             (
-                mock.call(mock_repo.return_value.diff(mock_commit_3, mock_commit_2)),
-                mock.call(mock_repo.return_value.diff(mock_commit_2, mock_commit_1)),
-                mock.call(mock_repo.return_value.revparse_single().tree.diff_to_tree()),
+                mock.call(
+                    mock_repo.return_value.diff(mock_commit_3, mock_commit_2),
+                    self.global_options.scan_filename,
+                ),
+                mock.call(
+                    mock_repo.return_value.diff(mock_commit_2, mock_commit_1),
+                    self.global_options.scan_filename,
+                ),
+                mock.call(
+                    mock_repo.return_value.revparse_single().tree.diff_to_tree(),
+                    self.global_options.scan_filename,
+                ),
             )
         )
 
@@ -301,7 +310,11 @@ class IterDiffIndexTests(ScannerTestCase):
         test_scanner = scanner.GitRepoScanner(
             self.global_options, self.git_options, "."
         )
-        diffs = list(test_scanner._iter_diff_index([mock_diff]))
+        diffs = list(
+            test_scanner._iter_diff_index(
+                [mock_diff], self.global_options.scan_filename
+            )
+        )
         self.assertEqual(diffs, [])
 
     @mock.patch("pygit2.Repository", new=mock.MagicMock())
@@ -313,7 +326,11 @@ class IterDiffIndexTests(ScannerTestCase):
         test_scanner = scanner.GitRepoScanner(
             self.global_options, self.git_options, "."
         )
-        diffs = list(test_scanner._iter_diff_index([mock_diff]))
+        diffs = list(
+            test_scanner._iter_diff_index(
+                [mock_diff], self.global_options.scan_filename
+            )
+        )
         self.assertEqual(diffs, [])
         mock_should.assert_called_once()
 
@@ -346,7 +363,11 @@ class IterDiffIndexTests(ScannerTestCase):
         test_scanner = scanner.GitRepoScanner(
             self.global_options, self.git_options, "."
         )
-        diffs = list(test_scanner._iter_diff_index([mock_diff_1, mock_diff_2]))
+        diffs = list(
+            test_scanner._iter_diff_index(
+                [mock_diff_1, mock_diff_2], self.global_options.scan_filename
+            )
+        )
         self.assertEqual(
             diffs,
             [

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -251,15 +251,12 @@ class ChunkGeneratorTests(ScannerTestCase):
             (
                 mock.call(
                     mock_repo.return_value.diff(mock_commit_3, mock_commit_2),
-                    self.global_options.scan_filenames,
                 ),
                 mock.call(
                     mock_repo.return_value.diff(mock_commit_2, mock_commit_1),
-                    self.global_options.scan_filenames,
                 ),
                 mock.call(
                     mock_repo.return_value.revparse_single().tree.diff_to_tree(),
-                    self.global_options.scan_filenames,
                 ),
             )
         )
@@ -310,11 +307,7 @@ class IterDiffIndexTests(ScannerTestCase):
         test_scanner = scanner.GitRepoScanner(
             self.global_options, self.git_options, "."
         )
-        diffs = list(
-            test_scanner._iter_diff_index(
-                [mock_diff], self.global_options.scan_filenames
-            )
-        )
+        diffs = list(test_scanner._iter_diff_index([mock_diff]))
         self.assertEqual(diffs, [])
 
     @mock.patch("pygit2.Repository", new=mock.MagicMock())
@@ -326,11 +319,7 @@ class IterDiffIndexTests(ScannerTestCase):
         test_scanner = scanner.GitRepoScanner(
             self.global_options, self.git_options, "."
         )
-        diffs = list(
-            test_scanner._iter_diff_index(
-                [mock_diff], self.global_options.scan_filenames
-            )
-        )
+        diffs = list(test_scanner._iter_diff_index([mock_diff]))
         self.assertEqual(diffs, [])
         mock_should.assert_called_once()
 
@@ -363,11 +352,7 @@ class IterDiffIndexTests(ScannerTestCase):
         test_scanner = scanner.GitRepoScanner(
             self.global_options, self.git_options, "."
         )
-        diffs = list(
-            test_scanner._iter_diff_index(
-                [mock_diff_1, mock_diff_2], self.global_options.scan_filenames
-            )
-        )
+        diffs = list(test_scanner._iter_diff_index([mock_diff_1, mock_diff_2]))
         self.assertEqual(
             diffs,
             [
@@ -414,9 +399,7 @@ class ScanFilenameTests(ScannerTestCase):
             self.global_options, self.git_options, "."
         )
 
-        for _ in test_scanner._iter_diff_index(
-            [mock_diff], self.global_options.scan_filenames
-        ):
+        for _ in test_scanner._iter_diff_index([mock_diff]):
             pass
 
         mock_header_length.assert_called_once_with(mock_diff.text)
@@ -431,9 +414,7 @@ class ScanFilenameTests(ScannerTestCase):
             self.global_options, self.git_options, "."
         )
 
-        for _ in test_scanner._iter_diff_index(
-            [mock_diff], self.global_options.scan_filenames
-        ):
+        for _ in test_scanner._iter_diff_index([mock_diff]):
             pass
 
         mock_header_length.assert_not_called()

--- a/tests/test_scan_folder.py
+++ b/tests/test_scan_folder.py
@@ -1,9 +1,14 @@
+import pathlib
 import unittest
 from unittest import mock
 
+import click
 from click.testing import CliRunner
 
 from tartufo import cli, types
+from tartufo.scanner import FolderScanner
+from tartufo.types import GlobalOptions
+from tests.helpers import generate_options
 
 
 class ScanFolderTests(unittest.TestCase):
@@ -28,3 +33,29 @@ class ScanFolderTests(unittest.TestCase):
                 f"Error: Invalid value for 'TARGET': Directory '{scan_folder}' does not exist.\n",
                 result.output,
             )
+
+    def test_filename_added_to_chunk_when_scan_filename_enabled(self):
+        path = pathlib.Path(__file__).parent / "data" / "scan_folder"
+        options = generate_options(GlobalOptions, scan_filenames=True)
+        scanner = FolderScanner(options, str(path))
+        for chunk in scanner.chunks:
+            file_path = chunk.file_path
+            try:
+                with pathlib.Path(f"{str(path)}/{file_path}").open("rb") as fhd:
+                    data = fhd.read().decode("utf-8")
+            except OSError as exc:
+                raise click.FileError(filename=str(file_path), hint=str(exc))
+            self.assertEqual(chunk.contents, f"{chunk.file_path}\n{data}")
+
+    def test_filename_not_added_to_chunk_when_scan_filename_disabled(self):
+        path = pathlib.Path(__file__).parent / "data" / "scan_folder"
+        options = generate_options(GlobalOptions, scan_filenames=False)
+        scanner = FolderScanner(options, str(path))
+        for chunk in scanner.chunks:
+            file_path = chunk.file_path
+            try:
+                with pathlib.Path(f"{str(path)}/{file_path}").open("rb") as fhd:
+                    data = fhd.read().decode("utf-8")
+            except OSError as exc:
+                raise click.FileError(filename=str(file_path), hint=str(exc))
+            self.assertEqual(chunk.contents, data)


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [ ] Documentation (if applicable)
* [x] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
Closes #188 

## What's new?
- This PR adds a new `--scan-filename/--no-scan-filename` flag which allows user to enable or disable file name scanning using Tartufo.
