### PR TITLE
Version bump for v3.0.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-vx.x.x - TBD
-------------
+v3.0.0-alpha.1 - 11 November 2021
+---------------------------------
 
 Bug fixes:
 
@@ -12,18 +12,18 @@ Features:
   as scan progresses instead of holding all of them until it has completed. This
   is a reimplementation of [#108](https://github.com/godaddy/tartufo/pull/108);
   thanks to @dclayton-godaddy for showing the way.
-* [#244](https://github.com/godaddy/tartufo/pull/244) - Drops support for 
+* [#244](https://github.com/godaddy/tartufo/pull/244) - Drops support for
   `--fetch/--no-fetch` option for local scans
 * [#253](https://github.com/godaddy/tartufo/issues/253) - Drops support for `--json` and `--compact`
   and consolidates the two options into one `---output-format json/compact/text`
-* [#259](https://github.com/godaddy/tartufo/pull/259) - Adds a new 
+* [#259](https://github.com/godaddy/tartufo/pull/259) - Adds a new
   `--scan-filenames/--no-scan-filenames` flag which allows users to enable or disable file name scanning.
-* [#254](https://github.com/godaddy/tartufo/pull/260) - Changes the default value of 
+* [#254](https://github.com/godaddy/tartufo/pull/260) - Changes the default value of
   `--regex/--no-regex` to True.
 
 Misc:
 
-* [#255](https://github.com/godaddy/tartufo/issues/255) -- Removed deprecated flags 
+* [#255](https://github.com/godaddy/tartufo/issues/255) -- Removed deprecated flags
   --include-paths and --exclude-paths
 
 v2.10.0 - 3 November 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,28 @@ Misc:
 * [#255](https://github.com/godaddy/tartufo/issues/255) -- Removed deprecated flags 
   --include-paths and --exclude-paths
 
+v2.10.0 - 3 November 2021
+------------
+
+Bug fixes:
+
+* [#247](https://github.com/godaddy/tartufo/issues/247) All versions of tartufo from
+  v2.2.0 through v2.9.0 inclusive mishandle `scan-remote-repo`. Only the repository's
+  default branch was scanned, and secrets present in other branches would not be
+  discovered. Additionally, the `--branch branch-name` option did not operate correctly
+  for remote repositories. Some versions would scan nothing and report no errors, and
+  other versions aborted immediately, claiming the branch did not exist (even if it did).
+  v2.10.0 corrects these problems and may detect secrets that were not reported by previous versions.
+
+Features:
+
+* [#231](https://github.com/godaddy/tartufo/issues/231) Change toml parsing library to use tomlkit
+
+Other changes:
+
+* [#251](https://github.com/godaddy/tartufo/issues/251) Document update to use --no-fetch flag
+  to all scan-local-repo
+
 v2.9.0 - 19 October 2021
 ------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ maintainers = ["GoDaddy <oss@godaddy.com>"]
 name = "tartufo"
 readme = "README.md"
 repository = "https://github.com/godaddy/tartufo/"
-version = "3.0.0-dev.0"
+version = "3.0.0-alpha.1"
 
 [tool.poetry.scripts]
 tartufo = "tartufo.cli:main"


### PR DESCRIPTION
This will be the first alpha release of tartufo v3, to give users a taste of what is to come, and to let them help shake out any bugs.

Documentation on new features is sparse still, but I think this could prove a welcome glimpse.

Plus it gives users a chance to make sure they are pinned to a "safe" v2.x version before we get TOO far down this rabbit hole.