### PR TITLE
Adding --recurse / --no-recurse option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ Features:
 * [#254](https://github.com/godaddy/tartufo/pull/260) - Changes the default value of
   `--regex/--no-regex` to True.
 * [#268](https://github.com/godaddy/tartufo/issues/268) - Adds a new
-  `--recurse / --no-recurse` flag which allows users scan entire directory or just the root directory
+  `--recurse / --no-recurse` flag which allows users to recursively scan the entire directory or just
+  the root directory
 
 Misc:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Features:
   `--scan-filenames/--no-scan-filenames` flag which allows users to enable or disable file name scanning.
 * [#254](https://github.com/godaddy/tartufo/pull/260) - Changes the default value of
   `--regex/--no-regex` to True.
+* [#268](https://github.com/godaddy/tartufo/issues/268) - Adds a new
+  `--recurse / --no-recurse` flag which allows users scan entire directory or just the root directory
 
 Misc:
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Commands:
   pre-commit        Scan staged changes in a pre-commit hook.
   scan-local-repo   Scan a repository already cloned to your local system.
   scan-remote-repo  Automatically clone and scan a remote git repository.
+  scan-folder       Scan a folder.
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Commands:
   pre-commit        Scan staged changes in a pre-commit hook.
   scan-local-repo   Scan a repository already cloned to your local system.
   scan-remote-repo  Automatically clone and scan a remote git repository.
-  scan-folder       Scan a folder.
+  scan-folder       Scan a folder on your local system.
 
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ exclude-signatures = [
   "d26b223efb2087d4a3db7b3ff0f65362372c46190fd74b8061db8099f4a2ee60", # tests/data/scan_folder/donotscan.txt
   "94c45f9acae0551a2438fa8932fac466e903fd9a09bd2e11897198b133937ccd", # tests/data/scan_folder/test.txt
   "743b893e30777d9c4e28d3d341ca4ba1c2541a9c62b497dece75c2a64420e770", # tests/test_folder_scanner.py
+  "9d1b278fa384c9dc58d607130d97740910309d13b29f13f7ed6348738ea4f32c", # tests/data/scan_folder/scan_sub_folder/sub_folder_test.txt
 ]
 json = false
 regex = true

--- a/tartufo/commands/scan_folder.py
+++ b/tartufo/commands/scan_folder.py
@@ -7,6 +7,13 @@ from tartufo.scanner import FolderScanner
 
 
 @click.command("scan-folder")
+@click.option(
+    "--recurse/--no-recurse",
+    is_flag=True,
+    default=True,
+    show_default=True,
+    help="Recurse and scan the entire folder",
+)
 @click.argument(
     "target",
     type=click.Path(exists=True, file_okay=False, resolve_path=True, allow_dash=False),
@@ -14,7 +21,7 @@ from tartufo.scanner import FolderScanner
 @click.pass_obj
 @click.pass_context
 def main(
-    ctx: click.Context, options: types.GlobalOptions, target: str
+    ctx: click.Context, options: types.GlobalOptions, target: str, recurse: bool
 ) -> FolderScanner:
     """Scan a folder."""
     try:
@@ -26,7 +33,7 @@ def main(
             )
         if resume is False:
             sys.exit(0)
-        scanner = FolderScanner(options, target)
+        scanner = FolderScanner(options, target, recurse)
         util.process_issues(target, scanner, options)
     except types.TartufoException as exc:
         util.fail(str(exc), ctx)

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -761,9 +761,7 @@ class FolderScanner(ScannerBase):
     target: str
 
     def __init__(
-        self,
-        global_options: types.GlobalOptions,
-        target: str,
+        self, global_options: types.GlobalOptions, target: str, recurse: bool
     ) -> None:
         """Used for scanning a folder.
 
@@ -771,6 +769,7 @@ class FolderScanner(ScannerBase):
         :param target: The local filesystem path to scan
         """
         self.target = target
+        self.recurse = recurse
         super().__init__(global_options)
 
     @property
@@ -785,7 +784,8 @@ class FolderScanner(ScannerBase):
 
     def _iter_folder(self) -> Generator[Tuple[str, str], None, None]:
         folder_path = pathlib.Path(self.target)
-        for file_path in folder_path.rglob("**/*"):
+        files = folder_path.rglob("**/*") if self.recurse else folder_path.glob("*")
+        for file_path in files:
             relative_path = file_path.relative_to(folder_path)
             if file_path.is_file() and self.should_scan(str(relative_path)):
                 try:

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -759,6 +759,7 @@ class FolderScanner(ScannerBase):
     """Used to scan a folder."""
 
     target: str
+    recurse: bool
 
     def __init__(
         self, global_options: types.GlobalOptions, target: str, recurse: bool

--- a/tests/data/scan_folder/scan_sub_folder/sub_folder_test.txt
+++ b/tests/data/scan_folder/scan_sub_folder/sub_folder_test.txt
@@ -1,0 +1,3 @@
+not matched
+ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=
+another not matched

--- a/tests/test_folder_scanner.py
+++ b/tests/test_folder_scanner.py
@@ -64,8 +64,7 @@ class FolderScannerTestCase(unittest.TestCase):
         actual_issues = []
         for issue in issues:
             actual_issues.append(issue.matched_string)
-        self.assertIn("KQ0I97OBuPlGB9yPRxoSxnX52zE=", actual_issues)
-        self.assertIn("KQ0I97OBuPlGB9yPRxoSxnX52zE=", actual_issues)
+        self.assertEqual(2, actual_issues.count("KQ0I97OBuPlGB9yPRxoSxnX52zE="))
         self.assertIn(
             "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
             actual_issues,
@@ -86,8 +85,7 @@ class FolderScannerTestCase(unittest.TestCase):
         actual_issues = []
         for issue in issues:
             actual_issues.append(issue.matched_string)
-        self.assertIn("KQ0I97OBuPlGB9yPRxoSxnX52zE=", actual_issues)
-        self.assertIn("KQ0I97OBuPlGB9yPRxoSxnX52zE=", actual_issues)
+        self.assertEqual(2, actual_issues.count("KQ0I97OBuPlGB9yPRxoSxnX52zE="))
 
 
 if __name__ == "__main__":

--- a/tests/test_folder_scanner.py
+++ b/tests/test_folder_scanner.py
@@ -54,6 +54,15 @@ class FolderScannerTestCase(unittest.TestCase):
         issues = list(test_scanner.scan())
 
         self.assertEqual(3, len(issues))
+        actual_issues = []
+        for issue in issues:
+            actual_issues.append(issue.matched_string)
+        self.assertIn("KQ0I97OBuPlGB9yPRxoSxnX52zE=", actual_issues)
+        self.assertIn("KQ0I97OBuPlGB9yPRxoSxnX52zE=", actual_issues)
+        self.assertIn(
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
+            actual_issues,
+        )
 
     def test_scan_only_root_level_files(self):
         folder_path = pathlib.Path(__file__).parent / "data/scan_folder"
@@ -67,6 +76,11 @@ class FolderScannerTestCase(unittest.TestCase):
         issues = list(test_scanner.scan())
 
         self.assertEqual(2, len(issues))
+        actual_issues = []
+        for issue in issues:
+            actual_issues.append(issue.matched_string)
+        self.assertIn("KQ0I97OBuPlGB9yPRxoSxnX52zE=", actual_issues)
+        self.assertIn("KQ0I97OBuPlGB9yPRxoSxnX52zE=", actual_issues)
 
 
 if __name__ == "__main__":

--- a/tests/test_folder_scanner.py
+++ b/tests/test_folder_scanner.py
@@ -27,7 +27,14 @@ class FolderScannerTestCase(unittest.TestCase):
         issues = list(test_scanner.scan())
 
         self.assertEqual(2, len(issues))
-        self.assertEqual("KQ0I97OBuPlGB9yPRxoSxnX52zE=", issues[0].matched_string)
+        actual_issues = []
+        for issue in issues:
+            actual_issues.append(issue.matched_string)
+        self.assertIn("KQ0I97OBuPlGB9yPRxoSxnX52zE=", actual_issues)
+        self.assertIn(
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
+            actual_issues,
+        )
         self.assertEqual(IssueType.Entropy, issues[0].issue_type)
 
     def test_scan_should_raise_click_error_on_file_permissions_issues(self):

--- a/tests/test_folder_scanner.py
+++ b/tests/test_folder_scanner.py
@@ -15,7 +15,7 @@ class FolderScannerTestCase(unittest.TestCase):
         self.global_options = generate_options(GlobalOptions)
 
     def test_scan_should_detect_entropy_and_not_binary(self):
-        folder_path = pathlib.Path(__file__).parent / "data/scan_folder"
+        folder_path = pathlib.Path(__file__).parent / "data" / "scan_folder"
         recurse = True
         self.global_options.entropy = True
         self.global_options.b64_entropy_score = 4.5
@@ -28,8 +28,7 @@ class FolderScannerTestCase(unittest.TestCase):
 
         self.assertEqual(2, len(issues))
         actual_issues = []
-        for issue in issues:
-            actual_issues.append(issue.matched_string)
+        actual_issues = [issue.matched_string for issue in issues]
         self.assertIn("KQ0I97OBuPlGB9yPRxoSxnX52zE=", actual_issues)
         self.assertIn(
             "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
@@ -38,7 +37,7 @@ class FolderScannerTestCase(unittest.TestCase):
         self.assertEqual(IssueType.Entropy, issues[0].issue_type)
 
     def test_scan_should_raise_click_error_on_file_permissions_issues(self):
-        folder_path = pathlib.Path(__file__).parent / "data/scan_folder"
+        folder_path = pathlib.Path(__file__).parent / "data" / "scan_folder"
         recurse = True
         self.global_options.entropy = True
         self.global_options.exclude_signatures = []
@@ -50,7 +49,7 @@ class FolderScannerTestCase(unittest.TestCase):
                 list(test_scanner.scan())
 
     def test_scan_all_the_files_recursively(self):
-        folder_path = pathlib.Path(__file__).parent / "data/scan_folder"
+        folder_path = pathlib.Path(__file__).parent / "data" / "scan_folder"
         recurse = True
         self.global_options.entropy = True
         self.global_options.exclude_signatures = []
@@ -62,8 +61,7 @@ class FolderScannerTestCase(unittest.TestCase):
 
         self.assertEqual(3, len(issues))
         actual_issues = []
-        for issue in issues:
-            actual_issues.append(issue.matched_string)
+        actual_issues = [issue.matched_string for issue in issues]
         self.assertEqual(2, actual_issues.count("KQ0I97OBuPlGB9yPRxoSxnX52zE="))
         self.assertIn(
             "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
@@ -71,7 +69,7 @@ class FolderScannerTestCase(unittest.TestCase):
         )
 
     def test_scan_only_root_level_files(self):
-        folder_path = pathlib.Path(__file__).parent / "data/scan_folder"
+        folder_path = pathlib.Path(__file__).parent / "data" / "scan_folder"
         recurse = False
         self.global_options.entropy = True
         self.global_options.exclude_signatures = []
@@ -83,8 +81,7 @@ class FolderScannerTestCase(unittest.TestCase):
 
         self.assertEqual(2, len(issues))
         actual_issues = []
-        for issue in issues:
-            actual_issues.append(issue.matched_string)
+        actual_issues = [issue.matched_string for issue in issues]
         self.assertEqual(2, actual_issues.count("KQ0I97OBuPlGB9yPRxoSxnX52zE="))
 
 

--- a/tests/test_scan_folder.py
+++ b/tests/test_scan_folder.py
@@ -37,7 +37,7 @@ class ScanFolderTests(unittest.TestCase):
     def test_filename_added_to_chunk_when_scan_filename_enabled(self):
         path = pathlib.Path(__file__).parent / "data" / "scan_folder"
         options = generate_options(GlobalOptions, scan_filenames=True)
-        scanner = FolderScanner(options, str(path))
+        scanner = FolderScanner(options, str(path), True)
         for chunk in scanner.chunks:
             file_path = chunk.file_path
             try:
@@ -50,7 +50,7 @@ class ScanFolderTests(unittest.TestCase):
     def test_filename_not_added_to_chunk_when_scan_filename_disabled(self):
         path = pathlib.Path(__file__).parent / "data" / "scan_folder"
         options = generate_options(GlobalOptions, scan_filenames=False)
-        scanner = FolderScanner(options, str(path))
+        scanner = FolderScanner(options, str(path), True)
         for chunk in scanner.chunks:
             file_path = chunk.file_path
             try:


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [ ] Documentation (if applicable)
* [x] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
Closes #268 

## What's new?
- Introducing new flag --recurse/--no-recurse to scan entire directory or just the root directory. It is defaulted to recurse to maintain the current behavior of scan-folder. 
