### PR TITLE
Fix url for Black Editor integration in docs

### DIFF
--- a/docs/source/CONTRIBUTING.md
+++ b/docs/source/CONTRIBUTING.md
@@ -241,7 +241,7 @@ Congratulations, you've just issued a new release for `tartufo`. The automation 
 - [GitHub Pull Request documentation](https://help.github.com/send-pull-requests/)
 
 [black]: https://github.com/psf/black
-[black-editors]: https://github.com/psf/black#editor-integration
+[black-editors]: https://black.readthedocs.io/en/stable/integrations/editors.html
 [bump the version]: https://python-poetry.org/docs/cli/#version
 [issues]: https://github.com/godaddy/tartufo/issues
 [Install Poetry]: https://python-poetry.org/docs/#installation


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [x] Documentation (if applicable)
* [ ] Changelog entry
* [ ] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [ ] Yes (backward compatible)
* [x] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->

## What's new?
- Black formatter no more has a link to editor-integration on the landing README. The link has been updated to the new link in Black docs
