### PR TITLE
Fix #245: Better boolean flag help output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Bug fixes:
 Misc:
 
 * [#282](https://github.com/godaddy/tartufo/pull/282) - Remove old style config for `exclude-entropy-patterns`
+* [#291](https://github.com/godaddy/tartufo/pull/291) - Use the latest `click`
+  to provide better output on boolean flag defaults
 
 Features:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Bug fixes:
 Misc:
 
 * [#282](https://github.com/godaddy/tartufo/pull/282) - Remove old style config for `exclude-entropy-patterns`
-* [#291](https://github.com/godaddy/tartufo/pull/291) - Use the latest `click`
+* [#292](https://github.com/godaddy/tartufo/pull/292) - Use the latest `click`
   to provide better output on boolean flag defaults
 
 Features:

--- a/README.md
+++ b/README.md
@@ -45,17 +45,21 @@ Usage: tartufo [OPTIONS] COMMAND [ARGS]...
   commit hook.
 
 Options:
-  --rules FILENAME                Path(s) to regex rules json list file(s).
+  --rules FILENAME                [DEPRECATED] Use the rule-patterns config
+                                  options instead. Path(s) to regex rules json
+                                  list file(s).
   --default-regexes / --no-default-regexes
                                   Whether to include the default regex list
                                   when configuring search patterns. Only
                                   applicable if --rules is also specified.
-                                  [default: True]
-
-  --entropy / --no-entropy        Enable entropy checks.  [default: True]
+                                  [default: default-regexes]
+  --entropy / --no-entropy        Enable entropy checks.  [default: entropy]
   --regex / --no-regex            Enable high signal regexes checks.
-                                  [default: True]
-
+                                  [default: regex]
+  --scan-filenames / --no-scan-filenames
+                                  Check the names of files being scanned as
+                                  well as their contents.  [default: scan-
+                                  filenames]
   -ip, --include-path-patterns TEXT
                                   Specify a regular expression which matches
                                   Git object paths to include in the scan.
@@ -64,7 +68,6 @@ Options:
                                   provided (default), all Git object paths are
                                   included unless otherwise excluded via the
                                   --exclude-path-patterns option.
-
   -xp, --exclude-path-patterns TEXT
                                   Specify a regular expression which matches
                                   Git object paths to exclude from the scan.
@@ -73,7 +76,6 @@ Options:
                                   provided (default), no Git object paths are
                                   excluded unless effectively excluded via the
                                   --include-path-patterns option.
-
   -of, --output-format [json|compact|text]
                                   Specify the format in which the output needs
                                   to be generated `--output-format
@@ -81,30 +83,20 @@ Options:
                                   or `text` can be specified. If not provided
                                   (default) the output will be generated in
                                   `text` format.
-
-  -xe, --exclude-entropy-patterns TEXT
-                                  Specify a regular expression which matches
-                                  entropy strings to exclude from the scan.
-                                  This option can be specified multiple times
-                                  to exclude multiple patterns. If not
-                                  provided (default), no entropy strings will
-                                  be excluded ({path regex}::{pattern regex}).
-
-  -e, --exclude-signatures TEXT   Specify signatures of matches that you
-                                  explicitly want to exclude from the scan,
-                                  and mark as okay. These signatures are
-                                  generated during the scan process, and
-                                  reported out with each individual match.
-                                  This option can be specified multiple times,
-                                  to exclude as many signatures as you would
-                                  like.
-
+  -e, --exclude-signatures TEXT   [DEPRECATED] Use the exclude-findings config
+                                  option instead. Specify signatures of
+                                  matches that you explicitly want to exclude
+                                  from the scan, and mark as okay. These
+                                  signatures are generated during the scan
+                                  process, and reported out with each
+                                  individual match. This option can be
+                                  specified multiple times, to exclude as many
+                                  signatures as you would like.
   -od, --output-dir DIRECTORY     If specified, all issues will be written out
                                   as individual JSON files to a uniquely named
                                   directory under this one. This will help
                                   with keeping the results of individual runs
                                   of tartufo separated.
-
   --git-rules-repo TEXT           A file path, or git URL, pointing to a git
                                   repository containing regex rules to be used
                                   for scanning. By default, all .json files
@@ -112,27 +104,21 @@ Options:
                                   repository. --git-rules-files can be used to
                                   override this behavior and load specific
                                   files.
-
   --git-rules-files TEXT          Used in conjunction with --git-rules-repo,
                                   specify glob-style patterns for files from
                                   which to load the regex rules. Can be
                                   specified multiple times.
-
   --config FILE                   Read configuration from specified file.
                                   [default: tartufo.toml]
-
   -q, --quiet / --no-quiet        Quiet mode. No outputs are reported if the
                                   scan is successful and doesn't find any
                                   issues
-
   -v, --verbose                   Display more verbose output. Specifying this
                                   option multiple times will incrementally
                                   increase the amount of output.
-
   --log-timestamps / --no-log-timestamps
                                   Enable or disable timestamps in logging
-                                  messages.  [default: True]
-
+                                  messages.  [default: log-timestamps]
   --entropy-sensitivity INTEGER RANGE
                                   Modify entropy detection sensitivity. This
                                   is expressed as on a scale of 0 to 100,
@@ -140,8 +126,8 @@ Options:
                                   means "totally random". Decreasing the
                                   scanner's sensitivity increases the
                                   likelihood that a given string will be
-                                  identified as suspicious.  [default: 75]
-
+                                  identified as suspicious.  [default: 75;
+                                  0<=x<=100]
   -b64, --b64-entropy-score TEXT  [DEPRECATED] Use `--entropy-sensitivity`.
                                   Modify the base64 entropy score. If a value
                                   greater than the default (4.5 in a range of
@@ -150,7 +136,6 @@ Options:
                                   randomized strings. A lower value lists
                                   lower entropy base64 strings (shorter or
                                   less randomized strings).
-
   -hex, --hex-entropy-score TEXT  [DEPRECATED] Use `--entropy-sensitivity`.
                                   Modify the hexadecimal entropy score. If a
                                   value greater than the default (3.0 in a
@@ -160,16 +145,14 @@ Options:
                                   value lists lower entropy hexadecimal
                                   strings (shorter or less randomized
                                   strings).
-
   -V, --version                   Show the version and exit.
   -h, --help                      Show this message and exit.
 
 Commands:
-  scan-folder       Scan a folder.
-  scan-remote-repo  Automatically clone and scan a remote git repository.
   pre-commit        Scan staged changes in a pre-commit hook.
+  scan-remote-repo  Automatically clone and scan a remote git repository.
+  scan-folder       Scan a folder.
   scan-local-repo   Scan a repository already cloned to your local system.
-
 ```
 
 ## Contributing

--- a/poetry.lock
+++ b/poetry.lock
@@ -45,10 +45,10 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
-docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
 tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
 
 [[package]]
 name = "babel"
@@ -96,10 +96,10 @@ typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\""}
 typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 
 [package.extras]
+uvloop = ["uvloop (>=0.15.2)"]
+python2 = ["typed-ast (>=1.4.2)"]
 colorama = ["colorama (>=0.4.3)"]
 d = ["aiohttp (>=3.6.0)", "aiohttp-cors (>=0.4.0)"]
-python2 = ["typed-ast (>=1.4.2)"]
-uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "cached-property"
@@ -149,11 +149,15 @@ unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
-version = "7.1.2"
+version = "8.0.3"
 description = "Composable command line interface toolkit"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "colorama"
@@ -287,8 +291,8 @@ typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
@@ -323,10 +327,10 @@ optional = false
 python-versions = ">=3.6.1,<4.0"
 
 [package.extras]
+plugins = ["setuptools"]
 pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
 requirements_deprecated_finder = ["pipreqs", "pip-api"]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
-plugins = ["setuptools"]
 
 [[package]]
 name = "jinja2"
@@ -381,8 +385,8 @@ typed-ast = {version = ">=1.4.0,<1.5.0", markers = "python_version < \"3.8\""}
 typing-extensions = ">=3.7.4"
 
 [package.extras]
-dmypy = ["psutil (>=4.0)"]
 python2 = ["typed-ast (>=1.4.0,<1.5.0)"]
+dmypy = ["psutil (>=4.0)"]
 
 [[package]]
 name = "mypy-extensions"
@@ -420,6 +424,14 @@ optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [[package]]
+name = "pbr"
+version = "5.8.0"
+description = "Python Build Reasonableness"
+category = "main"
+optional = true
+python-versions = ">=2.6"
+
+[[package]]
 name = "platformdirs"
 version = "2.4.0"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -428,8 +440,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)"]
 test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
+docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)"]
 
 [[package]]
 name = "pluggy"
@@ -692,21 +704,20 @@ sphinxcontrib-qthelp = "*"
 sphinxcontrib-serializinghtml = "*"
 
 [package.extras]
-docs = ["sphinxcontrib-websupport"]
 lint = ["flake8 (>=3.5.0)", "isort", "mypy (>=0.800)", "docutils-stubs"]
 test = ["pytest", "pytest-cov", "html5lib", "cython", "typed-ast"]
+docs = ["sphinxcontrib-websupport"]
 
 [[package]]
 name = "sphinx-click"
-version = "2.7.1"
+version = "2.5.0"
 description = "Sphinx extension that automatically documents click applications"
 category = "main"
 optional = true
 python-versions = "*"
 
 [package.dependencies]
-click = ">=6.0,<8.0"
-docutils = "*"
+pbr = ">=2.0"
 sphinx = ">=1.5,<4.0"
 
 [[package]]
@@ -809,9 +820,9 @@ PyEnchant = ">=3.1.1"
 Sphinx = ">=3.0.0"
 
 [package.extras]
+test = ["pytest", "pytest-cov", "fixtures (>=3.0.0)", "coverage (>=4.0,!=4.4)"]
 docs = ["reno"]
 linter = ["flake8 (==3.8.2)"]
-test = ["pytest", "pytest-cov", "fixtures (>=3.0.0)", "coverage (>=4.0,!=4.4)"]
 
 [[package]]
 name = "termcolor"
@@ -901,9 +912,9 @@ optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 brotli = ["brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
-socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
@@ -963,7 +974,7 @@ docs = ["recommonmark", "sphinx", "sphinx-click", "sphinx-rtd-theme", "sphinxcon
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "1a280535a4c13f09a63bf8763ab5fc32b1975c7fd4eacc06dc7526373f9099f7"
+content-hash = "9923e6dc6bad14941ccf5e303dbf937401a5acd9e5f2fb9eca1710a5acb94c6d"
 
 [metadata.files]
 alabaster = [
@@ -1067,8 +1078,8 @@ charset-normalizer = [
     {file = "charset_normalizer-2.0.7-py3-none-any.whl", hash = "sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b"},
 ]
 click = [
-    {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
-    {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
+    {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
+    {file = "click-8.0.3.tar.gz", hash = "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
@@ -1293,6 +1304,10 @@ pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
 ]
+pbr = [
+    {file = "pbr-5.8.0-py2.py3-none-any.whl", hash = "sha256:176e8560eaf61e127817ef93d8a844803abb27a4d4637f0ff3bb783129be2e0a"},
+    {file = "pbr-5.8.0.tar.gz", hash = "sha256:672d8ebee84921862110f23fcec2acea191ef58543d34dfe9ef3d9f13c31cddf"},
+]
 platformdirs = [
     {file = "platformdirs-2.4.0-py3-none-any.whl", hash = "sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d"},
     {file = "platformdirs-2.4.0.tar.gz", hash = "sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2"},
@@ -1467,8 +1482,8 @@ sphinx = [
     {file = "Sphinx-3.5.4.tar.gz", hash = "sha256:19010b7b9fa0dc7756a6e105b2aacd3a80f798af3c25c273be64d7beeb482cb1"},
 ]
 sphinx-click = [
-    {file = "sphinx-click-2.7.1.tar.gz", hash = "sha256:1b6175df5392564fd3780000d4627e5a2c8c3b29d05ad311dbbe38fcf5f3327b"},
-    {file = "sphinx_click-2.7.1-py2.py3-none-any.whl", hash = "sha256:e738a2c7a87f23e67da4a9e28ca6f085d3ca626f0e4164847f77ff3c36c65df1"},
+    {file = "sphinx-click-2.5.0.tar.gz", hash = "sha256:8ba44ca446ba4bb0585069b8aabaa81e833472d6669b36924a398405311d206f"},
+    {file = "sphinx_click-2.5.0-py2.py3-none-any.whl", hash = "sha256:6848ba2d084ef2feebae0ce3603c1c02a2ba5ded54fb6c0cf24fd01204a945f3"},
 ]
 sphinx-rtd-theme = [
     {file = "sphinx_rtd_theme-0.5.2-py2.py3-none-any.whl", hash = "sha256:4a05bdbe8b1446d77a01e20a23ebc6777c74f43237035e76be89699308987d6f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ tartufo = "tartufo.cli:main"
 [tool.poetry.dependencies]
 GitPython = "<3.1.20"
 pygit2 = "~1.6"
-click = "^7"
+click = "^8.0.3"
 colorama = {version = "*", markers = "sys_platform == 'win32'"}
 dataclasses = {version = "*", python = "< 3.7"}
 python = "^3.6.2"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import os.path
 import unittest
 from collections import namedtuple
 from pathlib import Path
@@ -106,14 +105,10 @@ class ProcessIssuesTest(unittest.TestCase):
                 cli.main, ["--output-dir", "./foo", "scan-local-repo", "."]
             )
         # Perform a little bit of trickery to make absolutely certain we get a full absolute path
-        # Adapted from https://github.com/pallets/click/pull/2006/files
-        output_dir = (
-            Path(dirname) / "foo" / "tartufo-scan-results-nownownow"
-        ).resolve()
-        dirname = os.path.dirname(os.path.abspath(output_dir))
-        if os.path.islink(output_dir):
-            output_dir = os.readlink(output_dir)  # type: ignore
-        output_dir = os.path.join(dirname, output_dir)  # type: ignore
+        # Adapted from https://github.com/pallets/click/pull/2094/files
+        output_dir = os.fsdecode(
+            (Path(dirname) / "foo" / "tartufo-scan-results-nownownow").resolve()
+        )
         self.assertEqual(
             result.output,
             f"Results have been saved in {output_dir}\n",
@@ -142,14 +137,10 @@ class ProcessIssuesTest(unittest.TestCase):
                 cli.main, ["--output-dir", "./foo", "scan-local-repo", "."]
             )
         # Perform a little bit of trickery to make absolutely certain we get a full absolute path
-        # Adapted from https://github.com/pallets/click/pull/2006/files
-        output_dir = (
-            Path(dirname) / "foo" / "tartufo-scan-results-nownownow"
-        ).resolve()
-        dirname = os.path.dirname(os.path.abspath(output_dir))
-        if os.path.islink(output_dir):
-            output_dir = os.readlink(output_dir)  # type: ignore
-        output_dir = os.path.join(dirname, output_dir)  # type: ignore
+        # Adapted from https://github.com/pallets/click/pull/2094/files
+        output_dir = os.fsdecode(
+            (Path(dirname) / "foo" / "tartufo-scan-results-nownownow").resolve()
+        )
         self.assertEqual(
             result.output,
             f"Results have been saved in {output_dir}\n",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,9 +103,11 @@ class ProcessIssuesTest(unittest.TestCase):
             result = runner.invoke(
                 cli.main, ["--output-dir", "./foo", "scan-local-repo", "."]
             )
+        # Perform a little bit of trickery to make absolutely certain we get a full absolute path
         output_dir = (
-            Path(dirname) / "foo" / "tartufo-scan-results-nownownow"
-        ).resolve()
+            Path.cwd()
+            / (Path(dirname) / "foo" / "tartufo-scan-results-nownownow").resolve()
+        )
         self.assertEqual(
             result.output,
             f"Results have been saved in {output_dir}\n",
@@ -133,9 +135,11 @@ class ProcessIssuesTest(unittest.TestCase):
             result = runner.invoke(
                 cli.main, ["--output-dir", "./foo", "scan-local-repo", "."]
             )
+        # Perform a little bit of trickery to make absolutely certain we get a full absolute path
         output_dir = (
-            Path(dirname) / "foo" / "tartufo-scan-results-nownownow"
-        ).resolve()
+            Path.cwd()
+            / (Path(dirname) / "foo" / "tartufo-scan-results-nownownow").resolve()
+        )
         self.assertEqual(
             result.output,
             f"Results have been saved in {output_dir}\n",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import unittest
 from collections import namedtuple
 from pathlib import Path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -101,14 +101,14 @@ class ProcessIssuesTest(unittest.TestCase):
         mock_dt.now.return_value.isoformat.return_value = "nownownow"
         runner = CliRunner()
         with runner.isolated_filesystem() as dirname:
+            # Perform a little bit of trickery to make absolutely certain we get a full absolute path
+            # Adapted from https://github.com/pallets/click/pull/2094/files
+            output_dir = os.fsdecode(
+                (Path(dirname) / "foo" / "tartufo-scan-results-nownownow").resolve()
+            )
             result = runner.invoke(
                 cli.main, ["--output-dir", "./foo", "scan-local-repo", "."]
             )
-        # Perform a little bit of trickery to make absolutely certain we get a full absolute path
-        # Adapted from https://github.com/pallets/click/pull/2094/files
-        output_dir = os.fsdecode(
-            (Path(dirname) / "foo" / "tartufo-scan-results-nownownow").resolve()
-        )
         self.assertEqual(
             result.output,
             f"Results have been saved in {output_dir}\n",
@@ -133,14 +133,14 @@ class ProcessIssuesTest(unittest.TestCase):
         mock_dt.now.return_value.isoformat.return_value = "now:now:now"
         runner = CliRunner()
         with runner.isolated_filesystem() as dirname:
+            # Perform a little bit of trickery to make absolutely certain we get a full absolute path
+            # Adapted from https://github.com/pallets/click/pull/2094/files
+            output_dir = os.fsdecode(
+                (Path(dirname) / "foo" / "tartufo-scan-results-nownownow").resolve()
+            )
             result = runner.invoke(
                 cli.main, ["--output-dir", "./foo", "scan-local-repo", "."]
             )
-        # Perform a little bit of trickery to make absolutely certain we get a full absolute path
-        # Adapted from https://github.com/pallets/click/pull/2094/files
-        output_dir = os.fsdecode(
-            (Path(dirname) / "foo" / "tartufo-scan-results-nownownow").resolve()
-        )
         self.assertEqual(
             result.output,
             f"Results have been saved in {output_dir}\n",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import os.path
 import unittest
 from collections import namedtuple
 from pathlib import Path
@@ -104,10 +106,14 @@ class ProcessIssuesTest(unittest.TestCase):
                 cli.main, ["--output-dir", "./foo", "scan-local-repo", "."]
             )
         # Perform a little bit of trickery to make absolutely certain we get a full absolute path
+        # Adapted from https://github.com/pallets/click/pull/2006/files
         output_dir = (
-            Path.cwd()
-            / (Path(dirname) / "foo" / "tartufo-scan-results-nownownow").resolve()
-        )
+            Path(dirname) / "foo" / "tartufo-scan-results-nownownow"
+        ).resolve()
+        dirname = os.path.dirname(os.path.abspath(output_dir))
+        if os.path.islink(output_dir):
+            output_dir = os.readlink(output_dir)  # type: ignore
+        output_dir = os.path.join(dirname, output_dir)  # type: ignore
         self.assertEqual(
             result.output,
             f"Results have been saved in {output_dir}\n",
@@ -136,10 +142,14 @@ class ProcessIssuesTest(unittest.TestCase):
                 cli.main, ["--output-dir", "./foo", "scan-local-repo", "."]
             )
         # Perform a little bit of trickery to make absolutely certain we get a full absolute path
+        # Adapted from https://github.com/pallets/click/pull/2006/files
         output_dir = (
-            Path.cwd()
-            / (Path(dirname) / "foo" / "tartufo-scan-results-nownownow").resolve()
-        )
+            Path(dirname) / "foo" / "tartufo-scan-results-nownownow"
+        ).resolve()
+        dirname = os.path.dirname(os.path.abspath(output_dir))
+        if os.path.islink(output_dir):
+            output_dir = os.readlink(output_dir)  # type: ignore
+        output_dir = os.path.join(dirname, output_dir)  # type: ignore
         self.assertEqual(
             result.output,
             f"Results have been saved in {output_dir}\n",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -101,17 +101,14 @@ class ProcessIssuesTest(unittest.TestCase):
         mock_dt.now.return_value.isoformat.return_value = "nownownow"
         runner = CliRunner()
         with runner.isolated_filesystem() as dirname:
-            # Perform a little bit of trickery to make absolutely certain we get a full absolute path
-            # Adapted from https://github.com/pallets/click/pull/2094/files
-            output_dir = os.fsdecode(
-                (Path(dirname) / "foo" / "tartufo-scan-results-nownownow").resolve()
-            )
+            output_dir = (Path(dirname) / "foo").resolve()
             result = runner.invoke(
-                cli.main, ["--output-dir", "./foo", "scan-local-repo", "."]
+                cli.main, ["--output-dir", str(output_dir), "scan-local-repo", "."]
             )
+        result_dir = output_dir / "tartufo-scan-results-nownownow"
         self.assertEqual(
             result.output,
-            f"Results have been saved in {output_dir}\n",
+            f"Results have been saved in {result_dir}\n",
         )
 
     @unittest.skipUnless(helpers.WINDOWS, "Test is Windows-only")
@@ -133,17 +130,14 @@ class ProcessIssuesTest(unittest.TestCase):
         mock_dt.now.return_value.isoformat.return_value = "now:now:now"
         runner = CliRunner()
         with runner.isolated_filesystem() as dirname:
-            # Perform a little bit of trickery to make absolutely certain we get a full absolute path
-            # Adapted from https://github.com/pallets/click/pull/2094/files
-            output_dir = os.fsdecode(
-                (Path(dirname) / "foo" / "tartufo-scan-results-nownownow").resolve()
-            )
+            output_dir = (Path(dirname) / "foo").resolve()
             result = runner.invoke(
-                cli.main, ["--output-dir", "./foo", "scan-local-repo", "."]
+                cli.main, ["--output-dir", str(output_dir), "scan-local-repo", "."]
             )
+        result_dir = output_dir / "tartufo-scan-results-nownownow"
         self.assertEqual(
             result.output,
-            f"Results have been saved in {output_dir}\n",
+            f"Results have been saved in {result_dir}\n",
         )
 
     @mock.patch("tartufo.commands.scan_local_repo.GitRepoScanner")


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [X] Tests (if applicable)
* [ ] Documentation (if applicable)
* [X] Changelog entry
* [X] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [X] Documentation content changes
* [ ] Tests
* [X] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [X] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->
Fixes #245 

## What's new?

Using the latest version of `click` gives us better output for our command line boolean flags. For example:
```md
  --entropy / --no-entropy        Enable entropy checks.  [default: True]
```
becomes:
```md
  --entropy / --no-entropy        Enable entropy checks.  [default: entropy]
```

Turns out, there's also a whole ton of other bugfixes and improvements. One of those bugfixes related to path resolution in Windows and resulted in us needing to update some tests. Overall, should be a major positive!