### PR TITLE
Remove old-style config for exclude-entropy-patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,9 @@ Features:
 
 Misc:
 
-* [#255](https://github.com/godaddy/tartufo/issues/255) -- Removed deprecated flags
+* [#255](https://github.com/godaddy/tartufo/issues/255) - Removed deprecated flags
   --include-paths and --exclude-paths
+* [#282](https://github.com/godaddy/tartufo/pull/282) - Remove old style config for `exclude-entropy-patterns`
 
 v2.10.0 - 3 November 2021
 ------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Bug fixes:
 * [#284](https://github.com/godaddy/tartufo/pull/284) - Fix handling of first
   commit during local scans; an exception was raised instead of processing the
   commit.
+  
+Misc:
+
+* [#282](https://github.com/godaddy/tartufo/pull/282) - Remove old style config for `exclude-entropy-patterns`
 
 Features:
 
@@ -53,7 +57,6 @@ Misc:
 
 * [#255](https://github.com/godaddy/tartufo/issues/255) - Removed deprecated flags
   --include-paths and --exclude-paths
-* [#282](https://github.com/godaddy/tartufo/pull/282) - Remove old style config for `exclude-entropy-patterns`
 
 v2.10.0 - 3 November 2021
 ------------

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -280,9 +280,9 @@ digests. To avoid these false positives, enable ``exclude-entropy-patterns``. Ex
 apply to any strings flagged by entropy checks. This option is not available on the command line,
 and must be specified in your config file.
 
-For example, if ``docs/README.md`` contains a git SHA and `.github/workflows/*.yml` containes pinned git SHAs
+For example, if ``docs/README.md`` contains a git SHA and `.github/workflows/*.yml` contains pinned git SHAs
 this would be flagged by entropy.
-To exclude this, add an entry to ``exclude-entropy-patterns`` in the config file.
+To exclude these, add the following entries to ``exclude-entropy-patterns`` in the config file.
 
 .. code-block:: toml
 
@@ -291,6 +291,14 @@ To exclude this, add an entry to ``exclude-entropy-patterns`` in the config file
         {path-pattern = 'docs/.*\.md$', pattern = '^[a-zA-Z0-9]$', reason = 'exclude all git SHAs in the docs'},
         {path-pattern = '\.github/workflows/.*\.yml', pattern = 'uses: .*@[a-zA-Z0-9]{40}', reason = 'GitHub Actions'}
     ]
+.. note::
+    ``match-type`` is used to select the ``search`` or ``match`` regex operation. ``search`` looks for the regex
+    anywhere in the selected scope, while ``match`` requires the regex to match at the beginning of the selected scope.
+    Defaults to ``search``
+
+    ``scope`` is used to specify if you want to perform the regex operation (search or match) by ``word`` or ``line``.
+    ``word`` means exactly the high-entropy string of characters, while ``line`` searches the entire input line
+    containing the high-entropy string. Defaults to ``line``
 
 Thanks to the magic of TOML, you could also split these out into their own tables
 in the config if you wanted. So the following would be 100% equivalent to what

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -280,7 +280,8 @@ digests. To avoid these false positives, enable ``exclude-entropy-patterns``. Ex
 apply to any strings flagged by entropy checks. This option is not available on the command line,
 and must be specified in your config file.
 
-For example, if ``docs/README.md`` contains a git SHA, this would be flagged by entropy.
+For example, if ``docs/README.md`` contains a git SHA and `.github/workflows/*.yml` containes pinned git SHAs
+this would be flagged by entropy.
 To exclude this, add an entry to ``exclude-entropy-patterns`` in the config file.
 
 .. code-block:: toml
@@ -288,6 +289,7 @@ To exclude this, add an entry to ``exclude-entropy-patterns`` in the config file
     [tool.tartufo]
     exclude-entropy-patterns = [
         {path-pattern = 'docs/.*\.md$', pattern = '^[a-zA-Z0-9]$', reason = 'exclude all git SHAs in the docs'},
+        {path-pattern = '\.github/workflows/.*\.yml', pattern = 'uses: .*@[a-zA-Z0-9]{40}', reason = 'GitHub Actions'}
     ]
 
 Thanks to the magic of TOML, you could also split these out into their own tables

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -280,7 +280,7 @@ digests. To avoid these false positives, enable ``exclude-entropy-patterns``. Ex
 apply to any strings flagged by entropy checks. This option is not available on the command line,
 and must be specified in your config file.
 
-For example, if ``docs/README.md`` contains a git SHA and `.github/workflows/*.yml` contains pinned git SHAs
+For example, if ``docs/README.md`` contains a git SHA and ``.github/workflows/*.yml`` contains pinned git SHAs
 this would be flagged by entropy.
 To exclude these, add the following entries to ``exclude-entropy-patterns`` in the config file.
 

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -277,41 +277,17 @@ Entropy Limiting
 
 Entropy scans can produce a high number of false positives such as git SHAs or md5
 digests. To avoid these false positives, enable ``exclude-entropy-patterns``. Exclusions
-apply to any strings flagged by entropy checks.
+apply to any strings flagged by entropy checks. This option is not available on the command line,
+and must be specified in your config file.
 
 For example, if ``docs/README.md`` contains a git SHA, this would be flagged by entropy.
-To exclude this, add ``docs/.*\.md$::^[a-zA-Z0-9]{40}$`` to ``exclude-entropy-patterns``.
-
-.. code-block:: sh
-
-    > tartufo ... --exclude-entropy-patterns "docs/.*\.md$::^[a-zA-Z0-9]{40}$"
-
-.. code-block:: toml
-
-    [tool.tartufo]
-    exclude-entropy-patterns = [
-      # format: "{file regex}::{entropy pattern}"
-      "docs/.*\.md$::^[a-zA-Z0-9]{40}$", # exclude all git SHAs in the docs directory
-    ]
-
-.. warning::
-    .. versionchanged:: 2.9.0
-    As of version 2.9.0, the above specification style has been deprecated, and
-    will be removed in version 3.0. The new style uses a TOML `array of tables`_
-    as shown below.
-
-    Note that this new syntax is not available on the command line, and must be
-    specified in your config file.
-
-Here is an example of how you might exclude SHA hashes in your docs, as well as
-hashes for GitHub Actions in your workflows:
+To exclude this, add an entry to ``exclude-entropy-patterns`` in the config file.
 
 .. code-block:: toml
 
     [tool.tartufo]
     exclude-entropy-patterns = [
         {path-pattern = 'docs/.*\.md$', pattern = '^[a-zA-Z0-9]$', reason = 'exclude all git SHAs in the docs'},
-        {path-pattern = '\.github/workflows/.*\.yml', pattern = 'uses: .*@[a-zA-Z0-9]{40}', reason = 'GitHub Actions'}
     ]
 
 Thanks to the magic of TOML, you could also split these out into their own tables

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -120,10 +120,11 @@ class TartufoCLI(click.MultiCommand):
     "-xe",
     "--exclude-entropy-patterns",
     multiple=True,
-    help="""Specify a regular expression which matches entropy strings to
-    exclude from the scan. This option can be specified multiple times to
-    exclude multiple patterns. If not provided (default), no entropy strings
-    will be excluded ({path regex}::{pattern regex}).""",
+    hidden=True,
+    help="""Specify a regular expression which matches entropy strings to exclude from the scan. This option can be
+    specified multiple times to exclude multiple patterns. If not provided (default), no entropy strings will be
+    excluded. ({"path-pattern": {path regex}, "pattern": {pattern regex}, "match-type": "match"|"search",
+    "scope": "word"|"line"}).""",
 )
 @click.option(
     "-e",

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -280,7 +280,7 @@ def compile_rules(patterns: Iterable[Dict[str, str]]) -> List[Rule]:
                     re_match_scope=scope,
                 )
             )
-        except (KeyError, AttributeError) as exc:
+        except KeyError as exc:
             raise ConfigException(
                 f"Invalid exclude-entropy-patterns: {patterns}"
             ) from exc

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -19,11 +19,12 @@ import click
 import tomlkit
 
 from tartufo import types, util
-from tartufo.types import ConfigException, Rule
+from tartufo.types import ConfigException, Rule, MatchType, Scope
 
 OptionTypes = Union[str, int, bool, None, TextIO, Tuple[TextIO, ...]]
 
 DEFAULT_PATTERN_FILE = pathlib.Path(__file__).parent / "data" / "default_regexes.json"
+EMPTY_PATTERN = re.compile("")
 
 
 def load_config_from_path(
@@ -218,8 +219,8 @@ def load_rules_from_file(rules_file: TextIO) -> Dict[str, Rule]:
                 pattern=re.compile(rule_definition["pattern"]),
                 path_pattern=re.compile(path_pattern)
                 if path_pattern
-                else re.compile(""),
-                re_match_type="match",
+                else EMPTY_PATTERN,
+                re_match_type=MatchType.Match,
                 re_match_scope=None,
             )
         except AttributeError:
@@ -227,7 +228,7 @@ def load_rules_from_file(rules_file: TextIO) -> Dict[str, Rule]:
                 name=rule_name,
                 pattern=re.compile(rule_definition),
                 path_pattern=None,
-                re_match_type="match",
+                re_match_type=MatchType.Match,
                 re_match_scope=None,
             )
         rules[rule_name] = rule
@@ -262,8 +263,8 @@ def compile_rules(patterns: Iterable[Union[str, Dict[str, str]]]) -> List[Rule]:
                     name=pattern.get("reason", None),  # type: ignore[union-attr]
                     pattern=re.compile(pattern["pattern"]),  # type: ignore[index]
                     path_pattern=re.compile(pattern.get("path-pattern", "")),  # type: ignore[union-attr]
-                    re_match_type=pattern.get("match-type", "search"),  # type: ignore[union-attr]
-                    re_match_scope=pattern.get("scope", "line"),  # type: ignore[union-attr]
+                    re_match_type=pattern.get("match-type", MatchType.Search),  # type: ignore[union-attr]
+                    re_match_scope=pattern.get("scope", Scope.Line),  # type: ignore[union-attr]
                 )
                 for pattern in patterns
             }

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -366,6 +366,8 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
             scope = string
         elif rule.re_match_scope == Scope.Line:
             scope = line
+        else:
+            raise TartufoException(f"Invalid value for scope: {rule.re_match_scope}")
         if rule.re_match_type == MatchType.Match:
             if rule.pattern:
                 match = rule.pattern.match(scope) is not None

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -351,18 +351,23 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
 
         :param rule: Rule to perform match
         :param string: string to match against rule pattern
+        :param line: Source line containing string of interest
         :param path: path to match against rule path_pattern
         :return: True if string and path matched, False otherwise.
         """
         match = False
+        if rule.re_match_scope == "word":
+            scope = string
+        else:
+            scope = line
         if rule.re_match_type == "match":
             if rule.pattern:
-                match = rule.pattern.match(string) is not None
+                match = rule.pattern.match(scope) is not None
             if rule.path_pattern:
                 match = match and rule.path_pattern.match(path) is not None
         elif rule.re_match_type == "search":
             if rule.pattern:
-                match = rule.pattern.search(line) is not None
+                match = rule.pattern.search(scope) is not None
             if rule.path_pattern:
                 match = match and rule.path_pattern.search(path) is not None
 
@@ -372,6 +377,7 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
         """Find whether the signature of some data has been excluded in configuration.
 
         :param string: String to check against rule pattern
+        :param line: Source line containing string of interest
         :param path: Path to check against rule path pattern
         :return: True if excluded, False otherwise
         """

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -364,7 +364,7 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
         match = False
         if rule.re_match_scope == Scope.Word:
             scope = string
-        else:
+        elif rule.re_match_scope == Scope.Line:
             scope = line
         if rule.re_match_type == MatchType.Match:
             if rule.pattern:
@@ -663,7 +663,9 @@ class GitRepoScanner(GitScanner):
                 self.global_options.exclude_signatures = tuple(
                     set(self.global_options.exclude_signatures + tuple(signatures))
                 )
-
+            entropy_patterns = data.get("exclude_entropy_patterns", None)
+            if entropy_patterns:
+                self.global_options.exclude_entropy_patterns += tuple(entropy_patterns)
             include_patterns = list(data.get("include_path_patterns", ()))
             repo_include_file = data.get("include_paths", None)
             if repo_include_file:

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -28,7 +28,13 @@ import git
 import pygit2
 
 from tartufo import config, types, util
-from tartufo.types import BranchNotFoundException, Rule, TartufoException
+from tartufo.types import (
+    BranchNotFoundException,
+    Rule,
+    TartufoException,
+    MatchType,
+    Scope,
+)
 
 BASE64_REGEX = re.compile(r"[A-Z0-9+/_-]+={,2}", re.IGNORECASE)
 HEX_REGEX = re.compile(r"[0-9A-F]+", re.IGNORECASE)
@@ -356,16 +362,16 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
         :return: True if string and path matched, False otherwise.
         """
         match = False
-        if rule.re_match_scope == "word":
+        if rule.re_match_scope == Scope.Word:
             scope = string
         else:
             scope = line
-        if rule.re_match_type == "match":
+        if rule.re_match_type == MatchType.Match:
             if rule.pattern:
                 match = rule.pattern.match(scope) is not None
             if rule.path_pattern:
                 match = match and rule.path_pattern.match(path) is not None
-        elif rule.re_match_type == "search":
+        elif rule.re_match_type == MatchType.Search:
             if rule.pattern:
                 match = rule.pattern.search(scope) is not None
             if rule.path_pattern:

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -1,7 +1,7 @@
 # pylint: disable=too-many-instance-attributes
 import enum
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, TextIO, Tuple, Pattern
+from typing import Any, Dict, Optional, TextIO, Tuple, Pattern, Union
 
 
 @dataclass
@@ -72,21 +72,6 @@ class Chunk:
     metadata: Dict[str, Any]
 
 
-@dataclass
-class Rule:
-    __slots__ = ("name", "pattern", "path_pattern", "re_match_type", "re_match_scope")
-    name: Optional[str]
-    pattern: Pattern
-    path_pattern: Optional[Pattern]
-    re_match_type: str
-    re_match_scope: Optional[str]
-
-    def __hash__(self) -> int:
-        if self.path_pattern:
-            return hash(f"{self.pattern.pattern}::{self.path_pattern.pattern}")
-        return hash(self.pattern.pattern)
-
-
 class MatchType(enum.Enum):
     Match = "match"  # pylint: disable=invalid-name
     Search = "search"  # pylint: disable=invalid-name
@@ -95,6 +80,21 @@ class MatchType(enum.Enum):
 class Scope(enum.Enum):
     Word = "word"  # pylint: disable=invalid-name
     Line = "line"  # pylint: disable=invalid-name
+
+
+@dataclass
+class Rule:
+    __slots__ = ("name", "pattern", "path_pattern", "re_match_type", "re_match_scope")
+    name: Optional[str]
+    pattern: Pattern
+    path_pattern: Optional[Pattern]
+    re_match_type: Union[str, MatchType]
+    re_match_scope: Optional[Union[str, Scope]]
+
+    def __hash__(self) -> int:
+        if self.path_pattern:
+            return hash(f"{self.pattern.pattern}::{self.path_pattern.pattern}")
+        return hash(self.pattern.pattern)
 
 
 class LogLevel(enum.IntEnum):

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -63,7 +63,7 @@ class GlobalOptions:
     scan_filenames: bool
     include_path_patterns: Tuple[str, ...]
     exclude_path_patterns: Tuple[str, ...]
-    exclude_entropy_patterns: Tuple[str, ...]
+    exclude_entropy_patterns: Tuple[Dict[str, str], ...]
     exclude_signatures: Tuple[str, ...]
     output_dir: Optional[str]
     git_rules_repo: Optional[str]

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -4,6 +4,34 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional, TextIO, Tuple, Pattern, Union
 
 
+class IssueType(enum.Enum):
+    Entropy = "High Entropy"  # pylint: disable=invalid-name
+    RegEx = "Regular Expression Match"  # pylint: disable=invalid-name
+
+
+class MatchType(enum.Enum):
+    Match = "match"  # pylint: disable=invalid-name
+    Search = "search"  # pylint: disable=invalid-name
+
+
+class Scope(enum.Enum):
+    Word = "word"  # pylint: disable=invalid-name
+    Line = "line"  # pylint: disable=invalid-name
+
+
+class LogLevel(enum.IntEnum):
+    ERROR = 0
+    WARNING = 1
+    INFO = 2
+    DEBUG = 3
+
+
+class OutputFormat(enum.Enum):
+    Text = "text"  # pylint: disable=invalid-name
+    Json = "json"  # pylint: disable=invalid-name
+    Compact = "compact"  # pylint: disable=invalid-name
+
+
 @dataclass
 class GlobalOptions:
     __slots__ = (
@@ -59,27 +87,12 @@ class GitOptions:
     include_submodules: bool
 
 
-class IssueType(enum.Enum):
-    Entropy = "High Entropy"  # pylint: disable=invalid-name
-    RegEx = "Regular Expression Match"  # pylint: disable=invalid-name
-
-
 @dataclass
 class Chunk:
     __slots__ = ("contents", "file_path", "metadata")
     contents: str
     file_path: str
     metadata: Dict[str, Any]
-
-
-class MatchType(enum.Enum):
-    Match = "match"  # pylint: disable=invalid-name
-    Search = "search"  # pylint: disable=invalid-name
-
-
-class Scope(enum.Enum):
-    Word = "word"  # pylint: disable=invalid-name
-    Line = "line"  # pylint: disable=invalid-name
 
 
 @dataclass
@@ -95,19 +108,6 @@ class Rule:
         if self.path_pattern:
             return hash(f"{self.pattern.pattern}::{self.path_pattern.pattern}")
         return hash(self.pattern.pattern)
-
-
-class LogLevel(enum.IntEnum):
-    ERROR = 0
-    WARNING = 1
-    INFO = 2
-    DEBUG = 3
-
-
-class OutputFormat(enum.Enum):
-    Text = "text"  # pylint: disable=invalid-name
-    Json = "json"  # pylint: disable=invalid-name
-    Compact = "compact"  # pylint: disable=invalid-name
 
 
 class TartufoException(Exception):

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -74,16 +74,27 @@ class Chunk:
 
 @dataclass
 class Rule:
-    __slots__ = ("name", "pattern", "path_pattern", "re_match_type")
+    __slots__ = ("name", "pattern", "path_pattern", "re_match_type", "re_match_scope")
     name: Optional[str]
     pattern: Pattern
     path_pattern: Optional[Pattern]
     re_match_type: str
+    re_match_scope: Optional[str]
 
     def __hash__(self) -> int:
         if self.path_pattern:
             return hash(f"{self.pattern.pattern}::{self.path_pattern.pattern}")
         return hash(self.pattern.pattern)
+
+
+class MatchType(enum.Enum):
+    Match = "match"  # pylint: disable=invalid-name
+    Search = "search"  # pylint: disable=invalid-name
+
+
+class Scope(enum.Enum):
+    Word = "word"  # pylint: disable=invalid-name
+    Line = "line"  # pylint: disable=invalid-name
 
 
 class LogLevel(enum.IntEnum):

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -107,11 +107,11 @@ def echo_result(
                 click.echo(f"Time: {now}\nAll clear. No secrets detected.")
         if options.verbose > 0:
             click.echo("\nExcluded paths:")
-            click.echo("\n".join([path.pattern for path in scanner.excluded_paths]))
+            click.echo("\n".join([str(path) for path in scanner.excluded_paths]))
             click.echo("\nExcluded signatures:")
             click.echo("\n".join(options.exclude_signatures))
             click.echo("\nExcluded entropy patterns:")
-            click.echo("\n".join(options.exclude_entropy_patterns))
+            click.echo("\n".join(str(path) for path in scanner.excluded_entropy))
 
 
 def write_outputs(found_issues: List["Issue"], output_dir: pathlib.Path) -> List[str]:

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -18,7 +18,6 @@ from typing import (
     Optional,
     Tuple,
     TYPE_CHECKING,
-    Pattern,
 )
 
 import click
@@ -26,12 +25,10 @@ import git
 import pygit2
 
 from tartufo import types
-from tartufo.types import Rule
 
 if TYPE_CHECKING:
     from tartufo.scanner import Issue  # pylint: disable=cyclic-import
     from tartufo.scanner import ScannerBase  # pylint: disable=cyclic-import
-    from tartufo.config import OptionTypes  # pylint: disable=cyclic-import
 
 
 DATETIME_FORMAT: str = "%Y-%m-%d %H:%M:%S"
@@ -48,13 +45,6 @@ def del_rw(_func: Callable, name: str, _exc: Exception) -> None:
     """
     os.chmod(name, stat.S_IWRITE)
     os.remove(name)
-
-
-def convert_regexes_to_rules(regexes: Dict[str, Pattern]) -> Dict[str, Rule]:
-    return {
-        name: Rule(name=name, pattern=pattern, path_pattern=None, re_match_type="match")
-        for name, pattern in regexes.items()
-    }
 
 
 def echo_result(

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -18,6 +18,7 @@ from typing import (
     Optional,
     Tuple,
     TYPE_CHECKING,
+    Pattern,
 )
 
 import click

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -305,19 +305,25 @@ class RegexScanTests(ScannerTestCase):
         test_scanner = TestScanner(self.options)
         test_scanner._rules_regexes = {  # pylint: disable=protected-access
             "foo": Rule(
-                name=None, pattern=rule_1, path_pattern=None, re_match_type="match"
+                name=None,
+                pattern=rule_1,
+                path_pattern=None,
+                re_match_type="match",
+                re_match_scope=None,
             ),
             "bar": Rule(
                 name=None,
                 pattern=rule_2,
                 path_pattern=rule_2_path,
                 re_match_type="match",
+                re_match_scope=None,
             ),
             "not-found": Rule(
                 name=None,
                 pattern=rule_3,
                 path_pattern=rule_3_path,
                 re_match_type="match",
+                re_match_scope=None,
             ),
         }
         chunk = types.Chunk("foo", "/file/path", {})
@@ -340,6 +346,7 @@ class RegexScanTests(ScannerTestCase):
                 pattern=re.compile("foo"),
                 path_pattern=None,
                 re_match_type="match",
+                re_match_scope=None,
             )
         }
         chunk = types.Chunk("foo", "bar", {})
@@ -359,6 +366,7 @@ class RegexScanTests(ScannerTestCase):
                 pattern=re.compile("foo"),
                 path_pattern=None,
                 re_match_type="match",
+                re_match_scope=None,
             )
         }
         chunk = types.Chunk("foo", "bar", {})
@@ -385,9 +393,16 @@ class EntropyManagementTests(ScannerTestCase):
         self.scanner = TestScanner(self.options)
 
     def test_entropy_string_is_excluded(self):
-        self.options.exclude_entropy_patterns = [r"docs/.*\.md::f.*"]
+        self.options.exclude_entropy_patterns = [
+            {
+                "path-pattern": r"docs/.*\.md",
+                "pattern": "f.*",
+                "match-type": "search",
+                "scope": "line",
+            }
+        ]
         excluded = self.scanner.entropy_string_is_excluded(
-            "foo", "bar", "docs/README.md"
+            "bar", "foo", "docs/README.md"
         )
         self.assertEqual(True, excluded)
 
@@ -401,12 +416,16 @@ class EntropyManagementTests(ScannerTestCase):
         self.assertEqual(True, excluded)
 
     def test_entropy_string_is_not_excluded(self):
-        self.options.exclude_entropy_patterns = [r"foo\..*::f.*"]
-        excluded = self.scanner.entropy_string_is_excluded("bar", "foo", "foo.py")
+        self.options.exclude_entropy_patterns = [
+            {"path-pattern": r"foo\..*", "pattern": "f.*", "match-type": "match"}
+        ]
+        excluded = self.scanner.entropy_string_is_excluded("foo", "bar", "foo.py")
         self.assertEqual(False, excluded)
 
     def test_entropy_string_is_not_excluded_given_different_path(self):
-        self.options.exclude_entropy_patterns = [r"foo\..*::f.*"]
+        self.options.exclude_entropy_patterns = [
+            {"path-pattern": r"foo\..*", "pattern": "f.*", "match-type": "match"}
+        ]
         excluded = self.scanner.entropy_string_is_excluded("foo", "bar", "bar.py")
         self.assertEqual(False, excluded)
 

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 from tartufo import scanner, types
 from tartufo.scanner import Issue
-from tartufo.types import GlobalOptions, Rule
+from tartufo.types import GlobalOptions, Rule, MatchType
 
 from tests.helpers import generate_options
 
@@ -308,21 +308,21 @@ class RegexScanTests(ScannerTestCase):
                 name=None,
                 pattern=rule_1,
                 path_pattern=None,
-                re_match_type="match",
+                re_match_type=MatchType.Match,
                 re_match_scope=None,
             ),
             "bar": Rule(
                 name=None,
                 pattern=rule_2,
                 path_pattern=rule_2_path,
-                re_match_type="match",
+                re_match_type=MatchType.Match,
                 re_match_scope=None,
             ),
             "not-found": Rule(
                 name=None,
                 pattern=rule_3,
                 path_pattern=rule_3_path,
-                re_match_type="match",
+                re_match_type=MatchType.Match,
                 re_match_scope=None,
             ),
         }
@@ -345,7 +345,7 @@ class RegexScanTests(ScannerTestCase):
                 name=None,
                 pattern=re.compile("foo"),
                 path_pattern=None,
-                re_match_type="match",
+                re_match_type=MatchType.Match,
                 re_match_scope=None,
             )
         }
@@ -365,7 +365,7 @@ class RegexScanTests(ScannerTestCase):
                 name=None,
                 pattern=re.compile("foo"),
                 path_pattern=None,
-                re_match_type="match",
+                re_match_type=MatchType.Match,
                 re_match_scope=None,
             )
         }

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -397,12 +397,10 @@ class EntropyManagementTests(ScannerTestCase):
             {
                 "path-pattern": r"docs/.*\.md",
                 "pattern": "f.*",
-                "match-type": "search",
-                "scope": "line",
             }
         ]
         excluded = self.scanner.entropy_string_is_excluded(
-            "bar", "foo", "docs/README.md"
+            "foo", "barfoo", "docs/README.md"
         )
         self.assertEqual(True, excluded)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,7 @@ import tomlkit
 from click.testing import CliRunner
 
 from tartufo import config, types
-from tartufo.types import Rule
+from tartufo.types import Rule, MatchType, Scope
 
 from tests import helpers
 
@@ -23,14 +23,14 @@ class ConfigureRegexTests(unittest.TestCase):
                 name="RSA private key 2",
                 pattern=re.compile("-----BEGIN EC PRIVATE KEY-----"),
                 path_pattern=None,
-                re_match_type="match",
+                re_match_type=MatchType.Match,
                 re_match_scope=None,
             ),
             "Complex Rule": Rule(
                 name="Complex Rule",
                 pattern=re.compile("complex-rule"),
                 path_pattern=re.compile("/tmp/[a-z0-9A-Z]+\\.(py|js|json)"),
-                re_match_type="match",
+                re_match_type=MatchType.Match,
                 re_match_scope=None,
             ),
         }
@@ -54,14 +54,14 @@ class ConfigureRegexTests(unittest.TestCase):
             name="RSA private key 2",
             pattern=re.compile("-----BEGIN EC PRIVATE KEY-----"),
             path_pattern=None,
-            re_match_type="match",
+            re_match_type=MatchType.Match,
             re_match_scope=None,
         )
         expected_regexes["Complex Rule"] = Rule(
             name="Complex Rule",
             pattern=re.compile("complex-rule"),
             path_pattern=re.compile("/tmp/[a-z0-9A-Z]+\\.(py|js|json)"),
-            re_match_type="match",
+            re_match_type=MatchType.Match,
             re_match_scope=None,
         )
 
@@ -144,14 +144,14 @@ class ConfigureRegexTests(unittest.TestCase):
                 name="RSA private key 2",
                 pattern=re.compile("-----BEGIN EC PRIVATE KEY-----"),
                 path_pattern=None,
-                re_match_type="match",
+                re_match_type=MatchType.Match,
                 re_match_scope=None,
             ),
             "Complex Rule": Rule(
                 name="Complex Rule",
                 pattern=re.compile("complex-rule"),
                 path_pattern=re.compile("/tmp/[a-z0-9A-Z]+\\.(py|js|json)"),
-                re_match_type="match",
+                re_match_type=MatchType.Match,
                 re_match_scope=None,
             ),
         }
@@ -320,22 +320,22 @@ class CompileRulesTests(unittest.TestCase):
                         None,
                         re.compile(r"^[a-zA-Z0-9]{26}$"),
                         re.compile(r"src/.*"),
-                        re_match_type="search",
-                        re_match_scope="line",
+                        re_match_type=MatchType.Search,
+                        re_match_scope=Scope.Line,
                     ),
                     Rule(
                         None,
                         re.compile(r"^[a-zA-Z0-9]test$"),
                         re.compile(r""),
-                        re_match_type="search",
-                        re_match_scope="line",
+                        re_match_type=MatchType.Search,
+                        re_match_scope=Scope.Line,
                     ),
                     Rule(
                         None,
                         re.compile(r"^[a-zA-Z0-9]{26}::test$"),
                         re.compile(r"src/.*"),
-                        re_match_type="search",
-                        re_match_scope="line",
+                        re_match_type=MatchType.Search,
+                        re_match_scope=Scope.Line,
                     ),
                 }
             ),
@@ -354,8 +354,8 @@ class CompileRulesTests(unittest.TestCase):
                     None,
                     re.compile(r"^[a-zA-Z0-9]::test$"),
                     re.compile(r""),
-                    re_match_type="search",
-                    re_match_scope="line",
+                    re_match_type=MatchType.Search,
+                    re_match_scope=Scope.Line,
                 )
             ],
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,12 +24,14 @@ class ConfigureRegexTests(unittest.TestCase):
                 pattern=re.compile("-----BEGIN EC PRIVATE KEY-----"),
                 path_pattern=None,
                 re_match_type="match",
+                re_match_scope=None,
             ),
             "Complex Rule": Rule(
                 name="Complex Rule",
                 pattern=re.compile("complex-rule"),
                 path_pattern=re.compile("/tmp/[a-z0-9A-Z]+\\.(py|js|json)"),
                 re_match_type="match",
+                re_match_scope=None,
             ),
         }
 
@@ -53,12 +55,14 @@ class ConfigureRegexTests(unittest.TestCase):
             pattern=re.compile("-----BEGIN EC PRIVATE KEY-----"),
             path_pattern=None,
             re_match_type="match",
+            re_match_scope=None,
         )
         expected_regexes["Complex Rule"] = Rule(
             name="Complex Rule",
             pattern=re.compile("complex-rule"),
             path_pattern=re.compile("/tmp/[a-z0-9A-Z]+\\.(py|js|json)"),
             re_match_type="match",
+            re_match_scope=None,
         )
 
         actual_regexes = config.configure_regexes(
@@ -141,12 +145,14 @@ class ConfigureRegexTests(unittest.TestCase):
                 pattern=re.compile("-----BEGIN EC PRIVATE KEY-----"),
                 path_pattern=None,
                 re_match_type="match",
+                re_match_scope=None,
             ),
             "Complex Rule": Rule(
                 name="Complex Rule",
                 pattern=re.compile("complex-rule"),
                 path_pattern=re.compile("/tmp/[a-z0-9A-Z]+\\.(py|js|json)"),
                 re_match_type="match",
+                re_match_scope=None,
             ),
         }
 
@@ -298,98 +304,65 @@ class CompilePathRulesTests(unittest.TestCase):
 
 
 class CompileRulesTests(unittest.TestCase):
-    def test_commented_lines_are_ignored(self):
-        rules = config.compile_rules(["# Poetry lock file", r"^[a-zA-Z0-9]{26}$"])
-        self.assertEqual(
-            rules,
-            [
-                Rule(
-                    None,
-                    re.compile(r"^[a-zA-Z0-9]{26}$"),
-                    re.compile(r".*"),
-                    re_match_type="match",
-                )
-            ],
-        )
-
-    def test_whitespace_lines_are_ignored(self):
-        rules = config.compile_rules(
-            [
-                "# Poetry lock file",
-                r"poetry\.lock::^[a-zA-Z0-9]{40}$",
-                "",
-                "\t\n",
-                "# NPM files",
-                r"^[a-zA-Z0-9]{26}$",
-            ]
-        )
-        self.assertEqual(
-            rules,
-            [
-                Rule(
-                    None,
-                    re.compile(r"^[a-zA-Z0-9]{40}$"),
-                    re.compile(r"poetry\.lock"),
-                    re_match_type="match",
-                ),
-                Rule(
-                    None,
-                    re.compile(r"^[a-zA-Z0-9]{26}$"),
-                    re.compile(r".*"),
-                    re_match_type="match",
-                ),
-            ],
-        )
-
     def test_path_is_used(self):
         rules = config.compile_rules(
             [
-                r"src/.*::^[a-zA-Z0-9]{26}$",
-                r"^[a-zA-Z0-9]test$",
-                r"src/.*::^[a-zA-Z0-9]{26}::test$",
+                {"path-pattern": r"src/.*", "pattern": r"^[a-zA-Z0-9]{26}$"},
+                {"pattern": r"^[a-zA-Z0-9]test$"},
+                {"path-pattern": r"src/.*", "pattern": r"^[a-zA-Z0-9]{26}::test$"},
             ]
         )
         self.assertEqual(
             rules,
-            [
-                Rule(
-                    None,
-                    re.compile(r"^[a-zA-Z0-9]{26}$"),
-                    re.compile(r"src/.*"),
-                    re_match_type="match",
-                ),
-                Rule(
-                    None,
-                    re.compile(r"^[a-zA-Z0-9]test$"),
-                    re.compile(r".*"),
-                    re_match_type="match",
-                ),
-                Rule(
-                    None,
-                    re.compile(r"^[a-zA-Z0-9]{26}::test$"),
-                    re.compile(r"src/.*"),
-                    re_match_type="match",
-                ),
-            ],
+            list(
+                {
+                    Rule(
+                        None,
+                        re.compile(r"^[a-zA-Z0-9]{26}$"),
+                        re.compile(r"src/.*"),
+                        re_match_type="search",
+                        re_match_scope="line",
+                    ),
+                    Rule(
+                        None,
+                        re.compile(r"^[a-zA-Z0-9]test$"),
+                        re.compile(r""),
+                        re_match_type="search",
+                        re_match_scope="line",
+                    ),
+                    Rule(
+                        None,
+                        re.compile(r"^[a-zA-Z0-9]{26}::test$"),
+                        re.compile(r"src/.*"),
+                        re_match_type="search",
+                        re_match_scope="line",
+                    ),
+                }
+            ),
         )
 
     def test_match_can_contain_delimiter(self):
-        rules = config.compile_rules([r".*::^[a-zA-Z0-9]::test$"])
+        rules = config.compile_rules(
+            [
+                {"pattern": r"^[a-zA-Z0-9]::test$"},
+            ]
+        )
         self.assertEqual(
             rules,
             [
                 Rule(
                     None,
                     re.compile(r"^[a-zA-Z0-9]::test$"),
-                    re.compile(r".*"),
-                    re_match_type="match",
+                    re.compile(r""),
+                    re_match_type="search",
+                    re_match_scope="line",
                 )
             ],
         )
 
     def test_config_exception_is_raised_if_no_match_field_found(self):
         with self.assertRaisesRegex(
-            types.ConfigException, "Malformed exclude-entropy-patterns: "
+            types.ConfigException, "Invalid exclude-entropy-patterns: "
         ):
             config.compile_rules([{"foo": "bar"}])
 


### PR DESCRIPTION
Fix tests

To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [x] Documentation (if applicable)
* [x] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [x] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [ ] Yes (backward compatible)
* [x] No (breaking changes)
Old style `exluded-entropy-patterns` will no longer be supported and will raise an error

## Issue Linking
Closes #264 

## What's new?
Old style `exluded-entropy-patterns` will no longer be supported and will raise an error. These must now follow the TOML `array of tables` format and can only be specified in the config file
