### PR TITLE
Fix scans of shallow clones such as those made by GitHub Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Bug fixes:
 
 * [#247](https://github.com/godaddy/tartufo/issues/247) - The `--branch` qualifier
   now works again when using `scan-remote-repo`.
+* [#270](https://github.com/godaddy/tartufo/issues/270) - When no refs/branches
+  are found locally, tartufo will now scan the repo HEAD as a single commit,
+  effectively scanning the entire codebase at once.
 
 Features:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+vx.y.z - TBD
+------------
+
+* [#270](https://github.com/godaddy/tartufo/issues/270) - When no refs/branches
+  are found locally, tartufo will now scan the repo HEAD as a single commit,
+  effectively scanning the entire codebase at once.
+
 v3.0.0-alpha.1 - 11 November 2021
 ---------------------------------
 
@@ -5,9 +12,6 @@ Bug fixes:
 
 * [#247](https://github.com/godaddy/tartufo/issues/247) - The `--branch` qualifier
   now works again when using `scan-remote-repo`.
-* [#270](https://github.com/godaddy/tartufo/issues/270) - When no refs/branches
-  are found locally, tartufo will now scan the repo HEAD as a single commit,
-  effectively scanning the entire codebase at once.
 
 Features:
 

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -661,7 +661,12 @@ class GitRepoScanner(GitScanner):
                     )
             else:
                 # Everything
-                branches = list(self._repo.branches)
+                branches = self._repo.listall_branches()
+                if not branches:
+                    # If no branches are found, assume that this is a
+                    # shallow clone and examine the repo head as a single
+                    # commit to scan all files at once
+                    branches = ["HEAD"]
         except pygit2.GitError as exc:
             raise types.GitRemoteException(str(exc)) from exc
 
@@ -672,20 +677,25 @@ class GitRepoScanner(GitScanner):
 
         for branch_name in branches:
             self.logger.info("Scanning branch: %s", branch_name)
-            branch: pygit2.Branch = self._repo.branches.get(branch_name)
+            if branch_name == "HEAD":
+                commits = [self._repo.get(self._repo.head.target)]
+            else:
+                branch = self._repo.branches.get(branch_name)
+                commits = self._repo.walk(
+                    branch.resolve().target, pygit2.GIT_SORT_TOPOLOGICAL
+                )
             diff_hash: bytes
             curr_commit: pygit2.Commit = None
             prev_commit: pygit2.Commit = None
-            for curr_commit in self._repo.walk(
-                branch.resolve().target, pygit2.GIT_SORT_TOPOLOGICAL
-            ):
-                # If a commit doesn't have a parent skip diff generation since it is the first commit
-                if not curr_commit.parents:
+            for curr_commit in commits:
+                try:
+                    prev_commit = curr_commit.parents[0]
+                except KeyError:
+                    # If a commit doesn't have a parent skip diff generation since it is the first commit
                     self.logger.debug(
                         "Skipping commit %s because it has no parents", curr_commit.hex
                     )
                     continue
-                prev_commit = curr_commit.parents[0]
                 diff: pygit2.Diff = self._repo.diff(prev_commit, curr_commit)
                 diff_hash = hashlib.md5(
                     (str(prev_commit) + str(curr_commit)).encode("utf-8")
@@ -698,7 +708,7 @@ class GitRepoScanner(GitScanner):
                     yield types.Chunk(
                         blob,
                         file_path,
-                        util.extract_commit_metadata(curr_commit, branch),
+                        util.extract_commit_metadata(curr_commit, branch_name),
                     )
 
             # Finally, yield the first commit to the branch
@@ -710,7 +720,7 @@ class GitRepoScanner(GitScanner):
                     yield types.Chunk(
                         blob,
                         file_path,
-                        util.extract_commit_metadata(curr_commit, branch),
+                        util.extract_commit_metadata(curr_commit, branch_name),
                     )
 
 

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -650,12 +650,12 @@ class GitRepoScanner(GitScanner):
         try:
             if self.git_options.branch:
                 # Single branch only
-                branches = [self._repo.branches.get(self.git_options.branch)]
-
-                if len(branches) == 0:
+                branch = self._repo.branches.get(self.git_options.branch)
+                if not branch:
                     raise BranchNotFoundException(
                         f"Branch {self.git_options.branch} was not found."
                     )
+                branches = [self.git_options.branch]
             else:
                 # Everything
                 if not self._repo.listall_branches():
@@ -692,7 +692,7 @@ class GitRepoScanner(GitScanner):
             for curr_commit in commits:
                 try:
                     prev_commit = curr_commit.parents[0]
-                except KeyError:
+                except (KeyError, TypeError):
                     # If a commit doesn't have a parent skip diff generation since it is the first commit
                     self.logger.debug(
                         "Skipping commit %s because it has no parents", curr_commit.hex

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -666,8 +666,8 @@ class GitRepoScanner(GitScanner):
                 else:
                     # We use `self._repo.branches` here so that we make sure to
                     # scan not only the locally checked out branches (as provided
-                    # by self._repo.listall_branches(), but to also scan all
-                    # available remote refs)
+                    # by self._repo.listall_branches()), but to also scan all
+                    # available remote refs
                     branches = list(self._repo.branches)
         except pygit2.GitError as exc:
             raise types.GitRemoteException(str(exc)) from exc

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -189,9 +189,7 @@ def generate_signature(snippet: str, filename: str) -> str:
     return blake2s(f"{snippet}$${filename}".encode("utf-8")).hexdigest()
 
 
-def extract_commit_metadata(
-    commit: pygit2.Commit, branch: pygit2.Branch
-) -> Dict[str, Any]:
+def extract_commit_metadata(commit: pygit2.Commit, branch_name: str) -> Dict[str, Any]:
     """Grab a consistent set of metadata from a git commit, for user output.
 
     :param commit: The commit to extract the data from
@@ -203,7 +201,7 @@ def extract_commit_metadata(
         ),
         "commit_message": commit.message,
         "commit_hash": commit.hex,
-        "branch": branch.branch_name,
+        "branch": branch_name,
     }
 
 

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -13,7 +13,7 @@ from tests.helpers import generate_options
 
 class ScannerTestCase(unittest.TestCase):
     def setUp(self) -> None:
-        self.global_options = generate_options(GlobalOptions)
+        self.global_options = generate_options(GlobalOptions, exclude_signatures=())
         self.git_options = generate_options(GitOptions)
 
 
@@ -96,7 +96,6 @@ class RepoLoadTests(ScannerTestCase):
     @mock.patch("pygit2.Repository", new=mock.MagicMock())
     @mock.patch("tartufo.config.load_config_from_path")
     def test_extra_signatures_get_added(self, mock_load: mock.MagicMock):
-        self.global_options.exclude_signatures = ()
         mock_load.return_value = (
             self.data_dir / "pyproject.toml",
             {"exclude_signatures": ["foo", "bar"]},
@@ -156,6 +155,7 @@ class ChunkGeneratorTests(ScannerTestCase):
         self.git_options.branch = "foo"
         mock_branch_foo = mock.MagicMock()
         mock_branch_bar = mock.MagicMock()
+        mock_repo.return_value.listall_branches.return_value = ["foo", "bar"]
         mock_repo.return_value.branches = {
             "foo": mock_branch_foo,
             "bar": mock_branch_bar,
@@ -178,6 +178,7 @@ class ChunkGeneratorTests(ScannerTestCase):
     ):
         mock_branch_foo = mock.MagicMock()
         mock_branch_bar = mock.MagicMock()
+        mock_repo.return_value.listall_branches.return_value = ["foo", "bar"]
         mock_repo.return_value.branches = {
             "foo": mock_branch_foo,
             "bar": mock_branch_bar,


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [ ] Documentation (if applicable)
* [x] Changelog entry
* [X] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [X] Bugfix
* [X] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [ ] Yes (backward compatible)
* [X] No (breaking changes)


## Issue Linking

Fixes #209 

## What's new?

This slightly changes the way we gather branches and commits so that we can more easily detect when we are in a scenario where there is no history or local branches. When that scenario is detected, we examine the entire current contents of the repository (the HEAD) as though it were a single commit.

In most cases, this code will never be encountered nor run. The primary thing this enables is for `tartufo` to run natively in an environment created by the `actions/checkout` GitHub Action. Specifically, an environment with a `max-depth=1` meaning no cloned history, and also no local refs or branches, with a detached HEAD.

At this point in time, a few tests still need to be updated, but I wanted to open this PR to show my work so far and get more eyes on it to make sure I'm not missing any obviously glaring points.