### PR TITLE
Change rule-patterns option type to click.UNPROCESSED

### DIFF
--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -55,7 +55,7 @@ class TartufoCLI(click.MultiCommand):
 @click.option(
     "--rule-patterns",
     multiple=True,
-    type=str,
+    type=click.UNPROCESSED,
     hidden=True,
     help="Regular expression patterns to search the target for. May be specified multiple times.",
 )

--- a/tests/data/config/rule_pattern_config.toml
+++ b/tests/data/config/rule_pattern_config.toml
@@ -1,0 +1,7 @@
+[tool.tartufo]
+regex = true
+
+rule-patterns = [
+    {reason = "RSA private key 2", pattern = "-----BEGIN EC PRIVATE KEY-----"},
+    {reason = "Null characters in GitHub Workflows", pattern = '\0', path-pattern = '\.github/workflows/(.*)\.yml'}
+]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -419,7 +419,9 @@ class CompileRulesTests(unittest.TestCase):
         ):
             config.compile_rules([{"foo": "bar"}])
 
-    def test_rule_patterns_are_read(self):
+    @mock.patch("tartufo.commands.scan_local_repo.GitRepoScanner")
+    def test_rule_patterns_are_read(self, mock_scanner: mock.MagicMock):
+        mock_scanner.return_value.issues = []
         conf = (
             pathlib.Path(__file__).parent
             / "data"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -419,6 +419,7 @@ class CompileRulesTests(unittest.TestCase):
         ):
             config.compile_rules([{"foo": "bar"}])
 
+    @mock.patch("tartufo.util.process_issues", new=mock.MagicMock())
     @mock.patch("tartufo.commands.scan_local_repo.GitRepoScanner")
     def test_rule_patterns_are_read(self, mock_scanner: mock.MagicMock):
         mock_scanner.return_value.issues = []
@@ -434,9 +435,9 @@ class CompileRulesTests(unittest.TestCase):
                 cli.main,
                 [
                     "--config",
-                    conf,
-                    "scan-remote-repo",
-                    "git@github.com:godaddy/tartufo.git",
+                    str(conf),
+                    "scan-folder",
+                    ".",
                 ],
             )
         self.assertEqual(result.exit_code, 0)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,7 +8,7 @@ import click
 import tomlkit
 from click.testing import CliRunner
 
-from tartufo import config, types
+from tartufo import config, types, cli
 from tartufo.types import ConfigException, Rule, MatchType, Scope
 
 from tests import helpers
@@ -418,6 +418,26 @@ class CompileRulesTests(unittest.TestCase):
             types.ConfigException, "Invalid exclude-entropy-patterns: "
         ):
             config.compile_rules([{"foo": "bar"}])
+
+    def test_rule_patterns_are_read(self):
+        conf = (
+            pathlib.Path(__file__).parent
+            / "data"
+            / "config"
+            / "rule_pattern_config.toml"
+        )
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                cli.main,
+                [
+                    "--config",
+                    conf,
+                    "scan-remote-repo",
+                    "git@github.com:godaddy/tartufo.git",
+                ],
+            )
+        self.assertEqual(result.exit_code, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [ ] Documentation (if applicable)
* [x] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [x] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
Fixes #316 

## What's new?
 Click doesn't recognize how to parse a toml dict, so it just defaults to stringifying it. Change type of `rule-patterns` to `UNPROCESSED` so it isn't converted to a string.
