### PR TITLE
Enable regex scans by default #254

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+vx.y.z - TBD
+------------
+
+Bug fixes:
+
+* [#247](https://github.com/godaddy/tartufo/issues/247) -- the `--branch` option
+  for `scan-remote-repo` has not worked since v2.0.2. Versions v2.2.0 through
+  v2.7.0 failed silently (not scanning the branch, and returning no error).
+  Versions v2.8.0 and later claimed the branch did not exist, even if it did.
+  This option now works correctly.
+
 v2.9.0 - 19 October 2021
 ------------------------
 

--- a/docs/source/examplecleanup.rst
+++ b/docs/source/examplecleanup.rst
@@ -123,7 +123,7 @@ More on this later!)
       mv tartufo.toml tartufo.toml_bak
       mv tartufo.toml_new tartufo.toml
       # one final run to make sure your signatures are all set
-      tartufo --regex scan-local-repo ${gitrepo}
+      tartufo --regex scan-local-repo --no-fetch ${gitrepo}
 
 #. Once you are happy with the data that is being stored, time to commit the
    changes back up!

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -23,14 +23,14 @@ Scanning a Local Repository
 
 .. code-block:: sh
 
-   $ tartufo scan-local-repo /path/to/my/repo
+   $ tartufo scan-local-repo --no-fetch /path/to/my/repo
 
 To use ``docker``, mount the local clone to the ``/git`` folder in the docker
 image:
 
 .. code-block:: sh
 
-   $ docker run --rm -v "/path/to/my/repo:/git" godaddy/tartufo scan-local-repo /git
+   $ docker run --rm -v "/path/to/my/repo:/git" godaddy/tartufo scan-local-repo --no-fetch /git
 
 .. note::
 
@@ -95,7 +95,7 @@ Using Docker for Linux, that will look something like this:
 
     $ docker run --rm -v "/path/to/my/repo:/git" \
       -v $SSH_AUTH_SOCK:/agent -e SSH_AUTH_SOCK=/agent \
-      godaddy/tartufo scan-local-repo /git
+      godaddy/tartufo scan-local-repo --no-fetch /git
 
 
 When using Docker Desktop for Mac, use ``/run/host-services/ssh-auth.sock`` as
@@ -414,7 +414,7 @@ in the config file:
    > tartufo \
      --include-path-patterns 'src/' -ip 'gradle/' \
      --exclude-path-patterns '(.*/)?\.classpath$' -xp '.*\.jmx$' \
-     scan-local-repo file://path/to/my/repo.git
+     scan-local-repo --no-fetch file://path/to/my/repo.git
 
 
 Additional usage information is provided when calling ``tartufo`` with the

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,7 +50,7 @@ Getting started is easy!
       $ tartufo scan-remote-repo git@github.com:my_user/my_repo.git
 
       # Or, scan a local clone of a repo!
-      $ tartufo scan-local-repo /path/to/your/git/repo
+      $ tartufo scan-local-repo --no-fetch /path/to/your/git/repo
 
    .. code-block:: console
 
@@ -58,7 +58,7 @@ Getting started is easy!
       $ docker run --rm godaddy/tartufo scan-remote-repo https://github.com/my_user/my_repo.git
 
       # Mount a local clone of a repo and scan it using docker!
-      $ docker run --rm -v "/path/to/your/git/repo:/git" godaddy/tartufo scan-local-repo /git
+      $ docker run --rm -v "/path/to/your/git/repo:/git" godaddy/tartufo scan-local-repo --no-fetch /git
 
    For more detail on usage and options, see :doc:`usage` and :doc:`features`.
 

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -79,7 +79,7 @@ class TartufoCLI(click.MultiCommand):
 @click.option(
     "--regex/--no-regex",
     is_flag=True,
-    default=False,
+    default=True,
     show_default=True,
     help="Enable high signal regexes checks.",
 )

--- a/tartufo/commands/scan_local_repo.py
+++ b/tartufo/commands/scan_local_repo.py
@@ -52,6 +52,7 @@ def main(
         branch=branch,
         fetch=fetch,
         include_submodules=include_submodules,
+        is_remote=False,
     )
     scanner = None
     try:

--- a/tartufo/commands/scan_remote_repo.py
+++ b/tartufo/commands/scan_remote_repo.py
@@ -59,6 +59,7 @@ def main(
         branch=branch,
         fetch=False,
         include_submodules=include_submodules,
+        is_remote=True,
     )
     repo_path: Optional[Path] = None
     if work_dir:

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -54,12 +54,20 @@ class GlobalOptions:
 
 @dataclass
 class GitOptions:
-    __slots__ = ("since_commit", "max_depth", "branch", "fetch", "include_submodules")
+    __slots__ = (
+        "since_commit",
+        "max_depth",
+        "branch",
+        "fetch",
+        "include_submodules",
+        "is_remote",
+    )
     since_commit: Optional[str]
     max_depth: int
     branch: Optional[str]
     fetch: bool
     include_submodules: bool
+    is_remote: bool
 
 
 class IssueType(enum.Enum):

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -148,6 +148,7 @@ class ChunkGeneratorTests(ScannerTestCase):
     def test_single_branch_is_loaded_if_specified(self, mock_repo: mock.MagicMock):
         self.git_options.branch = "foo"
         self.git_options.fetch = True
+        self.git_options.is_remote = False
         mock_fetch = mock.MagicMock()
         mock_fetch.return_value = []
         mock_branch = mock.MagicMock()
@@ -167,6 +168,7 @@ class ChunkGeneratorTests(ScannerTestCase):
         mock_fetch.return_value = []
         mock_repo.return_value.remotes.origin.fetch = mock_fetch
         self.git_options.fetch = True
+        self.git_options.is_remote = False
         test_scanner = scanner.GitRepoScanner(
             self.global_options, self.git_options, "."
         )
@@ -193,10 +195,11 @@ class ChunkGeneratorTests(ScannerTestCase):
 
     @mock.patch("tartufo.scanner.GitRepoScanner._iter_branch_commits")
     @mock.patch("git.Repo")
-    def test_all_branches_are_scanned_for_commits(
+    def test_all_local_branches_are_scanned_for_commits(
         self, mock_repo: mock.MagicMock, mock_iter_commits: mock.MagicMock
     ):
         self.git_options.fetch = True
+        self.git_options.is_remote = False
         mock_repo.return_value.remotes.origin.fetch.return_value = ["foo", "bar"]
         mock_repo.return_value.branches = ["foo", "bar"]
         test_scanner = scanner.GitRepoScanner(
@@ -214,10 +217,36 @@ class ChunkGeneratorTests(ScannerTestCase):
 
     @mock.patch("tartufo.scanner.GitRepoScanner._iter_branch_commits")
     @mock.patch("git.Repo")
-    def test_scan_all_branches_fetch_false(
+    def test_all_remote_branches_are_scanned_for_commits(
+        self, mock_repo: mock.MagicMock, mock_iter_commits: mock.MagicMock
+    ):
+        mock_foo = mock.MagicMock()
+        mock_foo.name = "origin/foo"
+        mock_bar = mock.MagicMock()
+        mock_bar.name = "origin/bar"
+
+        self.git_options.is_remote = True
+        mock_repo.return_value.remotes.origin.refs = [mock_foo, mock_bar]
+        test_scanner = scanner.GitRepoScanner(
+            self.global_options, self.git_options, "."
+        )
+        mock_iter_commits.return_value = []
+        for _ in test_scanner.chunks:
+            pass
+        mock_iter_commits.assert_has_calls(
+            (
+                mock.call(mock_repo.return_value, mock_foo),
+                mock.call(mock_repo.return_value, mock_bar),
+            )
+        )
+
+    @mock.patch("tartufo.scanner.GitRepoScanner._iter_branch_commits")
+    @mock.patch("git.Repo")
+    def test_scan_all_local_branches_fetch_false(
         self, mock_repo: mock.MagicMock, mock_iter_commits: mock.MagicMock
     ):
         self.git_options.fetch = False
+        self.git_options.is_remote = False
         mock_repo.return_value.remotes.origin.fetch.return_value = ["foo", "bar"]
         mock_repo.return_value.branches = ["foo", "bar"]
         test_scanner = scanner.GitRepoScanner(
@@ -259,10 +288,34 @@ class ChunkGeneratorTests(ScannerTestCase):
 
     @mock.patch("tartufo.scanner.GitRepoScanner._iter_branch_commits")
     @mock.patch("git.Repo")
-    def test_scan_single_branch_throws_exception_when_branch_not_found(
+    def test_scan_single_remote_branch(
+        self, mock_repo: mock.MagicMock, mock_iter_commits: mock.MagicMock
+    ):
+        self.git_options.is_remote = True
+        self.git_options.branch = "bar"
+        mock_foo = mock.MagicMock()
+        mock_foo.name = "origin/foo"
+        mock_bar = mock.MagicMock()
+        mock_bar.name = "origin/bar"
+        mock_repo.return_value.remotes.origin.refs = [mock_foo, mock_bar]
+        test_scanner = scanner.GitRepoScanner(
+            self.global_options, self.git_options, "."
+        )
+        mock_iter_commits.return_value = []
+        for _ in test_scanner.chunks:
+            pass
+        mock_repo.return_value.remotes.branches.assert_not_called()
+        mock_iter_commits.assert_has_calls(
+            (mock.call(mock_repo.return_value, mock_bar),)
+        )
+
+    @mock.patch("tartufo.scanner.GitRepoScanner._iter_branch_commits")
+    @mock.patch("git.Repo")
+    def test_scan_single_local_branch_throws_exception_when_branch_not_found(
         self, mock_repo: mock.MagicMock, mock_iter_commits: mock.MagicMock
     ):
         self.git_options.fetch = True
+        self.git_options.is_remote = False
         self.git_options.branch = "not-found"
         self.global_options.entropy = True
         mock_foo = mock.MagicMock()
@@ -280,10 +333,31 @@ class ChunkGeneratorTests(ScannerTestCase):
 
     @mock.patch("tartufo.scanner.GitRepoScanner._iter_branch_commits")
     @mock.patch("git.Repo")
+    def test_scan_single_remote_branch_throws_exception_when_branch_not_found(
+        self, mock_repo: mock.MagicMock, mock_iter_commits: mock.MagicMock
+    ):
+        self.git_options.is_remote = True
+        self.git_options.branch = "not-found"
+        self.global_options.entropy = True
+        mock_foo = mock.MagicMock()
+        mock_foo.name = "foo"
+        mock_bar = mock.MagicMock()
+        mock_bar.name = "bar"
+        mock_repo.return_value.remotes.origin.refs = [mock_foo, mock_bar]
+
+        test_scanner = scanner.GitRepoScanner(
+            self.global_options, self.git_options, "."
+        )
+        mock_iter_commits.return_value = []
+        self.assertRaises(types.BranchNotFoundException, test_scanner.scan)
+
+    @mock.patch("tartufo.scanner.GitRepoScanner._iter_branch_commits")
+    @mock.patch("git.Repo")
     def test_scan_single_branch_fetch_true(
         self, mock_repo: mock.MagicMock, mock_iter_commits: mock.MagicMock
     ):
         self.git_options.fetch = True
+        self.git_options.is_remote = False
         self.git_options.branch = "bar"
         mock_foo = mock.MagicMock()
         mock_foo.name = "foo"
@@ -312,6 +386,7 @@ class ChunkGeneratorTests(ScannerTestCase):
         mock_iter_commits: mock.MagicMock,
     ):
         self.git_options.fetch = True
+        self.git_options.is_remote = False
         mock_repo.return_value.remotes.origin.fetch.return_value = ["foo"]
         mock_repo.return_value.branches = ["foo"]
         test_scanner = scanner.GitRepoScanner(
@@ -354,6 +429,7 @@ class ChunkGeneratorTests(ScannerTestCase):
         mock_iter_commits: mock.MagicMock,
     ):
         self.git_options.fetch = True
+        self.git_options.is_remote = False
         mock_repo.return_value.remotes.origin.fetch.return_value = ["foo"]
         mock_repo.return_value.branches = ["foo"]
         test_scanner = scanner.GitRepoScanner(


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [ ] Documentation (if applicable)
* [x] Changelog entry
* [X] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [X] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [X] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
closes [#254](https://github.com/godaddy/tartufo/issues/254)

## What's new?
- Changed the default value of `"--regex/--no-regex",` to `True` so that by default we have all scans and users can omit the ones they don't like
