### PR TITLE
Enable regex scans by default #254

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Features:
   thanks to @dclayton-godaddy for showing the way.
 * [#244](https://github.com/godaddy/tartufo/pull/244) - Drops support for 
   `--fetch/--no-fetch` option for local scans
-
+* [#254](https://github.com/godaddy/tartufo/pull/260) - Changes the default value of 
+  `--regex/--no-regex` to True.
 v2.9.0 - 19 October 2021
 ------------------------
 

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -77,7 +77,7 @@ class TartufoCLI(click.MultiCommand):
 @click.option(
     "--regex/--no-regex",
     is_flag=True,
-    default=False,
+    default=True,
     show_default=True,
     help="Enable high signal regexes checks.",
 )


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [ ] Documentation (if applicable)
* [X] Changelog entry
* [X] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [X] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [X] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
closes [#254](https://github.com/godaddy/tartufo/issues/254)

## What's new?
- Changed the default value of "--regex/--no-regex", to True so that by default we have all scans and users can omit the ones they don't like