### PR TITLE
Removing --include-paths and --exclude-paths flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Bug fixes:
   Versions v2.8.0 and later claimed the branch did not exist, even if it did.
   This option now works correctly.
 
+Misc:
+
+* [#255](https://github.com/godaddy/tartufo/issues/255) -- Removed deprecated flags 
+  --include-paths and --exclude-paths
+
 v2.9.0 - 19 October 2021
 ------------------------
 

--- a/README.md
+++ b/README.md
@@ -58,16 +58,6 @@ Options:
   --regex / --no-regex            Enable high signal regexes checks.
                                   [default: False]
 
-  -i, --include-paths FILENAME    [DEPRECATED] Use `--include-path-patterns`.
-                                  File with regular expressions (one per
-                                  line), at least one of which must match a
-                                  Git object path in order for it to be
-                                  scanned; lines starting with '#' are treated
-                                  as comments and are ignored. If empty or not
-                                  provided (default), all Git object paths are
-                                  included unless otherwise excluded via the
-                                  --exclude-paths option.
-
   -ip, --include-path-patterns TEXT
                                   Specify a regular expression which matches
                                   Git object paths to include in the scan.
@@ -76,16 +66,6 @@ Options:
                                   provided (default), all Git object paths are
                                   included unless otherwise excluded via the
                                   --exclude-path-patterns option.
-
-  -x, --exclude-paths FILENAME    [DEPRECATED] Use `--exclude-path-patterns`.
-                                  File with regular expressions (one per
-                                  line), none of which may match a Git object
-                                  path in order for it to be scanned; lines
-                                  starting with '#' are treated as comments
-                                  and are ignored. If empty or not provided
-                                  (default), no Git object paths are excluded
-                                  unless effectively excluded via the
-                                  --include-paths option.
 
   -xp, --exclude-path-patterns TEXT
                                   Specify a regular expression which matches

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -84,17 +84,6 @@ class TartufoCLI(click.MultiCommand):
     help="Enable high signal regexes checks.",
 )
 @click.option(
-    "-i",
-    "--include-paths",
-    type=click.File("r"),
-    help="""[DEPRECATED] Use `--include-path-patterns`. File with regular
-    expressions (one per line), at least one of which must match a Git object
-    path in order for it to be scanned; lines starting with '#' are treated as
-    comments and are ignored. If empty or not provided (default), all Git object
-    paths are included unless otherwise excluded via the --exclude-paths
-    option.""",
-)
-@click.option(
     "-ip",
     "--include-path-patterns",
     multiple=True,
@@ -103,16 +92,6 @@ class TartufoCLI(click.MultiCommand):
     multiple patterns. If not provided (default), all Git object paths are
     included unless otherwise excluded via the --exclude-path-patterns
     option.""",
-)
-@click.option(
-    "-x",
-    "--exclude-paths",
-    type=click.File("r"),
-    help="""[DEPRECATED] Use `--exclude-path-patterns`. File with regular
-    expressions (one per line), none of which may match a Git object path in
-    order for it to be scanned; lines starting with '#' are treated as comments
-    and are ignored. If empty or not provided (default), no Git object paths are
-    excluded unless effectively excluded via the --include-paths option.""",
 )
 @click.option(
     "-xp",

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -6,7 +6,6 @@ import logging
 import math
 import pathlib
 import re
-import warnings
 from functools import lru_cache
 from typing import (
     Any,
@@ -166,13 +165,6 @@ class ScannerBase(abc.ABC):
         if self._included_paths is None:
             self.logger.info("Initializing included paths")
             patterns = list(self.global_options.include_path_patterns or ())
-            if self.global_options.include_paths:
-                warnings.warn(
-                    "--include-paths is deprecated and will be removed in v3.0. Use --include-path-patterns instead.",
-                    DeprecationWarning,
-                )
-                patterns += self.global_options.include_paths.readlines()
-                self.global_options.include_paths.close()
             self._included_paths = (
                 config.compile_path_rules(set(patterns)) if patterns else []
             )
@@ -205,13 +197,6 @@ class ScannerBase(abc.ABC):
         if self._excluded_paths is None:
             self.logger.info("Initializing excluded paths")
             patterns = list(self.global_options.exclude_path_patterns or ())
-            if self.global_options.exclude_paths:
-                warnings.warn(
-                    "--exclude-paths is deprecated and will be removed in v3.0. Use --exclude-path-patterns instead.",
-                    DeprecationWarning,
-                )
-                patterns += self.global_options.exclude_paths.readlines()
-                self.global_options.exclude_paths.close()
             self._excluded_paths = (
                 config.compile_path_rules(set(patterns)) if patterns else []
             )

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -12,9 +12,7 @@ class GlobalOptions:
         "default_regexes",
         "entropy",
         "regex",
-        "include_paths",
         "include_path_patterns",
-        "exclude_paths",
         "exclude_path_patterns",
         "exclude_entropy_patterns",
         "exclude_signatures",
@@ -34,9 +32,7 @@ class GlobalOptions:
     default_regexes: bool
     entropy: bool
     regex: bool
-    include_paths: Optional[TextIO]
     include_path_patterns: Tuple[str, ...]
-    exclude_paths: Optional[TextIO]
     exclude_path_patterns: Tuple[str, ...]
     exclude_entropy_patterns: Tuple[str, ...]
     exclude_signatures: Tuple[str, ...]

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -170,13 +170,10 @@ class IncludeExcludePathsTests(ScannerTestCase):
     def test_include_paths_are_calculated_if_specified(
         self, mock_compile: mock.MagicMock
     ):
-        mock_include = mock.MagicMock()
-        mock_include.readlines.return_value = ["bar"]
-        self.options.include_paths = mock_include
         self.options.include_path_patterns = ("foo",)
         test_scanner = TestScanner(self.options)
         test_scanner.included_paths  # pylint: disable=pointless-statement
-        mock_compile.assert_called_once_with({"foo", "bar"})
+        mock_compile.assert_called_once_with({"foo"})
 
     @mock.patch("tartufo.config.compile_path_rules")
     def test_populated_excluded_paths_list_does_not_recompute(
@@ -195,13 +192,10 @@ class IncludeExcludePathsTests(ScannerTestCase):
     def test_exclude_paths_are_calculated_if_specified(
         self, mock_compile: mock.MagicMock
     ):
-        mock_exclude = mock.MagicMock()
-        mock_exclude.readlines.return_value = ["Pipfile.lock\n"]
-        self.options.exclude_paths = mock_exclude
         self.options.exclude_path_patterns = ("foo",)
         test_scanner = TestScanner(self.options)
         test_scanner.excluded_paths  # pylint: disable=pointless-statement
-        mock_compile.assert_called_once_with({"foo", "Pipfile.lock\n"})
+        mock_compile.assert_called_once_with({"foo"})
 
     def test_should_scan_treats_included_paths_as_exclusive(self):
         test_scanner = TestScanner(self.options)

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -62,7 +62,7 @@ class RepoLoadTests(ScannerTestCase):
     def test_extra_inclusions_get_added(self, mock_load: mock.MagicMock):
         mock_load.return_value = (
             self.data_dir / "pyproject.toml",
-            {"include_paths": "include-files", "include_path_patterns": ("foo/",)},
+            {"include_path_patterns": ("foo/",)},
         )
         test_scanner = scanner.GitRepoScanner(
             self.global_options, self.git_options, str(self.data_dir)
@@ -70,7 +70,7 @@ class RepoLoadTests(ScannerTestCase):
         test_scanner.load_repo("../tartufo")
         self.assertCountEqual(
             test_scanner.included_paths,
-            [re.compile("foo/"), re.compile("tartufo/"), re.compile("scripts/")],
+            [re.compile("foo/")],
         )
 
     @mock.patch("git.Repo", new=mock.MagicMock())
@@ -78,7 +78,7 @@ class RepoLoadTests(ScannerTestCase):
     def test_extra_exclusions_get_added(self, mock_load: mock.MagicMock):
         mock_load.return_value = (
             self.data_dir / "pyproject.toml",
-            {"exclude_paths": "exclude-files", "exclude_path_patterns": ("bar/",)},
+            {"exclude_path_patterns": ("bar/",)},
         )
         test_scanner = scanner.GitRepoScanner(
             self.global_options, self.git_options, str(self.data_dir)
@@ -88,9 +88,6 @@ class RepoLoadTests(ScannerTestCase):
             test_scanner.excluded_paths,
             [
                 re.compile("bar/"),
-                re.compile("tests/"),
-                re.compile(r"\.venv/"),
-                re.compile(r".*\.egg-info/"),
             ],
         )
 


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [ ] Documentation (if applicable)
* [x] Changelog entry
* [ ] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [x] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [ ] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->

## What's new?
- Removed flags -i/--include-paths and -x/--exclude-paths which were deprecated since the release of tartufo v2.5.0
