### PR TITLE
Updating --include-path-patterns and --exclude-path-patterns to use a table of tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Features:
   that was still stored in an external file.
 * [#202](https://github.com/godaddy/tartufo/issues/202) - Supports new format of exclusions in config file 
   with the ability to specify the reason along with exclusion
+* [#257](https://github.com/godaddy/tartufo/issues/257) - Supports new format of include-path-patterns and
+  exclude-path-patterns in config file with the ability to specify the reason along with the path-patterns.
 
 v3.0.0-alpha.1 - 11 November 2021
 ---------------------------------

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -106,10 +106,11 @@ class TartufoCLI(click.MultiCommand):
     multiple=True,
     hidden=True,
     help="""Specify a regular expression which matches Git object paths to
-    include in the scan. This option can be specified multiple times to include
-    multiple patterns. If not provided (default), all Git object paths are
-    included unless otherwise excluded via the --exclude-path-patterns
-    option.""",
+    include in the scan along with the reason. This option can be specified
+    multiple times to include multiple patterns. If not provided (default),
+    all Git object paths are included unless otherwise excluded via the
+    --include-path=[{path_pattern='path_pattern', reason='Test path pattern
+    that needs to be included'}] option.""",
 )
 @click.option(
     "-x",
@@ -117,10 +118,11 @@ class TartufoCLI(click.MultiCommand):
     multiple=True,
     hidden=True,
     help="""Specify a regular expression which matches Git object paths to
-    exclude from the scan. This option can be specified multiple times to
-    exclude multiple patterns. If not provided (default), no Git object paths
-    are excluded unless effectively excluded via the --include-path-patterns
-    option.""",
+    exclude from the scan along with the reason. This option can be specified
+    multiple times to exclude multiple patterns. If not provided (default),
+    no Git object paths are excluded unless effectively excluded via the
+    --exclude-path=[{path_pattern='path_pattern', reason='Test path pattern
+    that needs to be excluded'}] option.""",
 )
 @click.option(
     "-of",

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -88,8 +88,9 @@ class TartufoCLI(click.MultiCommand):
     help="""Specify a regular expression which matches Git object paths to
     include in the scan. Multiple patterns can be included in the config file using
     include-path-patterns = [{path-pattern="pattern", reason="reason to include pattern},].
-    If not provided (default), all Git object paths are included unless otherwise excluded using
-    exclude-path-patterns""",
+    If not provided (default), all Git object paths
+    are included unless otherwise excluded via the --exclude-path-patterns
+    option.""",
 )
 @click.option(
     "-xp",

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -84,7 +84,7 @@ class TartufoCLI(click.MultiCommand):
     "-ip",
     "--include-path-patterns",
     multiple=True,
-    help="""Specify a regular expression which matches Git object paths to
+    help="""[DEPRECATED] Specify a regular expression which matches Git object paths to
     include in the scan. This option can be specified multiple times to include
     multiple patterns. If not provided (default), all Git object paths are
     included unless otherwise excluded via the --exclude-path-patterns
@@ -94,6 +94,28 @@ class TartufoCLI(click.MultiCommand):
     "-xp",
     "--exclude-path-patterns",
     multiple=True,
+    help="""[DEPRECATED] Specify a regular expression which matches Git object paths to
+    exclude from the scan. This option can be specified multiple times to
+    exclude multiple patterns. If not provided (default), no Git object paths
+    are excluded unless effectively excluded via the --include-path-patterns
+    option.""",
+)
+@click.option(
+    "-i",
+    "--include-path",
+    multiple=True,
+    hidden=True,
+    help="""Specify a regular expression which matches Git object paths to
+    include in the scan. This option can be specified multiple times to include
+    multiple patterns. If not provided (default), all Git object paths are
+    included unless otherwise excluded via the --exclude-path-patterns
+    option.""",
+)
+@click.option(
+    "-x",
+    "--exclude-path",
+    multiple=True,
+    hidden=True,
     help="""Specify a regular expression which matches Git object paths to
     exclude from the scan. This option can be specified multiple times to
     exclude multiple patterns. If not provided (default), no Git object paths

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -84,45 +84,24 @@ class TartufoCLI(click.MultiCommand):
     "-ip",
     "--include-path-patterns",
     multiple=True,
-    help="""[DEPRECATED] Specify a regular expression which matches Git object paths to
-    include in the scan. This option can be specified multiple times to include
-    multiple patterns. If not provided (default), all Git object paths are
-    included unless otherwise excluded via the --exclude-path-patterns
-    option.""",
+    hidden=True,
+    help="""Specify a regular expression which matches Git object paths to
+    include in the scan. Multiple patterns can be included in the config file using
+    include-path-patterns = [{path-pattern="pattern", reason="reason to include pattern},].
+    If not provided (default), all Git object paths are included unless otherwise excluded using
+    exclude-path-patterns""",
 )
 @click.option(
     "-xp",
     "--exclude-path-patterns",
     multiple=True,
-    help="""[DEPRECATED] Specify a regular expression which matches Git object paths to
-    exclude from the scan. This option can be specified multiple times to
-    exclude multiple patterns. If not provided (default), no Git object paths
+    hidden=True,
+    help="""Specify a regular expression which matches Git object paths to
+    exclude from the scan. Multiple patterns can be excluded in the config file using
+    exclude-path-patterns = [{path-pattern="pattern", reason="reason to exclude pattern},].
+    If not provided (default), no Git object paths
     are excluded unless effectively excluded via the --include-path-patterns
     option.""",
-)
-@click.option(
-    "-i",
-    "--include-path",
-    multiple=True,
-    hidden=True,
-    help="""Specify a regular expression which matches Git object paths to
-    include in the scan along with the reason. This option can be specified
-    multiple times to include multiple patterns. If not provided (default),
-    all Git object paths are included unless otherwise excluded via the
-    --include-path=[{path_pattern='path_pattern', reason='Test path pattern
-    that needs to be included'}] option.""",
-)
-@click.option(
-    "-x",
-    "--exclude-path",
-    multiple=True,
-    hidden=True,
-    help="""Specify a regular expression which matches Git object paths to
-    exclude from the scan along with the reason. This option can be specified
-    multiple times to exclude multiple patterns. If not provided (default),
-    no Git object paths are excluded unless effectively excluded via the
-    --exclude-path=[{path_pattern='path_pattern', reason='Test path pattern
-    that needs to be excluded'}] option.""",
 )
 @click.option(
     "-of",

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -247,20 +247,7 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
         if self._included_paths is None:
             self.logger.info("Initializing included paths")
             patterns = list(self.global_options.include_path_patterns or ())  # type: ignore
-            if all(isinstance(pattern, str) for pattern in patterns):
-                warnings.warn(
-                    "Old format of --include-path-patterns option and config file setup include-path-patterns "
-                    "= ['inclusion pattern'] has been deprecated and will be removed in a future version. "
-                    "Make sure all the inclusions are set up using new pattern i.e. include-path-patterns = "
-                    "[path-pattern='inclusion pattern',reason='reason for inclusion'] in the config file",
-                    DeprecationWarning,
-                )
-                self._included_paths = (
-                    config.compile_path_rules(set(cast(List[str], patterns)))
-                    if patterns
-                    else []
-                )
-            elif all(isinstance(pattern, dict) for pattern in patterns):
+            try:
                 patterns = [
                     pattern["path-pattern"]
                     for pattern in cast(List[Dict[str, str]], patterns)
@@ -270,12 +257,25 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
                     if patterns
                     else []
                 )
-            else:
-                self.logger.error(
-                    "Combination of old and new format of include-path-patterns will not be supported."
+                return self._included_paths
+            except TypeError:
+                warnings.warn(
+                    "Old format of --include-path-patterns option and config file setup include-path-patterns "
+                    "= ['inclusion pattern'] has been deprecated and will be removed in a future version. "
+                    "Make sure all the inclusions are set up using new pattern i.e. include-path-patterns = "
+                    "[path-pattern='inclusion pattern',reason='reason for inclusion'] in the config file",
+                    DeprecationWarning,
                 )
+            try:
+                self._included_paths = (
+                    config.compile_path_rules(set(cast(List[str], patterns)))
+                    if patterns
+                    else []
+                )
+                return self._included_paths
+            except TypeError as exc:
                 raise types.ConfigException(
-                    "Combination of old and new format of include-path-patterns will not be supported."
+                    f"Combination of old and new format of include-path-patterns will not be supported.\n{exc}"
                 )
             self.logger.debug(
                 "Included paths was initialized as: %s", self._included_paths
@@ -306,20 +306,7 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
         if self._excluded_paths is None:
             self.logger.info("Initializing excluded paths")
             patterns = list(self.global_options.exclude_path_patterns or ())
-            if all(isinstance(x, str) for x in patterns):
-                warnings.warn(
-                    "Old format of '--exclude-path-patterns option' and config file setup 'exclude-path-patterns "
-                    "= ['exclusion pattern']' has been deprecated and will be removed in a future version. "
-                    "Make sure all the exclusions are set up using new pattern i.e. exclude-path-patterns = "
-                    "[path-pattern='exclusion pattern',reason='reason for exclusion'] in the config file",
-                    DeprecationWarning,
-                )
-                self._excluded_paths = (
-                    config.compile_path_rules(set(cast(List[str], patterns)))
-                    if patterns
-                    else []
-                )
-            elif all(isinstance(x, dict) for x in patterns):
+            try:
                 patterns = [
                     pattern["path-pattern"]
                     for pattern in cast(List[Dict[str, str]], patterns)
@@ -329,12 +316,25 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
                     if patterns
                     else []
                 )
-            else:
-                self.logger.error(
-                    "Combination of old and new format of exclude-path-patterns will not be supported."
+                return self._excluded_paths
+            except TypeError:
+                warnings.warn(
+                    "Old format of '--exclude-path-patterns option' and config file setup 'exclude-path-patterns "
+                    "= ['exclusion pattern']' has been deprecated and will be removed in a future version. "
+                    "Make sure all the exclusions are set up using new pattern i.e. exclude-path-patterns = "
+                    "[path-pattern='exclusion pattern',reason='reason for exclusion'] in the config file",
+                    DeprecationWarning,
                 )
+            try:
+                self._excluded_paths = (
+                    config.compile_path_rules(set(cast(List[str], patterns)))
+                    if patterns
+                    else []
+                )
+                return self._excluded_paths
+            except TypeError as exc:
                 raise types.ConfigException(
-                    "Combination of old and new format of exclude-path-patterns will not be supported."
+                    f"Combination of old and new format of exclude-path-patterns will not be supported.\n{exc}"
                 )
             self.logger.debug(
                 "Excluded paths was initialized as: %s", self._excluded_paths

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -258,8 +258,8 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
             self.logger.info("Initializing included paths")
             patterns = list(self.global_options.include_path_patterns or ())  # type: ignore
             include_patterns = list(self.config_data.get("include_path_patterns", ()))
-            patterns = list(patterns + include_patterns)
             try:
+                patterns = patterns + [x for x in include_patterns if x not in patterns]
                 patterns = [
                     pattern["path-pattern"]
                     for pattern in cast(List[Dict[str, str]], patterns)
@@ -282,6 +282,7 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
                     DeprecationWarning,
                 )
             try:
+                patterns = list(set(patterns + include_patterns))
                 self._included_paths = (
                     config.compile_path_rules(set(cast(List[str], patterns)))
                     if patterns

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -150,7 +150,6 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
     global_options: types.GlobalOptions
     logger: logging.Logger
     _scan_lock: threading.Lock = threading.Lock()
-    _config_data: MutableMapping[str, Any] = {}
 
     def __init__(self, options: types.GlobalOptions) -> None:
         self.global_options = options
@@ -277,9 +276,7 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
                 raise types.ConfigException(
                     f"Combination of old and new format of include-path-patterns will not be supported.\n{exc}"
                 )
-            self.logger.debug(
-                "Included paths was initialized as: %s", self._included_paths
-            )
+        self.logger.debug("Included paths was initialized as: %s", self._included_paths)
         return self._included_paths
 
     @property
@@ -336,9 +333,7 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
                 raise types.ConfigException(
                     f"Combination of old and new format of exclude-path-patterns will not be supported.\n{exc}"
                 )
-            self.logger.debug(
-                "Excluded paths was initialized as: %s", self._excluded_paths
-            )
+        self.logger.debug("Excluded paths was initialized as: %s", self._excluded_paths)
         return self._excluded_paths
 
     @property

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -265,7 +265,7 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
                     "Old format of --include-path-patterns option and config file setup include-path-patterns "
                     "= ['inclusion pattern'] has been deprecated and will be removed in a future version. "
                     "Make sure all the inclusions are set up using new pattern i.e. include-path-patterns = "
-                    "[path-pattern='inclusion pattern',reason='reason for inclusion'] in the config file",
+                    "[{path-pattern='inclusion pattern',reason='reason for inclusion'}] in the config file",
                     DeprecationWarning,
                 )
             try:
@@ -322,7 +322,7 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
                     "Old format of '--exclude-path-patterns option' and config file setup 'exclude-path-patterns "
                     "= ['exclusion pattern']' has been deprecated and will be removed in a future version. "
                     "Make sure all the exclusions are set up using new pattern i.e. exclude-path-patterns = "
-                    "[path-pattern='exclusion pattern',reason='reason for exclusion'] in the config file",
+                    "[{path-pattern='exclusion pattern',reason='reason for exclusion'}] in the config file",
                     DeprecationWarning,
                 )
             try:

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -42,8 +42,6 @@ class GlobalOptions:
         "scan_filenames",
         "include_path_patterns",
         "exclude_path_patterns",
-        "include_path",
-        "exclude_path",
         "exclude_entropy_patterns",
         "exclude_signatures",
         "output_dir",
@@ -63,10 +61,8 @@ class GlobalOptions:
     entropy: bool
     regex: bool
     scan_filenames: bool
-    include_path_patterns: Tuple[str, ...]
-    exclude_path_patterns: Tuple[str, ...]
-    include_path: Tuple[Dict[str, str], ...]
-    exclude_path: Tuple[Dict[str, str], ...]
+    include_path_patterns: Union[Tuple[str, ...], Tuple[Dict[str, str], ...]]
+    exclude_path_patterns: Union[Tuple[str, ...], Tuple[Dict[str, str], ...]]
     exclude_entropy_patterns: Tuple[Dict[str, str], ...]
     exclude_signatures: Tuple[str, ...]
     output_dir: Optional[str]

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -42,6 +42,8 @@ class GlobalOptions:
         "scan_filenames",
         "include_path_patterns",
         "exclude_path_patterns",
+        "include_path",
+        "exclude_path",
         "exclude_entropy_patterns",
         "exclude_signatures",
         "output_dir",
@@ -63,6 +65,8 @@ class GlobalOptions:
     scan_filenames: bool
     include_path_patterns: Tuple[str, ...]
     exclude_path_patterns: Tuple[str, ...]
+    include_path: Tuple[Dict[str, str], ...]
+    exclude_path: Tuple[Dict[str, str], ...]
     exclude_entropy_patterns: Tuple[Dict[str, str], ...]
     exclude_signatures: Tuple[str, ...]
     output_dir: Optional[str]

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -61,7 +61,7 @@ class RepoLoadTests(ScannerTestCase):
     def test_extra_inclusions_get_added(self, mock_load: mock.MagicMock):
         mock_load.return_value = (
             self.data_dir / "pyproject.toml",
-            {"include_path_patterns": ("foo/",)},
+            {"include_path_patterns": ("tartufo/", "scripts/")},
         )
         self.global_options.include_path_patterns = ("foo/",)
         test_scanner = scanner.GitRepoScanner(
@@ -70,7 +70,7 @@ class RepoLoadTests(ScannerTestCase):
         test_scanner.load_repo("../tartufo")
         self.assertCountEqual(
             test_scanner.included_paths,
-            [re.compile("foo/")],
+            [re.compile("foo/"), re.compile("tartufo/"), re.compile("scripts/")],
         )
 
     @mock.patch("pygit2.Repository", new=mock.MagicMock())
@@ -78,7 +78,7 @@ class RepoLoadTests(ScannerTestCase):
     def test_extra_exclusions_get_added(self, mock_load: mock.MagicMock):
         mock_load.return_value = (
             self.data_dir / "pyproject.toml",
-            {"exclude_path_patterns": ("bar/",)},
+            {"exclude_path_patterns": ("tests/", r"\.venv/", r".*\.egg-info/")},
         )
         self.global_options.exclude_path_patterns = ("bar/",)
         test_scanner = scanner.GitRepoScanner(
@@ -89,6 +89,9 @@ class RepoLoadTests(ScannerTestCase):
             test_scanner.excluded_paths,
             [
                 re.compile("bar/"),
+                re.compile("tests/"),
+                re.compile(r"\.venv/"),
+                re.compile(r".*\.egg-info/"),
             ],
         )
 

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -471,7 +471,7 @@ class IncludedPathsTests(ScannerTestCase):
         )
         self.assertEqual(test_scanner.included_paths, [re.compile("bar/")])
 
-    def test_error_is_raised_when_two_styles_included_paths_are_configured(self):
+    def test_error_is_not_raised_when_two_styles_included_paths_are_configured(self):
         self.global_options.include_path_patterns = [
             "foo/",
             {"path-pattern": "bar/", "reason": "path pattern"},
@@ -479,9 +479,9 @@ class IncludedPathsTests(ScannerTestCase):
         test_scanner = scanner.GitRepoScanner(
             self.global_options, self.git_options, "."
         )
-        error_msg = "Combination of old and new format of include-path-patterns will not be supported."
-        with self.assertRaisesRegex(types.ConfigException, error_msg):
-            list(test_scanner.included_paths)
+        self.assertCountEqual(
+            test_scanner.included_paths, [re.compile("foo/"), re.compile("bar/")]
+        )
 
 
 class ExcludedPathsTests(ScannerTestCase):
@@ -502,7 +502,7 @@ class ExcludedPathsTests(ScannerTestCase):
         self.assertEqual(test_scanner.excluded_paths, [re.compile("bar/")])
 
     @mock.patch("tartufo.scanner.GitScanner.filter_submodules", mock.MagicMock())
-    def test_error_is_raised_when_two_styles_excluded_paths_are_configured(self):
+    def test_error_is_not_raised_when_two_styles_excluded_paths_are_configured(self):
         self.global_options.exclude_path_patterns = [
             "foo/",
             {"path-pattern": "bar/", "reason": "path pattern"},
@@ -510,9 +510,9 @@ class ExcludedPathsTests(ScannerTestCase):
         test_scanner = scanner.GitRepoScanner(
             self.global_options, self.git_options, "."
         )
-        error_msg = "Combination of old and new format of exclude-path-patterns will not be supported."
-        with self.assertRaisesRegex(types.ConfigException, error_msg):
-            list(test_scanner.excluded_paths)
+        self.assertCountEqual(
+            test_scanner.excluded_paths, [re.compile("foo/"), re.compile("bar/")]
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -476,7 +476,7 @@ class ExcludedSignaturesTests(ScannerTestCase):
             self.global_options, self.git_options, "."
         )
         self.assertCountEqual(test_scanner.excluded_signatures, ("foo/", "bar/"))
-        
+
 
 class IncludedPathsTests(ScannerTestCase):
     def test_old_style_included_paths_are_processed(self):

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -61,7 +61,13 @@ class RepoLoadTests(ScannerTestCase):
     def test_extra_inclusions_get_added(self, mock_load: mock.MagicMock):
         mock_load.return_value = (
             self.data_dir / "pyproject.toml",
-            {"include_paths": "include-files", "include_path_patterns": ("foo/",)},
+            {
+                "include_path_patterns": ("foo/",),
+                "include_path": (
+                    {"path-pattern": "tartufo/", "reason": "tartufo test path"},
+                    {"path-pattern": "scripts/", "reason": "scripts test path"},
+                ),
+            },
         )
         test_scanner = scanner.GitRepoScanner(
             self.global_options, self.git_options, str(self.data_dir)
@@ -77,7 +83,17 @@ class RepoLoadTests(ScannerTestCase):
     def test_extra_exclusions_get_added(self, mock_load: mock.MagicMock):
         mock_load.return_value = (
             self.data_dir / "pyproject.toml",
-            {"exclude_paths": "exclude-files", "exclude_path_patterns": ("bar/",)},
+            {
+                "exclude_path_patterns": ("bar/",),
+                "exclude_path": (
+                    {"path-pattern": "tests/", "reason": "tests test path"},
+                    {"path-pattern": r"\.venv/", "reason": "venv test path"},
+                    {
+                        "path-pattern": r".*\.egg-info/",
+                        "reason": "egg-info test path",
+                    },
+                ),
+            },
         )
         test_scanner = scanner.GitRepoScanner(
             self.global_options, self.git_options, str(self.data_dir)


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [x] Documentation (if applicable)
* [x] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
closes #257 

## What's new?
- Supports table of tables format for `--include-path-patterns` and `--exclude-path-patterns` with an option to specify the reason.
Ex: include-path-patterns = [{path-pattern="path-pattern", reason="reason to include path patterns"}]
- Warns users about deprecation of old format
- Making sure either one the formats is used until the old format is completely deprecated
