### PR TITLE
Add --entropy-sensitivity option for controlling entropy checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Features:
   `--scan-filenames/--no-scan-filenames` flag which allows users to enable or disable file name scanning.
 * [#254](https://github.com/godaddy/tartufo/pull/260) - Changes the default value of
   `--regex/--no-regex` to True.
-* [#265](https://github.com/godaddy/tartufo/issues/265) - Adds new `--sensitivity`
+* [#265](https://github.com/godaddy/tartufo/issues/265) - Adds new `--entropy-sensitivity`
   option which provides a friendlier way to adjust entropy detection sensitivity.
   This replaces `--b64-entropy-score` and `--hex-entropy-score`, which now are
   marked as deprecated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ Features:
   `--scan-filenames/--no-scan-filenames` flag which allows users to enable or disable file name scanning.
 * [#254](https://github.com/godaddy/tartufo/pull/260) - Changes the default value of
   `--regex/--no-regex` to True.
+* [#265](https://github.com/godaddy/tartufo/issues/265) - Adds new `--sensitivity`
+  option which provides a friendlier way to adjust entropy detection sensitivity.
+  This replaces `--b64-entropy-score` and `--hex-entropy-score`, which now are
+  marked as deprecated.
 
 Misc:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 vx.y.z - TBD
 ------------
 
+Features:
+
 * [#270](https://github.com/godaddy/tartufo/issues/270) - When no refs/branches
   are found locally, tartufo will now scan the repo HEAD as a single commit,
   effectively scanning the entire codebase at once.
+* [#265](https://github.com/godaddy/tartufo/issues/265) - Adds new `--entropy-sensitivity`
+  option which provides a friendlier way to adjust entropy detection sensitivity.
+  This replaces `--b64-entropy-score` and `--hex-entropy-score`, which now are
+  marked as deprecated.
 
 v3.0.0-alpha.1 - 11 November 2021
 ---------------------------------
@@ -27,10 +33,6 @@ Features:
   `--scan-filenames/--no-scan-filenames` flag which allows users to enable or disable file name scanning.
 * [#254](https://github.com/godaddy/tartufo/pull/260) - Changes the default value of
   `--regex/--no-regex` to True.
-* [#265](https://github.com/godaddy/tartufo/issues/265) - Adds new `--entropy-sensitivity`
-  option which provides a friendlier way to adjust entropy detection sensitivity.
-  This replaces `--b64-entropy-score` and `--hex-entropy-score`, which now are
-  marked as deprecated.
 
 Misc:
 

--- a/README.md
+++ b/README.md
@@ -136,11 +136,11 @@ Options:
   --entropy-sensitivity INTEGER RANGE
                                   Modify entropy detection sensitivity. This
                                   is expressed as on a scale of 0 to 100,
-                                  where 0 means "totally random" and 100 means
-                                  "totally nonrandom". Increasing the
+                                  where 0 means "totally nonrandom" and 100
+                                  means "totally random". Decreasing the
                                   scanner's sensitivity increases the
                                   likelihood that a given string will be
-                                  identified as suspicious.  [default: 25]
+                                  identified as suspicious.  [default: 75]
 
   -b64, --b64-entropy-score TEXT  [DEPRECATED] Use `--entropy-sensitivity`.
                                   Modify the base64 entropy score. If a value

--- a/README.md
+++ b/README.md
@@ -54,9 +54,6 @@ Options:
 
   --entropy / --no-entropy        Enable entropy checks.  [default: True]
   --regex / --no-regex            Enable high signal regexes checks.
-                                  [default: False]
-  --scan-filenames / --no-scan-filenames            
-                                  Check the names of files being scanned as well as their contents.
                                   [default: True]
 
   -ip, --include-path-patterns TEXT
@@ -76,6 +73,14 @@ Options:
                                   provided (default), no Git object paths are
                                   excluded unless effectively excluded via the
                                   --include-path-patterns option.
+
+  -of, --output-format [json|compact|text]
+                                  Specify the format in which the output needs
+                                  to be generated `--output-format
+                                  json/compact/text`. Either `json`, `compact`
+                                  or `text` can be specified. If not provided
+                                  (default) the output will be generated in
+                                  `text` format.
 
   -xe, --exclude-entropy-patterns TEXT
                                   Specify a regular expression which matches
@@ -99,12 +104,6 @@ Options:
                                   directory under this one. This will help
                                   with keeping the results of individual runs
                                   of tartufo separated.
-
-  -of, --output-format TEXT       Specify the format in which the output needs
-                                  to be generated `--output-format json/compact/text`.
-                                  Either `json`, `compact` or `text` can be specified.
-                                  If not provided (default) the output will be generated
-                                  in `text` format.
 
   --git-rules-repo TEXT           A file path, or git URL, pointing to a git
                                   repository containing regex rules to be used
@@ -134,31 +133,42 @@ Options:
                                   Enable or disable timestamps in logging
                                   messages.  [default: True]
 
-  -b64, --b64-entropy-score FLOAT
-                                  Modify the base64 entropy score. If you
-                                  specify a value greater than the default,
-                                  tartufo lists higher entropy base64 strings
-                                  (longer or more randomized strings). A lower
-                                  value lists lower entropy base64 strings
-                                  (shorter or less randomized strings).
-                                  [default: 4.5]
+  --entropy-sensitivity INTEGER RANGE
+                                  Modify entropy detection sensitivity. This
+                                  is expressed as on a scale of 0 to 100,
+                                  where 0 means "totally random" and 100 means
+                                  "totally nonrandom". Increasing the
+                                  scanner's sensitivity increases the
+                                  likelihood that a given string will be
+                                  identified as suspicious.  [default: 25]
 
-  -hex, --hex-entropy-score FLOAT
-                                  Modify the hexadecimal entropy score. If you
-                                  specify a value greater than the default,
-                                  tartufo lists higher entropy hexadecimal
-                                  strings (longer or more randomized strings).
-                                  A lower value lists lower entropy
-                                  hexadecimal strings (shorter or less
-                                  randomized strings).  [default: 3.0]
+  -b64, --b64-entropy-score TEXT  [DEPRECATED] Use `--entropy-sensitivity`.
+                                  Modify the base64 entropy score. If a value
+                                  greater than the default (4.5 in a range of
+                                  0.0-6.0) is specified, tartufo lists higher
+                                  entropy base64 strings (longer or more
+                                  randomized strings. A lower value lists
+                                  lower entropy base64 strings (shorter or
+                                  less randomized strings).
+
+  -hex, --hex-entropy-score TEXT  [DEPRECATED] Use `--entropy-sensitivity`.
+                                  Modify the hexadecimal entropy score. If a
+                                  value greater than the default (3.0 in a
+                                  range of 0.0-4.0) is specified, tartufo
+                                  lists higher entropy hexadecimal strings
+                                  (longer or more randomized strings). A lower
+                                  value lists lower entropy hexadecimal
+                                  strings (shorter or less randomized
+                                  strings).
 
   -V, --version                   Show the version and exit.
   -h, --help                      Show this message and exit.
 
 Commands:
+  scan-folder       Scan a folder.
+  scan-remote-repo  Automatically clone and scan a remote git repository.
   pre-commit        Scan staged changes in a pre-commit hook.
   scan-local-repo   Scan a repository already cloned to your local system.
-  scan-remote-repo  Automatically clone and scan a remote git repository.
 
 ```
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -105,7 +105,7 @@ uvloop = ["uvloop (>=0.15.2)"]
 name = "cached-property"
 version = "1.5.2"
 description = "A decorator for caching properties in classes."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -963,7 +963,7 @@ docs = ["recommonmark", "sphinx", "sphinx-click", "sphinx-rtd-theme", "sphinxcon
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "9f04bb49f0605b7c6606f6f15640a2d3231eaa01506afbe253f32521b5a669b5"
+content-hash = "1a280535a4c13f09a63bf8763ab5fc32b1975c7fd4eacc06dc7526373f9099f7"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ sphinx-click = {version = "^2.5.0", optional = true}
 sphinx-rtd-theme = {version = "^0.5.0", optional = true}
 sphinxcontrib-spelling = {version = "^5.4.0", optional = true}
 tomlkit = "^0.7.2"
+cached-property = "^1.5.2"
 
 [tool.poetry.dev-dependencies]
 black = {version = "21.5b2", allow-prereleases = true, markers = "platform_python_implementation == 'CPython'"}

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -201,7 +201,7 @@ class TartufoCLI(click.MultiCommand):
     help="Enable or disable timestamps in logging messages.",
 )
 @click.option(
-    "--sensitivity",
+    "--entropy-sensitivity",
     type=click.IntRange(0, 100),
     default=25,
     show_default=True,
@@ -213,7 +213,7 @@ class TartufoCLI(click.MultiCommand):
 @click.option(
     "-b64",
     "--b64-entropy-score",
-    help="""[DEPRECATED] Use `--sensitivity`. Modify the base64 entropy score. If
+    help="""[DEPRECATED] Use `--entropy-sensitivity`. Modify the base64 entropy score. If
     a value greater than the default (4.5 in a range of 0.0-6.0) is specified,
     tartufo lists higher entropy base64 strings (longer or more randomized strings.
     A lower value lists lower entropy base64 strings (shorter or less randomized
@@ -222,7 +222,7 @@ class TartufoCLI(click.MultiCommand):
 @click.option(
     "-hex",
     "--hex-entropy-score",
-    help="""[DEPRECATED] Use `--sensitivity`. Modify the hexadecimal entropy score.
+    help="""[DEPRECATED] Use `--entropy-sensitivity`. Modify the hexadecimal entropy score.
     If a value greater than the default (3.0 in a range of 0.0-4.0) is specified,
     tartufo lists higher entropy hexadecimal strings (longer or more randomized
     strings). A lower value lists lower entropy hexadecimal strings (shorter or less

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -203,11 +203,11 @@ class TartufoCLI(click.MultiCommand):
 @click.option(
     "--entropy-sensitivity",
     type=click.IntRange(0, 100),
-    default=25,
+    default=75,
     show_default=True,
     help="""Modify entropy detection sensitivity. This is expressed as on a scale
-    of 0 to 100, where 0 means "totally random" and 100 means "totally nonrandom".
-    Increasing the scanner's sensitivity increases the likelihood that a given
+    of 0 to 100, where 0 means "totally nonrandom" and 100 means "totally random".
+    Decreasing the scanner's sensitivity increases the likelihood that a given
     string will be identified as suspicious.""",
 )
 @click.option(

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -201,24 +201,32 @@ class TartufoCLI(click.MultiCommand):
     help="Enable or disable timestamps in logging messages.",
 )
 @click.option(
+    "--sensitivity",
+    type=click.IntRange(0, 100),
+    default=25,
+    show_default=True,
+    help="""Modify entropy detection sensitivity. This is expressed as the probability
+    (between 0 and 100) a given string is *not* random and should be ignored.
+    A higher value increases the likelihood a string will be considered suspicious
+    and result in a finding.""",
+)
+@click.option(
     "-b64",
     "--b64-entropy-score",
-    default=4.5,
-    show_default=True,
-    help="Modify the base64 entropy score. If a value greater than the default is "
-    "specified, tartufo lists higher entropy base64 strings (longer or more randomized "
-    "strings). A lower value lists lower entropy base64 strings (shorter or less "
-    "randomized strings).",
+    help="""[DEPRECATED] Use `--sensitivity`. Modify the base64 entropy score. If
+    a value greater than the default (4.5 in a range of 0.0-6.0) is specified,
+    tartufo lists higher entropy base64 strings (longer or more randomized strings.
+    A lower value lists lower entropy base64 strings (shorter or less randomized
+    strings).""",
 )
 @click.option(
     "-hex",
     "--hex-entropy-score",
-    default=3.0,
-    show_default=True,
-    help="Modify the hexadecimal entropy score. If a value greater than the default is "
-    "specified, tartufo lists higher entropy hexadecimal strings (longer or more randomized "
-    "strings). A lower value lists lower entropy hexadecimal strings (shorter or less "
-    "randomized strings).",
+    help="""[DEPRECATED] Use `--sensitivity`. Modify the hexadecimal entropy score.
+    If a value greater than the default (3.0 in a range of 0.0-4.0) is specified,
+    tartufo lists higher entropy hexadecimal strings (longer or more randomized
+    strings). A lower value lists lower entropy hexadecimal strings (shorter or less
+    randomized strings).""",
 )
 # The first positional argument here would be a hard-coded version, hence the `None`
 @click.version_option(None, "-V", "--version")

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -205,10 +205,10 @@ class TartufoCLI(click.MultiCommand):
     type=click.IntRange(0, 100),
     default=25,
     show_default=True,
-    help="""Modify entropy detection sensitivity. This is expressed as the probability
-    (between 0 and 100) a given string is *not* random and should be ignored.
-    A higher value increases the likelihood a string will be considered suspicious
-    and result in a finding.""",
+    help="""Modify entropy detection sensitivity. This is expressed as a percentage
+    (between 0 and 100) that represents the amount of entropy in a given string
+    relative to a theoretical maximum. Strings that have higher entropy (are more
+    random) than this threshhold will result in findings.""",
 )
 @click.option(
     "-b64",

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -205,10 +205,10 @@ class TartufoCLI(click.MultiCommand):
     type=click.IntRange(0, 100),
     default=25,
     show_default=True,
-    help="""Modify entropy detection sensitivity. This is expressed as a percentage
-    (between 0 and 100) that represents the amount of entropy in a given string
-    relative to a theoretical maximum. Strings that have higher entropy (are more
-    random) than this threshhold will result in findings.""",
+    help="""Modify entropy detection sensitivity. This is expressed as on a scale
+    of 0 to 100, where 0 means "totally random" and 100 means "totally nonrandom".
+    Increasing the scanner's sensitivity increases the likelihood that a given
+    string will be identified as suspicious.""",
 )
 @click.option(
     "-b64",

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -153,10 +153,10 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
         # in findings. We convert this from "sensitivity" (0-100) which is inverted
         # so that intuitively "more sensitive" means "more likely to flag a given
         # string as suspicious."
-        if self.global_options.sensitivity is None:
+        if self.global_options.entropy_sensitivity is None:
             sensitivity = 25
         else:
-            sensitivity = self.global_options.sensitivity
+            sensitivity = self.global_options.entropy_sensitivity
         entropy_score = float(100 - sensitivity) / 100.0
 
         # We now compute an effective score for each type of entropy string by
@@ -171,13 +171,13 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
         # these representation-specific scores directly (but complain about it).
         if self.global_options.hex_entropy_score:
             warnings.warn(
-                "--hex-entropy-score is deprecated. Use --sensitivity instead."
+                "--hex-entropy-score is deprecated. Use --entropy-sensitivity instead."
             )
             self._hex_entropy_score = self.global_options.hex_entropy_score
 
         if self.global_options.b64_entropy_score:
             warnings.warn(
-                "--b64-entropy-score is deprecated. Use --sensitivity instead."
+                "--b64-entropy-score is deprecated. Use --entropy-sensitivity instead."
             )
             self._b64_entropy_score = self.global_options.b64_entropy_score
 

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -19,6 +19,7 @@ from typing import (
     Set,
     Tuple,
 )
+import warnings
 
 import click
 import git

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -171,13 +171,15 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
         # these representation-specific scores directly (but complain about it).
         if self.global_options.hex_entropy_score:
             warnings.warn(
-                "--hex-entropy-score is deprecated. Use --entropy-sensitivity instead."
+                "--hex-entropy-score is deprecated. Use --entropy-sensitivity instead.",
+                DeprecationWarning,
             )
             self._hex_entropy_score = self.global_options.hex_entropy_score
 
         if self.global_options.b64_entropy_score:
             warnings.warn(
-                "--b64-entropy-score is deprecated. Use --entropy-sensitivity instead."
+                "--b64-entropy-score is deprecated. Use --entropy-sensitivity instead.",
+                DeprecationWarning,
             )
             self._b64_entropy_score = self.global_options.b64_entropy_score
 

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -184,6 +184,18 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
             self._b64_entropy_score = self.global_options.b64_entropy_score
 
     @property
+    def hex_entropy_limit(self) -> float:
+        """Returns low limit for suspicious hexadecimal encodings"""
+
+        return self._hex_entropy_score
+
+    @property
+    def b64_entropy_limit(self) -> float:
+        """Returns low limit for suspicious base64 encodings"""
+
+        return self._b64_entropy_score
+
+    @property
     def completed(self) -> bool:
         """Return True if scan has completed
 
@@ -457,12 +469,12 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
 
                 for string in b64_strings:
                     yield from self.evaluate_entropy_string(
-                        chunk, line, string, BASE64_CHARS, self._b64_entropy_score
+                        chunk, line, string, BASE64_CHARS, self.b64_entropy_limit
                     )
 
                 for string in hex_strings:
                     yield from self.evaluate_entropy_string(
-                        chunk, line, string, HEX_CHARS, self._hex_entropy_score
+                        chunk, line, string, HEX_CHARS, self.hex_entropy_limit
                     )
 
     def evaluate_entropy_string(

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -26,6 +26,7 @@ class GlobalOptions:
         "output_format",
         "b64_entropy_score",
         "hex_entropy_score",
+        "sensitivity",
     )
     rules: Tuple[TextIO, ...]
     default_regexes: bool
@@ -46,6 +47,7 @@ class GlobalOptions:
     output_format: Optional[str]
     b64_entropy_score: float
     hex_entropy_score: float
+    sensitivity: int
 
 
 @dataclass

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -26,7 +26,7 @@ class GlobalOptions:
         "output_format",
         "b64_entropy_score",
         "hex_entropy_score",
-        "sensitivity",
+        "entropy_sensitivity",
     )
     rules: Tuple[TextIO, ...]
     default_regexes: bool
@@ -47,7 +47,7 @@ class GlobalOptions:
     output_format: Optional[str]
     b64_entropy_score: float
     hex_entropy_score: float
-    sensitivity: int
+    entropy_sensitivity: int
 
 
 @dataclass

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -573,23 +573,21 @@ class EntropyTests(ScannerTestCase):
         issues = list(self.scanner.scan_entropy(self.chunk))
         self.assertEqual(len(issues), 0)
 
-    # pylint: disable=protected-access
     def test_sensitivity_low_end_calculation(self):
         self.options.entropy_sensitivity = 0
         test_scanner = TestScanner(self.options)
 
         # 0% sensitivity means entropy rate must equal bit rate
-        self.assertEqual(test_scanner._b64_entropy_score, 6.0)
-        self.assertEqual(test_scanner._hex_entropy_score, 4.0)
+        self.assertEqual(test_scanner.b64_entropy_limit, 6.0)
+        self.assertEqual(test_scanner.hex_entropy_limit, 4.0)
 
-    # pylint: disable=protected-access
     def test_sensitivity_high_end_calculation(self):
         self.options.entropy_sensitivity = 100
         test_scanner = TestScanner(self.options)
 
         # 100% sensitivity means required entropy rate will be zero
-        self.assertEqual(test_scanner._b64_entropy_score, 0.0)
-        self.assertEqual(test_scanner._hex_entropy_score, 0.0)
+        self.assertEqual(test_scanner.b64_entropy_limit, 0.0)
+        self.assertEqual(test_scanner.hex_entropy_limit, 0.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -574,7 +574,7 @@ class EntropyTests(ScannerTestCase):
         self.assertEqual(len(issues), 0)
 
     def test_sensitivity_low_end_calculation(self):
-        self.options.sensitivity = 0
+        self.options.entropy_sensitivity = 0
         scanner = TestScanner(self.options)
 
         # 0% sensitivity means entropy rate must equal bit rate
@@ -582,7 +582,7 @@ class EntropyTests(ScannerTestCase):
         self.assertEqual(scanner._hex_entropy_score, 4.0)
 
     def test_sensitivity_high_end_calculation(self):
-        self.options.sensitivity = 100
+        self.options.entropy_sensitivity = 100
         scanner = TestScanner(self.options)
 
         # 100% sensitivity means required entropy rate will be zero

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -578,16 +578,24 @@ class EntropyTests(ScannerTestCase):
         test_scanner = TestScanner(self.options)
 
         # 0% sensitivity means entropy rate must equal bit rate
-        self.assertEqual(test_scanner.b64_entropy_limit, 6.0)
-        self.assertEqual(test_scanner.hex_entropy_limit, 4.0)
+        self.assertEqual(test_scanner.b64_entropy_limit, 0.0)
+        self.assertEqual(test_scanner.hex_entropy_limit, 0.0)
 
     def test_sensitivity_high_end_calculation(self):
         self.options.entropy_sensitivity = 100
         test_scanner = TestScanner(self.options)
 
         # 100% sensitivity means required entropy rate will be zero
-        self.assertEqual(test_scanner.b64_entropy_limit, 0.0)
-        self.assertEqual(test_scanner.hex_entropy_limit, 0.0)
+        self.assertEqual(test_scanner.b64_entropy_limit, 6.0)
+        self.assertEqual(test_scanner.hex_entropy_limit, 4.0)
+
+    def test_sensitivity_deprecated_overrides(self):
+        self.options.b64_entropy_score = 11.1
+        self.options.hex_entropy_score = 22.2
+        test_scanner = TestScanner(self.options)
+
+        self.assertEqual(test_scanner.b64_entropy_limit, 11.1)
+        self.assertEqual(test_scanner.hex_entropy_limit, 22.2)
 
 
 if __name__ == "__main__":

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -573,21 +573,23 @@ class EntropyTests(ScannerTestCase):
         issues = list(self.scanner.scan_entropy(self.chunk))
         self.assertEqual(len(issues), 0)
 
+    # pylint: disable=protected-access
     def test_sensitivity_low_end_calculation(self):
         self.options.entropy_sensitivity = 0
-        scanner = TestScanner(self.options)
+        test_scanner = TestScanner(self.options)
 
         # 0% sensitivity means entropy rate must equal bit rate
-        self.assertEqual(scanner._b64_entropy_score, 6.0)
-        self.assertEqual(scanner._hex_entropy_score, 4.0)
+        self.assertEqual(test_scanner._b64_entropy_score, 6.0)
+        self.assertEqual(test_scanner._hex_entropy_score, 4.0)
 
+    # pylint: disable=protected-access
     def test_sensitivity_high_end_calculation(self):
         self.options.entropy_sensitivity = 100
-        scanner = TestScanner(self.options)
+        test_scanner = TestScanner(self.options)
 
         # 100% sensitivity means required entropy rate will be zero
-        self.assertEqual(scanner._b64_entropy_score, 0.0)
-        self.assertEqual(scanner._hex_entropy_score, 0.0)
+        self.assertEqual(test_scanner._b64_entropy_score, 0.0)
+        self.assertEqual(test_scanner._hex_entropy_score, 0.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [X] Tests (if applicable)
* [ ] Documentation (if applicable)
* [X] Changelog entry
* [X] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [X] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [X] Yes (backward compatible)
* [ ] No (breaking changes)

## Issue Linking
fixes #265

## What's new?

This PR introduces a new `--entropy-sensitivity` option that replaces `--b64-entropy-score` and `--hex-entropy-score`. The older options are marked "deprecated" and generate warnings when used.

The default sensitivity is exactly the same as it was before, but it is presented differently and applied consistently to both hexadecimal and base64 strings. "Sensitivity" is expressed on a scale of 0 (totally random) to 100 (totally nonrandom) -- the default is 25 -- and intuitively higher sensitivity means more borderline-random strings will be reported as suspicious.

For purposes of minimizing this PR's footprint, the default is applied both in `cli.py` (real world) and in `scanner.py` (because existing unit tests do not specify most options).
