### PR TITLE
Deprecate --rules in favor of rule-patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Features:
 * [#268](https://github.com/godaddy/tartufo/issues/268) - Adds a new
   `--recurse / --no-recurse` flag which allows users to recursively scan the entire directory or just
   the root directory
+* [#256](https://github.com/godaddy/tartufo/issues/256) - Deprecated `--rules` in
+  favor of a new `rule-patterns` config option. This is the final piece of config
+  that was still stored in an external file.
 
 v3.0.0-alpha.1 - 11 November 2021
 ---------------------------------

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -52,6 +52,58 @@ this:
 Note that all options specified in a configuration file are treated as
 defaults, and will be overridden by any options specified on the command line.
 
-For a full list of configuration options, check out the :doc:`usage` document.
+For a full list of available command line options, check out the :doc:`usage`
+document.
 
-.. _TOML: https://github.com/toml-lang/toml
+Configuration File Exclusive Options
+------------------------------------
+
+.. versionadded:: 3.0
+
+As of version 3.0, we have added several configuration options which are
+available only in the configuration file. This is due to the nature of their
+construction, and the fact that they would be exceedingly difficult to
+represent on the command line.
+
+Rule Patterns
++++++++++++++
+
+.. versionadded:: 3.0
+
+``tartufo`` comes bundled with a number of regular expression rules that it will
+check your code for by default. If you would like to scan for additional regular
+expressions, you may add them to your configuration with the ``rule-patterns``
+directive. This directive utilizes a `TOML`_ `array of tables`_, and thus can
+take one of two forms:
+
+Option 1: Keeping it contained in your ``[tool.tartufo]`` table.
+
+.. code-block:: toml
+
+    [tool.tartufo]
+    rule-patterns = [
+        {reason = "RSA private key 2", pattern = "-----BEGIN EC PRIVATE KEY-----"},
+        {reason = "Null characters in GitHub Workflows", pattern = '\0', path-pattern = '\.github/workflows/(.*)\.yml'}
+    ]
+
+Option 2: Separating each rule out into its own table.
+
+.. code-block:: toml
+
+    [[tool.tartufo.rule-patterns]]
+    reason = "RSA private key 2"
+    pattern = "-----BEGIN EC PRIVATE KEY-----"
+
+    [[tool.tartufo.rule-patterns]]
+    reason = "Null characters in GitHub Workflows"
+    pattern = '\0'
+    path-pattern = '\.github/workflows/(.*)\.yml'
+
+.. note::
+
+    There are 3 different keys used here: ``reason``, ``pattern``, and ``path-pattern``.
+    Only ``reason`` and ``pattern`` are required. If no ``path-pattern`` is
+    specified, then the pattern will be used to scan against all files.
+
+.. _TOML: https://toml.io/
+.. _array of tables: https://toml.io/en/v1.0.0#array-of-tables

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -49,7 +49,14 @@ class TartufoCLI(click.MultiCommand):
     "--rules",
     multiple=True,
     type=click.File("r"),
-    help="Path(s) to regex rules json list file(s).",
+    help="[DEPRECATED] Use the rule-patterns config options instead. Path(s) to regex "
+    "rules json list file(s).",
+)
+@click.option(
+    "--rule-patterns",
+    multiple=True,
+    type=str,
+    help="Regex rule patterns to be detected",
 )
 @click.option(
     "--default-regexes/--no-default-regexes",

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -56,7 +56,8 @@ class TartufoCLI(click.MultiCommand):
     "--rule-patterns",
     multiple=True,
     type=str,
-    help="Regex rule patterns to be detected",
+    hidden=True,
+    help="Regular expression patterns to search the target for. May be specified multiple times.",
 )
 @click.option(
     "--default-regexes/--no-default-regexes",

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -148,7 +148,7 @@ def read_pyproject_toml(
 def configure_regexes(
     include_default: bool = True,
     rules_files: Optional[Iterable[TextIO]] = None,
-    rule_patterns: Optional[Iterable[str]] = None,
+    rule_patterns: Optional[Iterable[Dict[str, str]]] = None,
     rules_repo: Optional[str] = None,
     rules_repo_files: Optional[Iterable[str]] = None,
 ) -> Dict[str, Rule]:
@@ -156,6 +156,7 @@ def configure_regexes(
 
     :param include_default: Whether to include the built-in set of regexes
     :param rules_files: A list of files to load rules from
+    :param rule_patterns: A set of previously-collected rules
     :param rules_repo: A separate git repository to load rules from
     :param rules_repo_files: A set of patterns used to find files in the rules repo
     """
@@ -168,11 +169,12 @@ def configure_regexes(
     if rule_patterns:
         try:
             for pattern in rule_patterns:
-                rules[pattern["name"]] = Rule(
-                    name=pattern["name"],
-                    pattern=pattern["pattern"],
+                pattern_name = pattern.get("reason", "FIXME")
+                rules[pattern_name] = Rule(
+                    name=pattern_name,
+                    pattern=re.compile(pattern["pattern"]),
                     path_pattern=re.compile(pattern.get("path-pattern", "")),
-                    re_match_type=None,
+                    re_match_type="search",
                 )
         except KeyError as exc:
             raise ConfigException(

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -148,6 +148,7 @@ def read_pyproject_toml(
 def configure_regexes(
     include_default: bool = True,
     rules_files: Optional[Iterable[TextIO]] = None,
+    rule_patterns: Optional[Iterable[str]] = None,
     rules_repo: Optional[str] = None,
     rules_repo_files: Optional[Iterable[str]] = None,
 ) -> Dict[str, Rule]:
@@ -164,7 +165,27 @@ def configure_regexes(
     else:
         rules = {}
 
+    if rule_patterns:
+        try:
+            for pattern in rule_patterns:
+                rules[pattern["name"]] = Rule(
+                    name=pattern["name"],
+                    pattern=pattern["pattern"],
+                    path_pattern=re.compile(pattern.get("path-pattern", "")),
+                    re_match_type=None,
+                )
+        except KeyError as exc:
+            raise ConfigException(
+                f"Invalid rule-pattern; required field missing. Rule: {pattern}"
+            ) from exc
+
     if rules_files:
+        warnings.warn(
+            "Storing rules in a separate file has been deprecated and will be removed "
+            "in a future release. You should be using the 'rule-patterns' config "
+            " option instead.",
+            DeprecationWarning,
+        )
         all_files: List[TextIO] = list(rules_files)
     else:
         all_files = []

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -174,16 +174,16 @@ def configure_regexes(
         try:
             for pattern in rule_patterns:
                 rule = Rule(
-                    name=pattern.get("reason"),
+                    name=pattern["reason"],
                     pattern=re.compile(pattern["pattern"]),
                     path_pattern=re.compile(pattern.get("path-pattern", "")),
-                    re_match_type="search",
+                    re_match_type=MatchType.Search,
                     re_match_scope=None,
                 )
                 rules.add(rule)
         except KeyError as exc:
             raise ConfigException(
-                f"Invalid rule-pattern; required field missing. Rule: {pattern}"
+                f"Invalid rule-pattern; both reason and pattern are required fields. Rule: {pattern}"
             ) from exc
 
     if rules_files:

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -742,9 +742,15 @@ class GitRepoScanner(GitScanner):
                 commits = [self._repo.get(self._repo.head.target)]
             else:
                 branch = self._repo.branches.get(branch_name)
-                commits = self._repo.walk(
-                    branch.resolve().target, pygit2.GIT_SORT_TOPOLOGICAL
-                )
+                try:
+                    commits = self._repo.walk(
+                        branch.resolve().target, pygit2.GIT_SORT_TOPOLOGICAL
+                    )
+                except AttributeError:
+                    self.logger.debug(
+                        "Skipping branch %s because it cannot be resolved.", branch_name
+                    )
+                    continue
             diff_hash: bytes
             curr_commit: pygit2.Commit = None
             prev_commit: pygit2.Commit = None

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -298,6 +298,7 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
                 self._rules_regexes = config.configure_regexes(
                     self.global_options.default_regexes,
                     self.global_options.rules,
+                    self.global_options.rule_patterns,
                     self.global_options.git_rules_repo,
                     self.global_options.git_rules_files,
                 )

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -295,11 +295,11 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
             self.logger.info("Initializing regex rules")
             try:
                 self._rules_regexes = config.configure_regexes(
-                    self.global_options.default_regexes,
-                    self.global_options.rules,
-                    self.global_options.rule_patterns,
-                    self.global_options.git_rules_repo,
-                    self.global_options.git_rules_files,
+                    include_default=self.global_options.default_regexes,
+                    rules_files=self.global_options.rules,
+                    rule_patterns=self.global_options.rule_patterns,
+                    rules_repo=self.global_options.git_rules_repo,
+                    rules_repo_files=self.global_options.git_rules_files,
                 )
             except (ValueError, re.error) as exc:
                 self.logger.exception("Error loading regex rules", exc_info=exc)

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -58,7 +58,7 @@ class GlobalOptions:
         "entropy_sensitivity",
     )
     rules: Tuple[TextIO, ...]
-    rule_patterns: Tuple[str, ...]
+    rule_patterns: Tuple[Dict[str, str], ...]
     default_regexes: bool
     entropy: bool
     regex: bool

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -36,6 +36,7 @@ class OutputFormat(enum.Enum):
 class GlobalOptions:
     __slots__ = (
         "rules",
+        "rule_patterns",
         "default_regexes",
         "entropy",
         "regex",
@@ -57,6 +58,7 @@ class GlobalOptions:
         "entropy_sensitivity",
     )
     rules: Tuple[TextIO, ...]
+    rule_patterns: Tuple[str, ...]
     default_regexes: bool
     entropy: bool
     regex: bool

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -256,11 +256,12 @@ class RegexRulesTests(ScannerTestCase):
     ):
         self.options.default_regexes = True
         self.options.rules = "foo"  # type: ignore
+        self.options.rule_patterns = "oof"  # type: ignore
         self.options.git_rules_repo = "bar"
         self.options.git_rules_files = "baz"  # type: ignore
         test_scanner = TestScanner(self.options)
         test_scanner.rules_regexes  # pylint: disable=pointless-statement
-        mock_configure.assert_called_once_with(True, "foo", "bar", "baz")
+        mock_configure.assert_called_once_with(True, "foo", "oof", "bar", "baz")
 
 
 class SignatureTests(ScannerTestCase):

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -246,7 +246,7 @@ class RegexRulesTests(ScannerTestCase):
         self, mock_configure: mock.MagicMock
     ):
         test_scanner = TestScanner(self.options)
-        test_scanner._rules_regexes = {}  # pylint: disable=protected-access
+        test_scanner._rules_regexes = set()  # pylint: disable=protected-access
         test_scanner.rules_regexes  # pylint: disable=pointless-statement
         mock_configure.assert_not_called()
 
@@ -305,22 +305,22 @@ class RegexScanTests(ScannerTestCase):
         rule_3_path.match = mock.MagicMock(return_value=[])
         test_scanner = TestScanner(self.options)
         test_scanner._rules_regexes = {  # pylint: disable=protected-access
-            "foo": Rule(
-                name=None,
+            Rule(
+                name="foo",
                 pattern=rule_1,
                 path_pattern=None,
                 re_match_type=MatchType.Match,
                 re_match_scope=None,
             ),
-            "bar": Rule(
-                name=None,
+            Rule(
+                name="bar",
                 pattern=rule_2,
                 path_pattern=rule_2_path,
                 re_match_type=MatchType.Match,
                 re_match_scope=None,
             ),
-            "not-found": Rule(
-                name=None,
+            Rule(
+                name="not-found",
                 pattern=rule_3,
                 path_pattern=rule_3_path,
                 re_match_type=MatchType.Match,
@@ -342,8 +342,8 @@ class RegexScanTests(ScannerTestCase):
         mock_signature.return_value = True
         test_scanner = TestScanner(self.options)
         test_scanner._rules_regexes = {  # pylint: disable=protected-access
-            "foo": Rule(
-                name=None,
+            Rule(
+                name="foo",
                 pattern=re.compile("foo"),
                 path_pattern=None,
                 re_match_type=MatchType.Match,
@@ -362,8 +362,8 @@ class RegexScanTests(ScannerTestCase):
         mock_signature.return_value = False
         test_scanner = TestScanner(self.options)
         test_scanner._rules_regexes = {  # pylint: disable=protected-access
-            "foo": Rule(
-                name=None,
+            Rule(
+                name="foo",
                 pattern=re.compile("foo"),
                 path_pattern=None,
                 re_match_type=MatchType.Match,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,14 +19,14 @@ class ConfigureRegexTests(unittest.TestCase):
         rules_path = pathlib.Path(__file__).parent / "data" / "testRules.json"
         rules_files = (rules_path.open(),)
         expected_regexes = {
-            "RSA private key 2": Rule(
+            Rule(
                 name="RSA private key 2",
                 pattern=re.compile("-----BEGIN EC PRIVATE KEY-----"),
                 path_pattern=None,
                 re_match_type=MatchType.Match,
                 re_match_scope=None,
             ),
-            "Complex Rule": Rule(
+            Rule(
                 name="Complex Rule",
                 pattern=re.compile("complex-rule"),
                 path_pattern=re.compile("/tmp/[a-z0-9A-Z]+\\.(py|js|json)"),
@@ -50,19 +50,23 @@ class ConfigureRegexTests(unittest.TestCase):
         rules_files = (rules_path.open(),)
         with config.DEFAULT_PATTERN_FILE.open() as handle:
             expected_regexes = config.load_rules_from_file(handle)
-        expected_regexes["RSA private key 2"] = Rule(
-            name="RSA private key 2",
-            pattern=re.compile("-----BEGIN EC PRIVATE KEY-----"),
-            path_pattern=None,
-            re_match_type=MatchType.Match,
-            re_match_scope=None,
+        expected_regexes.add(
+            Rule(
+                name="RSA private key 2",
+                pattern=re.compile("-----BEGIN EC PRIVATE KEY-----"),
+                path_pattern=None,
+                re_match_type=MatchType.Match,
+                re_match_scope=None,
+            )
         )
-        expected_regexes["Complex Rule"] = Rule(
-            name="Complex Rule",
-            pattern=re.compile("complex-rule"),
-            path_pattern=re.compile("/tmp/[a-z0-9A-Z]+\\.(py|js|json)"),
-            re_match_type=MatchType.Match,
-            re_match_scope=None,
+        expected_regexes.add(
+            Rule(
+                name="Complex Rule",
+                pattern=re.compile("complex-rule"),
+                path_pattern=re.compile("/tmp/[a-z0-9A-Z]+\\.(py|js|json)"),
+                re_match_type=MatchType.Match,
+                re_match_scope=None,
+            )
         )
 
         actual_regexes = config.configure_regexes(
@@ -140,14 +144,14 @@ class ConfigureRegexTests(unittest.TestCase):
             rules_repo_files=["testRules.json"],
         )
         expected_regexes = {
-            "RSA private key 2": Rule(
+            Rule(
                 name="RSA private key 2",
                 pattern=re.compile("-----BEGIN EC PRIVATE KEY-----"),
                 path_pattern=None,
                 re_match_type=MatchType.Match,
                 re_match_scope=None,
             ),
-            "Complex Rule": Rule(
+            Rule(
                 name="Complex Rule",
                 pattern=re.compile("complex-rule"),
                 path_pattern=re.compile("/tmp/[a-z0-9A-Z]+\\.(py|js|json)"),
@@ -312,7 +316,7 @@ class CompileRulesTests(unittest.TestCase):
                 {"path-pattern": r"src/.*", "pattern": r"^[a-zA-Z0-9]{26}::test$"},
             ]
         )
-        self.assertEqual(
+        self.assertCountEqual(
             rules,
             list(
                 {


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [X] Tests (if applicable)
* [x] Documentation (if applicable)
* [x] Changelog entry
* [X] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [X] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [X] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->
Fixes #256 

## What's new?
- A new `rule-patterns` configuration option has been added to move the contents of rules files directly into the tartufo config file.
- Using the old `--rules` option will now raise a `DeprecationWarning`.