### PR TITLE
Entropy scanning optimizations and base64url support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ Features:
   `--scan-filenames/--no-scan-filenames` flag which allows users to enable or disable file name scanning.
 * [#254](https://github.com/godaddy/tartufo/pull/260) - Changes the default value of
   `--regex/--no-regex` to True.
+* [#273](https://github.com/godaddy/tartufo/inssues/273) - Entropy checking support
+  routines have been rewritten to utilize library abstractions and operate more
+  efficiently while returning effectively identical results.
 
 Misc:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Features:
   option which provides a friendlier way to adjust entropy detection sensitivity.
   This replaces `--b64-entropy-score` and `--hex-entropy-score`, which now are
   marked as deprecated.
+* [#273](https://github.com/godaddy/tartufo/inssues/273) - Entropy checking support
+  routines have been rewritten to utilize library abstractions and operate more
+  efficiently while returning effectively identical results.
+* [#177](https://github.com/godaddy/tartufo/issues/177) -
+  [base64url](https://datatracker.ietf.org/doc/html/rfc4648#section-5) encodings
+  are now recognized and scanned for entropy.
 
 v3.0.0-alpha.1 - 11 November 2021
 ---------------------------------
@@ -33,9 +39,6 @@ Features:
   `--scan-filenames/--no-scan-filenames` flag which allows users to enable or disable file name scanning.
 * [#254](https://github.com/godaddy/tartufo/pull/260) - Changes the default value of
   `--regex/--no-regex` to True.
-* [#273](https://github.com/godaddy/tartufo/inssues/273) - Entropy checking support
-  routines have been rewritten to utilize library abstractions and operate more
-  efficiently while returning effectively identical results.
 
 Misc:
 

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -30,7 +30,7 @@ import pygit2
 from tartufo import config, types, util
 from tartufo.types import BranchNotFoundException, Rule, TartufoException
 
-BASE64_REGEX = re.compile(r"[A-Z0-9+/]+={,2}", re.IGNORECASE)
+BASE64_REGEX = re.compile(r"[A-Z0-9+/_-]+={,2}", re.IGNORECASE)
 HEX_REGEX = re.compile(r"[0-9A-F]+", re.IGNORECASE)
 
 

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -469,11 +469,11 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
             for word in line.split():
                 for string in util.find_strings_by_regex(word, BASE64_REGEX):
                     yield from self.evaluate_entropy_string(
-                        chunk, line, string, BASE64_CHARS, self.b64_entropy_limit
+                        chunk, line, string, self.b64_entropy_limit
                     )
                 for string in util.find_strings_by_regex(word, HEX_REGEX):
                     yield from self.evaluate_entropy_string(
-                        chunk, line, string, HEX_CHARS, self.hex_entropy_limit
+                        chunk, line, string, self.hex_entropy_limit
                     )
 
     def evaluate_entropy_string(

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -487,9 +487,8 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
         Check entropy string using entropy characters and score.
 
         :param chunk: The chunk of data to check
-        :param issues: Issue list to append any strings flagged
+        :param line: Source line containing string of interest
         :param string: String to check
-        :param alphabet_size: How many characters available for representation?
         :param min_entropy_score: Minimum entropy score to flag
         return: Iterator of issues flagged
         """

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -465,6 +465,32 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
         :param chunk: The chunk of data to be scanned
         """
 
+        # If you have thought about this too much :) you might ask yourself,
+        # "can't this produce duplicate findings?" After all, a hexadecimal
+        # encoding uses a strict subset of the base64 alphabet, so any string
+        # that matches HEX_REGEX will match BASE64_REGEX too, and be found by
+        # both inner loops below.
+        #
+        # The reason this doesn't (with default settings) is because the maximum
+        # entropy you can get with a hexadecimal encoding is 4.46. (Hint: you
+        # get maximum entropy if you use every character in the encoding alphabet
+        # exactly the same number of times -- such as once. Such a string would
+        # be 22 characters long. Spelling it out here would generate a finding.)
+        #
+        # By default, `b64_entropy_score` is 4.5, which means it is impossible for
+        # any hexadecimal encoding to trigger a base64 entropy finding. The only
+        # way to make the entropy higher is to add more (unique) characters, but
+        # doing so means the string would no longer be recognized as hexadecimal
+        # encoding; thus it is impossible for anything that could trigger a base64
+        # entropy finding to also trigger a hexadecimal entropy finding (because
+        # such a string won't be recognized by the hex loop).
+        #
+        # It's never been written anywhere that I've found, but this behavior
+        # might explain how the tartufo (and TruffleHog before it) defaults were
+        # chosen -- they are the smallest "roundish" entropy cutoffs you can
+        # choose that are mutually consistent and prevent duplicate findings.
+        # Just a theory.
+
         for line in chunk.contents.split("\n"):
             for word in line.split():
                 for string in util.find_string_encodings(word, BASE64_REGEX):

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -3,6 +3,7 @@ import json
 import os
 import pathlib
 import platform
+import re
 import stat
 import tempfile
 import uuid
@@ -13,6 +14,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Generator,
     Iterable,
     List,
     Optional,
@@ -205,35 +207,24 @@ def extract_commit_metadata(commit: pygit2.Commit, branch_name: str) -> Dict[str
     }
 
 
-def get_strings_of_set(
-    word: str, char_set: Iterable[str], threshold: int = 20
-) -> List[str]:
-    """Split a "word" into a set of "strings", based on a given character set.
+def find_string_encodings(
+    text: str, regex: re.Pattern, threshold: int = 20
+) -> Generator[str, None, None]:
+    """Locate binary encodings in input text
 
-    The returned strings must have a length, at minimum, equal to `threshold`.
-    This is meant for extracting long strings which are likely to be things like
+    Each returned encoding must have a length, at minimum, equal to `threshold`.
+    This is meant to return longer strings which are likely to be things like
     auto-generated passwords, tokens, hashes, etc.
 
-    :param word: The word to be analyzed
-    :param char_set: The set of characters used to compose the strings (i.e. hex)
-    :param threshold: The minimum length for what is accepted as a string
+    :param text: The text string to be analyzed
+    :param regex: A pattern which matches all valid encodings of a given type
+    :param threshold: The minimum acceptable length of an encoding
     """
-    count: int = 0
-    letters: str = ""
-    strings: List[str] = []
 
-    for char in word:
-        if char in char_set:
-            letters += char
-            count += 1
-        else:
-            if count > threshold:
-                strings.append(letters)
-            letters = ""
-            count = 0
-    if count > threshold:
-        strings.append(letters)
-    return strings
+    for match in regex.finditer(text):
+        encoding = match.group()
+        if len(encoding) >= threshold:
+            yield encoding
 
 
 def path_contains_git(path: str) -> bool:

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -205,24 +205,24 @@ def extract_commit_metadata(commit: pygit2.Commit, branch_name: str) -> Dict[str
     }
 
 
-def find_string_encodings(
+def find_strings_by_regex(
     text: str, regex: Pattern, threshold: int = 20
 ) -> Generator[str, None, None]:
-    """Locate binary encodings in input text
+    """Locate strings ("words") of interest in input text
 
-    Each returned encoding must have a length, at minimum, equal to `threshold`.
+    Each returned string must have a length, at minimum, equal to `threshold`.
     This is meant to return longer strings which are likely to be things like
     auto-generated passwords, tokens, hashes, etc.
 
     :param text: The text string to be analyzed
-    :param regex: A pattern which matches all valid encodings of a given type
-    :param threshold: The minimum acceptable length of an encoding
+    :param regex: A pattern which matches all character sequences of interest
+    :param threshold: The minimum acceptable length of a matching string
     """
 
     for match in regex.finditer(text):
-        encoding = match.group()
-        if len(encoding) >= threshold:
-            yield encoding
+        substring = match.group()
+        if len(substring) >= threshold:
+            yield substring
 
 
 def path_contains_git(path: str) -> bool:

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -15,7 +15,6 @@ from typing import (
     Callable,
     Dict,
     Generator,
-    Iterable,
     List,
     Optional,
     Tuple,

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -3,7 +3,6 @@ import json
 import os
 import pathlib
 import platform
-import re
 import stat
 import tempfile
 import uuid

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -207,7 +207,7 @@ def extract_commit_metadata(commit: pygit2.Commit, branch_name: str) -> Dict[str
 
 
 def find_string_encodings(
-    text: str, regex: re.Pattern, threshold: int = 20
+    text: str, regex: Pattern, threshold: int = 20
 ) -> Generator[str, None, None]:
     """Locate binary encodings in input text
 

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -1,4 +1,5 @@
 import re
+import string
 import unittest
 from unittest import mock
 
@@ -425,7 +426,7 @@ class EntropyTests(ScannerTestCase):
     def test_empty_string_has_no_entropy(self):
         self.assertEqual(self.scanner.calculate_entropy(""), 0.0)
 
-    @mock.patch("tartufo.util.find_string_encodings")
+    @mock.patch("tartufo.util.find_strings_by_regex")
     def test_scan_entropy_find_b64_strings_for_every_word_in_diff(
         self, mock_strings: mock.MagicMock
     ):
@@ -444,7 +445,7 @@ class EntropyTests(ScannerTestCase):
 
     @mock.patch("tartufo.scanner.ScannerBase.calculate_entropy")
     @mock.patch("tartufo.scanner.ScannerBase.signature_is_excluded")
-    @mock.patch("tartufo.util.find_string_encodings")
+    @mock.patch("tartufo.util.find_strings_by_regex")
     def test_issues_are_not_created_for_b64_string_excluded_signatures(
         self,
         mock_strings: mock.MagicMock,
@@ -459,7 +460,7 @@ class EntropyTests(ScannerTestCase):
 
     @mock.patch("tartufo.scanner.ScannerBase.calculate_entropy")
     @mock.patch("tartufo.scanner.ScannerBase.signature_is_excluded")
-    @mock.patch("tartufo.util.find_string_encodings")
+    @mock.patch("tartufo.util.find_strings_by_regex")
     def test_issues_are_not_created_for_hex_string_excluded_signatures(
         self,
         mock_strings: mock.MagicMock,
@@ -474,7 +475,7 @@ class EntropyTests(ScannerTestCase):
 
     @mock.patch("tartufo.scanner.ScannerBase.calculate_entropy")
     @mock.patch("tartufo.scanner.ScannerBase.signature_is_excluded")
-    @mock.patch("tartufo.util.find_string_encodings")
+    @mock.patch("tartufo.util.find_strings_by_regex")
     def test_issues_are_created_for_high_entropy_b64_strings(
         self,
         mock_strings: mock.MagicMock,
@@ -491,7 +492,7 @@ class EntropyTests(ScannerTestCase):
 
     @mock.patch("tartufo.scanner.ScannerBase.calculate_entropy")
     @mock.patch("tartufo.scanner.ScannerBase.signature_is_excluded")
-    @mock.patch("tartufo.util.find_string_encodings")
+    @mock.patch("tartufo.util.find_strings_by_regex")
     def test_issues_are_created_for_high_entropy_hex_strings(
         self,
         mock_strings: mock.MagicMock,
@@ -509,7 +510,7 @@ class EntropyTests(ScannerTestCase):
     @mock.patch("tartufo.scanner.ScannerBase.calculate_entropy")
     @mock.patch("tartufo.scanner.ScannerBase.signature_is_excluded")
     @mock.patch("tartufo.scanner.ScannerBase.entropy_string_is_excluded")
-    @mock.patch("tartufo.util.find_string_encodings")
+    @mock.patch("tartufo.util.find_strings_by_regex")
     def test_issues_are_not_created_for_high_entropy_hex_strings_given_entropy_is_excluded(
         self,
         mock_strings: mock.MagicMock,
@@ -527,7 +528,7 @@ class EntropyTests(ScannerTestCase):
     @mock.patch("tartufo.scanner.ScannerBase.calculate_entropy")
     @mock.patch("tartufo.scanner.ScannerBase.signature_is_excluded")
     @mock.patch("tartufo.scanner.ScannerBase.entropy_string_is_excluded")
-    @mock.patch("tartufo.util.find_string_encodings")
+    @mock.patch("tartufo.util.find_strings_by_regex")
     def test_issues_are_not_created_for_low_entropy_b64_strings_given_entropy_is_excluded(
         self,
         mock_strings: mock.MagicMock,
@@ -544,7 +545,7 @@ class EntropyTests(ScannerTestCase):
 
     @mock.patch("tartufo.scanner.ScannerBase.calculate_entropy")
     @mock.patch("tartufo.scanner.ScannerBase.signature_is_excluded")
-    @mock.patch("tartufo.util.find_string_encodings")
+    @mock.patch("tartufo.util.find_strings_by_regex")
     def test_issues_are_not_created_for_low_entropy_b64_strings(
         self,
         mock_strings: mock.MagicMock,
@@ -559,7 +560,7 @@ class EntropyTests(ScannerTestCase):
 
     @mock.patch("tartufo.scanner.ScannerBase.calculate_entropy")
     @mock.patch("tartufo.scanner.ScannerBase.signature_is_excluded")
-    @mock.patch("tartufo.util.find_string_encodings")
+    @mock.patch("tartufo.util.find_strings_by_regex")
     def test_issues_are_not_created_for_low_entropy_hex_strings(
         self,
         mock_strings: mock.MagicMock,
@@ -614,7 +615,7 @@ class EntropyTests(ScannerTestCase):
         # However, it is convenient to use the real thing to avoid errors. Note
         # that representation is case-insensitive so we do not include uppercase
         # letters in this alphabet.
-        alphabet = "0123" "4567" "89ab" "cdef"  # pylint: disable=implicit-str-concat
+        alphabet = string.hexdigits[:16]
         self.assertEqual(self.scanner.calculate_entropy(alphabet), 4.0)
 
     def test_calculate_entropy_maximum_base64(self):
@@ -622,25 +623,7 @@ class EntropyTests(ScannerTestCase):
         # See above. base64 uses 4 characters to represent 3 bytes, so the
         # underlying bit rate is 24 / 4 = 6 bits per character. Unlike above,
         # case matters, so we include both upper- and lowercase letters.
-        alphabet = (
-            "ABCD"
-            "EFGH"
-            "IJKL"
-            "MNOP"
-            "QRST"
-            "UVWX"
-            "YZ"
-            "abcd"
-            "efgh"
-            "ijkl"
-            "mnop"
-            "qrst"
-            "uvwx"
-            "yz"
-            "0123"
-            "4567"
-            "89+/"
-        )
+        alphabet = string.ascii_letters + string.digits + "+/"
         self.assertEqual(self.scanner.calculate_entropy(alphabet), 6.0)
 
 

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -414,19 +414,18 @@ class EntropyTests(ScannerTestCase):
             "ZWVTjPQSdhwRgl204Hc51YCsritMIzn8B=/p9UyeX7xu6KkAGqfm3FJ+oObLDNEva"
         )
         self.assertGreaterEqual(
-            self.scanner.calculate_entropy(random_string, scanner.BASE64_CHARS), 4.5
+            self.scanner.calculate_entropy(random_string),
+            4.5,
         )
 
     def test_calculate_hex_entropy_calculation(self):
         random_string = "b3A0a1FDfe86dcCE945B72"
-        self.assertGreaterEqual(
-            self.scanner.calculate_entropy(random_string, scanner.HEX_CHARS), 3
-        )
+        self.assertGreaterEqual(self.scanner.calculate_entropy(random_string), 3)
 
     def test_empty_string_has_no_entropy(self):
-        self.assertEqual(self.scanner.calculate_entropy("", ""), 0.0)
+        self.assertEqual(self.scanner.calculate_entropy(""), 0.0)
 
-    @mock.patch("tartufo.util.get_strings_of_set")
+    @mock.patch("tartufo.util.find_string_encodings")
     def test_scan_entropy_find_b64_strings_for_every_word_in_diff(
         self, mock_strings: mock.MagicMock
     ):
@@ -434,18 +433,18 @@ class EntropyTests(ScannerTestCase):
         list(self.scanner.scan_entropy(self.chunk))
         mock_strings.assert_has_calls(
             (
-                mock.call("foo", scanner.BASE64_CHARS),
-                mock.call("foo", scanner.HEX_CHARS),
-                mock.call("bar", scanner.BASE64_CHARS),
-                mock.call("bar", scanner.HEX_CHARS),
-                mock.call("asdfqwer", scanner.BASE64_CHARS),
-                mock.call("asdfqwer", scanner.HEX_CHARS),
+                mock.call("foo", scanner.BASE64_REGEX),
+                mock.call("foo", scanner.HEX_REGEX),
+                mock.call("bar", scanner.BASE64_REGEX),
+                mock.call("bar", scanner.HEX_REGEX),
+                mock.call("asdfqwer", scanner.BASE64_REGEX),
+                mock.call("asdfqwer", scanner.HEX_REGEX),
             )
         )
 
     @mock.patch("tartufo.scanner.ScannerBase.calculate_entropy")
     @mock.patch("tartufo.scanner.ScannerBase.signature_is_excluded")
-    @mock.patch("tartufo.util.get_strings_of_set")
+    @mock.patch("tartufo.util.find_string_encodings")
     def test_issues_are_not_created_for_b64_string_excluded_signatures(
         self,
         mock_strings: mock.MagicMock,
@@ -460,7 +459,7 @@ class EntropyTests(ScannerTestCase):
 
     @mock.patch("tartufo.scanner.ScannerBase.calculate_entropy")
     @mock.patch("tartufo.scanner.ScannerBase.signature_is_excluded")
-    @mock.patch("tartufo.util.get_strings_of_set")
+    @mock.patch("tartufo.util.find_string_encodings")
     def test_issues_are_not_created_for_hex_string_excluded_signatures(
         self,
         mock_strings: mock.MagicMock,
@@ -475,7 +474,7 @@ class EntropyTests(ScannerTestCase):
 
     @mock.patch("tartufo.scanner.ScannerBase.calculate_entropy")
     @mock.patch("tartufo.scanner.ScannerBase.signature_is_excluded")
-    @mock.patch("tartufo.util.get_strings_of_set")
+    @mock.patch("tartufo.util.find_string_encodings")
     def test_issues_are_created_for_high_entropy_b64_strings(
         self,
         mock_strings: mock.MagicMock,
@@ -492,7 +491,7 @@ class EntropyTests(ScannerTestCase):
 
     @mock.patch("tartufo.scanner.ScannerBase.calculate_entropy")
     @mock.patch("tartufo.scanner.ScannerBase.signature_is_excluded")
-    @mock.patch("tartufo.util.get_strings_of_set")
+    @mock.patch("tartufo.util.find_string_encodings")
     def test_issues_are_created_for_high_entropy_hex_strings(
         self,
         mock_strings: mock.MagicMock,
@@ -510,7 +509,7 @@ class EntropyTests(ScannerTestCase):
     @mock.patch("tartufo.scanner.ScannerBase.calculate_entropy")
     @mock.patch("tartufo.scanner.ScannerBase.signature_is_excluded")
     @mock.patch("tartufo.scanner.ScannerBase.entropy_string_is_excluded")
-    @mock.patch("tartufo.util.get_strings_of_set")
+    @mock.patch("tartufo.util.find_string_encodings")
     def test_issues_are_not_created_for_high_entropy_hex_strings_given_entropy_is_excluded(
         self,
         mock_strings: mock.MagicMock,
@@ -528,7 +527,7 @@ class EntropyTests(ScannerTestCase):
     @mock.patch("tartufo.scanner.ScannerBase.calculate_entropy")
     @mock.patch("tartufo.scanner.ScannerBase.signature_is_excluded")
     @mock.patch("tartufo.scanner.ScannerBase.entropy_string_is_excluded")
-    @mock.patch("tartufo.util.get_strings_of_set")
+    @mock.patch("tartufo.util.find_string_encodings")
     def test_issues_are_not_created_for_low_entropy_b64_strings_given_entropy_is_excluded(
         self,
         mock_strings: mock.MagicMock,
@@ -545,7 +544,7 @@ class EntropyTests(ScannerTestCase):
 
     @mock.patch("tartufo.scanner.ScannerBase.calculate_entropy")
     @mock.patch("tartufo.scanner.ScannerBase.signature_is_excluded")
-    @mock.patch("tartufo.util.get_strings_of_set")
+    @mock.patch("tartufo.util.find_string_encodings")
     def test_issues_are_not_created_for_low_entropy_b64_strings(
         self,
         mock_strings: mock.MagicMock,
@@ -560,7 +559,7 @@ class EntropyTests(ScannerTestCase):
 
     @mock.patch("tartufo.scanner.ScannerBase.calculate_entropy")
     @mock.patch("tartufo.scanner.ScannerBase.signature_is_excluded")
-    @mock.patch("tartufo.util.get_strings_of_set")
+    @mock.patch("tartufo.util.find_string_encodings")
     def test_issues_are_not_created_for_low_entropy_hex_strings(
         self,
         mock_strings: mock.MagicMock,

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -596,6 +596,7 @@ class EntropyTests(ScannerTestCase):
 
         self.assertEqual(test_scanner.b64_entropy_limit, 11.1)
         self.assertEqual(test_scanner.hex_entropy_limit, 22.2)
+
     def test_calculate_entropy_minimum_calculation(self):
 
         # We already know an empty string trivially has zero entropy.

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -595,6 +595,53 @@ class EntropyTests(ScannerTestCase):
 
         self.assertEqual(test_scanner.b64_entropy_limit, 11.1)
         self.assertEqual(test_scanner.hex_entropy_limit, 22.2)
+    def test_calculate_entropy_minimum_calculation(self):
+
+        # We already know an empty string trivially has zero entropy.
+        # Doing the math, a one-character string also should have zero entropy.
+        self.assertEqual(self.scanner.calculate_entropy("a"), 0.0)
+
+    def test_calculate_entropy_maximum_hexadecimal(self):
+
+        # We reach maximum entropy when every character in the alphabet appears
+        # once in the input string (order doesn't matter). Each character represents
+        # 4 bits (has 2^4 = 16 possible values).
+        #
+        # Try to avoid causing a finding ourselves. :)
+        #
+        # Note there is no requirement that the test alphabet actually is the
+        # same as the hexadecimal representation, as long as the size is identical.
+        # However, it is convenient to use the real thing to avoid errors. Note
+        # that representation is case-insensitive so we do not include uppercase
+        # letters in this alphabet.
+        alphabet = "0123" "4567" "89ab" "cdef"  # pylint: disable=implicit-str-concat
+        self.assertEqual(self.scanner.calculate_entropy(alphabet), 4.0)
+
+    def test_calculate_entropy_maximum_base64(self):
+
+        # See above. base64 uses 4 characters to represent 3 bytes, so the
+        # underlying bit rate is 24 / 4 = 6 bits per character. Unlike above,
+        # case matters, so we include both upper- and lowercase letters.
+        alphabet = (
+            "ABCD"
+            "EFGH"
+            "IJKL"
+            "MNOP"
+            "QRST"
+            "UVWX"
+            "YZ"
+            "abcd"
+            "efgh"
+            "ijkl"
+            "mnop"
+            "qrst"
+            "uvwx"
+            "yz"
+            "0123"
+            "4567"
+            "89+/"
+        )
+        self.assertEqual(self.scanner.calculate_entropy(alphabet), 6.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -385,21 +385,29 @@ class GeneralUtilTests(unittest.TestCase):
 
     def test_find_string_encodings_recognizes_hexadecimal(self):
 
-        foo = """
+        sample_name_that_pylint_likes = """
         1111111111fffffCCCCC This is valid hexadecimal
         g111111111fffffCCCCC This is not because "g" is not in alphabet
         """
 
-        strings = list(util.find_string_encodings(foo, scanner.HEX_REGEX, 20))
+        strings = list(
+            util.find_string_encodings(
+                sample_name_that_pylint_likes, scanner.HEX_REGEX, 20
+            )
+        )
         self.assertEqual(strings, ["1111111111fffffCCCCC"])
 
     def test_find_string_encodings_recognizes_base64(self):
 
-        foo = """
+        sample_name_that_pylint_likes = """
         111111111+ffffCCCC== This is valid base64
         @111111111+ffffCCCC= This is not because "@" is not in alphabet
         _111111111+ffffCCCC= This is not because "_" is not in alphabet
         """
 
-        strings = list(util.find_string_encodings(foo, scanner.BASE64_REGEX, 20))
+        strings = list(
+            util.find_string_encodings(
+                sample_name_that_pylint_likes, scanner.BASE64_REGEX, 20
+            )
+        )
         self.assertEqual(strings, ["111111111+ffffCCCC=="])

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -382,3 +382,24 @@ class GeneralUtilTests(unittest.TestCase):
             util.find_string_encodings("w.asdf.q", re.compile(r"[asdfqwer]+"), 3)
         )
         self.assertEqual(strings, ["asdf"])
+
+    def test_find_string_encodings_recognizes_hexadecimal(self):
+
+        foo = """
+        1111111111fffffCCCCC This is valid hexadecimal
+        g111111111fffffCCCCC This is not because "g" is not in alphabet
+        """
+
+        strings = list(util.find_string_encodings(foo, scanner.HEX_REGEX, 20))
+        self.assertEqual(strings, ["1111111111fffffCCCCC"])
+
+    def test_find_string_encodings_recognizes_base64(self):
+
+        foo = """
+        111111111+ffffCCCC== This is valid base64
+        @111111111+ffffCCCC= This is not because "@" is not in alphabet
+        _111111111+ffffCCCC= This is not because "_" is not in alphabet
+        """
+
+        strings = list(util.find_string_encodings(foo, scanner.BASE64_REGEX, 20))
+        self.assertEqual(strings, ["111111111+ffffCCCC=="])

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -371,43 +371,37 @@ class GeneralUtilTests(unittest.TestCase):
         util.generate_signature("foo", "bar")
         mock_hash.assert_called_once_with(b"foo$$bar")
 
-    def test_find_string_encodings_splits_string_by_chars_outside_charset(self):
+    def test_find_strings_by_regex_splits_string_by_chars_outside_charset(self):
         strings = list(
-            util.find_string_encodings("asdf.qwer", re.compile(r"[asdfqwer]+"), 1)
+            util.find_strings_by_regex("asdf.qwer", re.compile(r"[asdfqwer]+"), 1)
         )
         self.assertEqual(strings, ["asdf", "qwer"])
 
-    def test_find_string_encodings_will_not_return_strings_below_threshold_length(self):
+    def test_find_strings_by_regex_will_not_return_strings_below_threshold_length(self):
         strings = list(
-            util.find_string_encodings("w.asdf.q", re.compile(r"[asdfqwer]+"), 3)
+            util.find_strings_by_regex("w.asdf.q", re.compile(r"[asdfqwer]+"), 3)
         )
         self.assertEqual(strings, ["asdf"])
 
-    def test_find_string_encodings_recognizes_hexadecimal(self):
+    def test_find_strings_by_regex_recognizes_hexadecimal(self):
 
-        sample_name_that_pylint_likes = """
+        sample_input = """
         1111111111fffffCCCCC This is valid hexadecimal
         g111111111fffffCCCCC This is not because "g" is not in alphabet
         """
 
-        strings = list(
-            util.find_string_encodings(
-                sample_name_that_pylint_likes, scanner.HEX_REGEX, 20
-            )
-        )
+        strings = list(util.find_strings_by_regex(sample_input, scanner.HEX_REGEX, 20))
         self.assertEqual(strings, ["1111111111fffffCCCCC"])
 
-    def test_find_string_encodings_recognizes_base64(self):
+    def test_find_strings_by_regex_recognizes_base64(self):
 
-        sample_name_that_pylint_likes = """
+        sample_input = """
         111111111+ffffCCCC== This is valid base64
         @111111111+ffffCCCC= This is not because "@" is not in alphabet
         _111111111+ffffCCCC= This is not because "_" is not in alphabet
         """
 
         strings = list(
-            util.find_string_encodings(
-                sample_name_that_pylint_likes, scanner.BASE64_REGEX, 20
-            )
+            util.find_strings_by_regex(sample_input, scanner.BASE64_REGEX, 20)
         )
         self.assertEqual(strings, ["111111111+ffffCCCC=="])

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -371,10 +371,14 @@ class GeneralUtilTests(unittest.TestCase):
         util.generate_signature("foo", "bar")
         mock_hash.assert_called_once_with(b"foo$$bar")
 
-    def test_get_strings_of_set_splits_string_by_chars_outside_charset(self):
-        strings = util.get_strings_of_set("asdf.qwer", "asdfqwer", 1)
+    def test_find_string_encodings_splits_string_by_chars_outside_charset(self):
+        strings = list(
+            util.find_string_encodings("asdf.qwer", re.compile(r"[asdfqwer]+"), 1)
+        )
         self.assertEqual(strings, ["asdf", "qwer"])
 
-    def test_get_strings_of_set_will_not_return_strings_below_threshold_length(self):
-        strings = util.get_strings_of_set("w.asdf.q", "asdfqwer", 3)
+    def test_find_string_encodings_will_not_return_strings_below_threshold_length(self):
+        strings = list(
+            util.find_string_encodings("w.asdf.q", re.compile(r"[asdfqwer]+"), 3)
+        )
         self.assertEqual(strings, ["asdf"])

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -398,10 +398,34 @@ class GeneralUtilTests(unittest.TestCase):
         sample_input = """
         111111111+ffffCCCC== This is valid base64
         @111111111+ffffCCCC= This is not because "@" is not in alphabet
-        _111111111+ffffCCCC= This is not because "_" is not in alphabet
         """
 
         strings = list(
             util.find_strings_by_regex(sample_input, scanner.BASE64_REGEX, 20)
         )
         self.assertEqual(strings, ["111111111+ffffCCCC=="])
+
+    def test_find_strings_by_regex_recognizes_base64url(self):
+
+        sample_input = """
+        111111111-ffffCCCC== This is valid base64url
+        @111111111-ffffCCCC= This is not because "@" is not in alphabet
+        """
+
+        strings = list(
+            util.find_strings_by_regex(sample_input, scanner.BASE64_REGEX, 20)
+        )
+        self.assertEqual(strings, ["111111111-ffffCCCC=="])
+
+    def test_find_strings_by_regex_recognizes_mutant_base64(self):
+
+        sample_input = """
+        +111111111-ffffCCCC= Can't mix + and - but both are in regex
+        111111111111111111111== Not a valid length but we don't care
+        ==111111111111111111 Not recognized, = can only be at the end
+        """
+
+        strings = list(
+            util.find_strings_by_regex(sample_input, scanner.BASE64_REGEX, 20)
+        )
+        self.assertEqual(strings, ["+111111111-ffffCCCC=", "111111111111111111111=="])


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [X] Tests (if applicable)
* [ ] Documentation (if applicable)
* [X] Changelog entry
* [X] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [X] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [X] Yes (backward compatible) -- with minor/rare corner cases noted below
* [ ] No (breaking changes)


## Issue Linking

closes #177 
closes #273

## What's new?

Several key components have been rewritten for better performance and improved maintainability:

* `get_strings_of_set()` has been replaced with `find_string_encodings()` -- Previously we performed matching ourselves, a character at a time. I'm betting a standard regex will be at least as or more efficient. It's also more accurate; in particular the base64 pad character `=` now is allowed only at the end of an encoding, as specified by RFC4648.
* `calculate_entropy()` -- Previously we used the encoding alphabet (unnecessarily) as a loop range, and scanned the input data once for every character in the alphabet. Now we scan the input once and use a Counter to generate probability data.
* `evaluate_entropy_string()` no longer requires the encoding alphabet as input
* `scan_entropy()` was reorganized to avoid buffering intermediate results
* `BASE64_CHARS` and `HEX_CHARS` have been replaced by `BASE64_REGEX` and `HEX_REGEX` respectively.
* Finally, `BASE64_REGEX` has been extended to include `-` and `_` so it discovers base64url strings in addition to base64 strings.

All unit tests pass after only changes to fix up call signatures. Possible regressions are these, none of which are expected to appear in real life:
* A string containing `=` in the middle would have been recognized as base64 but now it will be recognized as two base64 strings (the first ending with the `=` and the second containing the remainder of the string). `=` is not allowed to appear in a base64 (or base64url) string except at the end.
* A base64 string adjacent to either `-` or `_` will now be recognized as a longer string containing those characters. These are not valid base64 but are valid base64url and the scanner does not distinguish between the two (or a mutant combination of both of them).