### PR TITLE
Relax base64 checking to match tartufo v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Features:
   marked as deprecated.
 * [#273](https://github.com/godaddy/tartufo/inssues/273) - Entropy checking support
   routines have been rewritten to utilize library abstractions and operate more
-  efficiently while returning effectively identical results.
+  efficiently while returning identical results.
 * [#177](https://github.com/godaddy/tartufo/issues/177) -
   [base64url](https://datatracker.ietf.org/doc/html/rfc4648#section-5) encodings
   are now recognized and scanned for entropy.

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -30,7 +30,7 @@ import pygit2
 from tartufo import config, types, util
 from tartufo.types import BranchNotFoundException, Rule, TartufoException
 
-BASE64_REGEX = re.compile(r"[A-Z0-9+/_-]+={,2}", re.IGNORECASE)
+BASE64_REGEX = re.compile(r"[A-Z0-9=+/_-]+", re.IGNORECASE)
 HEX_REGEX = re.compile(r"[0-9A-F]+", re.IGNORECASE)
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -422,10 +422,13 @@ class GeneralUtilTests(unittest.TestCase):
         sample_input = """
         +111111111-ffffCCCC= Can't mix + and - but both are in regex
         111111111111111111111== Not a valid length but we don't care
-        ==111111111111111111 Not recognized, = can only be at the end
+        ==111111111111111111 = Is supposed to be end only but we don't care
         """
 
         strings = list(
             util.find_strings_by_regex(sample_input, scanner.BASE64_REGEX, 20)
         )
-        self.assertEqual(strings, ["+111111111-ffffCCCC=", "111111111111111111111=="])
+        self.assertEqual(
+            strings,
+            ["+111111111-ffffCCCC=", "111111111111111111111==", "==111111111111111111"],
+        )


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [X] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] Changelog entry
* [X] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [X] Other -- what do you get when you put "bugfix" and "feature" in a blender?

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [X] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->

## What's new?
- Allow `=` to appear in the middle of strings (like we did in 2.x) instead of forcing it to appear only at the end (like base64 RFC
requires). This more faithfully reproduces the old behavior and allows users -- such as ourselves -- to avoid updating signatures.
