### PR TITLE
Actually determine if we are dealing with a shallow clone instead of …

### DIFF
--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -767,9 +767,8 @@ class GitRepoScanner(GitScanner):
                 branches = [self.git_options.branch]
             else:
                 # Everything
-                if not self._repo.listall_branches():
-                    # If no local branches are found, assume that this is a
-                    # shallow clone and examine the repo head as a single
+                if util.is_shallow_clone(self._repo):
+                    # If this is a shallow clone, examine the repo head as a single
                     # commit to scan all files at once
                     branches = ["HEAD"]
                 else:

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -242,3 +242,17 @@ def process_issues(
         write_outputs(scan.issues, output_dir)
         if options.output_format != types.OutputFormat.Json.value:
             click.echo(f"Results have been saved in {output_dir}")
+
+
+def is_shallow_clone(repo: pygit2.Repository) -> bool:
+    """Determine whether a repository is a shallow clone
+
+    :param repo: The repository to check for "shallowness"
+
+    This is used to work around https://github.com/libgit2/libgit2/issues/3058
+    Basically, any time a git repository is a "shallow" clone (it was cloned
+    with `--max-depth N`), git will create a file at `.git/shallow`. So we
+    simply need to test whether that file exists to know whether we are
+    interacting with a shallow repository.
+    """
+    return (pathlib.Path(repo.path) / "shallow").exists()

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -306,8 +306,9 @@ class ChunkGeneratorTests(ScannerTestCase):
             for _ in test_scanner.chunks:
                 pass
 
-    def test_head_is_scanned_when_no_local_branches_are_found(self):
-        self.mock_repo.return_value.listall_branches.return_value = []
+    @mock.patch("tartufo.scanner.util.is_shallow_clone")
+    def test_head_is_scanned_when_shallow_clone_is_found(self, mock_shallow):
+        mock_shallow.return_value = True
         self.mock_iter_diff.return_value = []
         self.mock_repo.return_value.head.target = "commit-hash"
         mock_head = mock.MagicMock(spec=pygit2.Commit)

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -151,12 +151,17 @@ class ChunkGeneratorTests(ScannerTestCase):
     def setUp(self) -> None:
         self.diff_patcher = mock.patch("tartufo.scanner.GitScanner._iter_diff_index")
         self.repo_patcher = mock.patch("pygit2.Repository")
+        self.shallow_patcher = mock.patch("tartufo.scanner.util.is_shallow_clone")
 
         self.mock_iter_diff = self.diff_patcher.start()
         self.mock_repo = self.repo_patcher.start()
+        self.mock_shallow = self.shallow_patcher.start()
+
+        self.mock_shallow.return_value = False
 
         self.addCleanup(self.diff_patcher.stop)
         self.addCleanup(self.repo_patcher.stop)
+        self.addCleanup(self.shallow_patcher.stop)
         return super().setUp()
 
     def test_single_branch_is_loaded_if_specified(self):
@@ -306,9 +311,8 @@ class ChunkGeneratorTests(ScannerTestCase):
             for _ in test_scanner.chunks:
                 pass
 
-    @mock.patch("tartufo.scanner.util.is_shallow_clone")
-    def test_head_is_scanned_when_shallow_clone_is_found(self, mock_shallow):
-        mock_shallow.return_value = True
+    def test_head_is_scanned_when_shallow_clone_is_found(self):
+        self.mock_shallow.return_value = True
         self.mock_iter_diff.return_value = []
         self.mock_repo.return_value.head.target = "commit-hash"
         mock_head = mock.MagicMock(spec=pygit2.Commit)


### PR DESCRIPTION
…assuming

To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [X] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] Changelog entry
* [X] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [X] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [X] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->

## What's new?
Previously we checked to see if there were any local branches/refs to see if the clone was shallow. That worked great in PRs, because they have no local refs. Unfortunately when tartufo was used to scan against a branch that was a shallow clone, it failed again.

Now, we use a slightly more reliable method. When a shallow clone is created, a `.git/shallow` file is created. So now we check for that instead. This should work both in the case of a PR and in the case of a branch scan.
