### PR TITLE
Eliminate OOM errors in tartufo by using temporary file for issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Unreleased
+----------
+
+Features:
+
+* [#328](https://github.com/godaddy/tartufo/pull/328) - Buffer issues to temporary file as needed
+
 v3.0.0 - 5 January 2022
 -----------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Unreleased
 
 Features:
 
-* [#328](https://github.com/godaddy/tartufo/pull/328) - Buffer issues to temporary file as needed
+* [#328](https://github.com/godaddy/tartufo/pull/328) - Buffer issues beyond --buffer-size to a temporary file
 
 v3.0.0 - 5 January 2022
 -----------------------

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -183,7 +183,7 @@ class TartufoCLI(click.MultiCommand):
     help="If specified, temporary files will be written to the specified path",
 )
 @click.option(
-    "--max-buffered-issues",
+    "--buffer-size",
     type=int,
     default=10000,
     show_default=True,

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -170,6 +170,26 @@ class TartufoCLI(click.MultiCommand):
     "the results of individual runs of tartufo separated.",
 )
 @click.option(
+    "-td",
+    "--temp-dir",
+    type=click.Path(
+        exists=False,
+        file_okay=False,
+        dir_okay=True,
+        writable=True,
+        resolve_path=True,
+        allow_dash=False,
+    ),
+    help="If specified, temporary files will be written to the specified path",
+)
+@click.option(
+    "--max-buffered-issues",
+    type=int,
+    default=10000,
+    show_default=True,
+    help="Maximum number of issue to buffer in memory before shifting to temporary file buffering",
+)
+@click.option(
     "--git-rules-repo",
     help="A file path, or git URL, pointing to a git repository containing regex "
     "rules to be used for scanning. By default, all .json files will be loaded "
@@ -304,7 +324,7 @@ def process_exit(
     scan: scanner.ScannerBase,
     **_kwargs: config.OptionTypes,
 ):
-    if scan.issues:
+    if scan.issue_count > 0:
         ctx.exit(1)
 
     ctx.exit(0)

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -43,7 +43,6 @@ from tartufo.types import (
 
 BASE64_REGEX = re.compile(r"[A-Z0-9=+/_-]+", re.IGNORECASE)
 HEX_REGEX = re.compile(r"[0-9A-F]+", re.IGNORECASE)
-OUTPUT_SEPARATOR = "~~~~~~~~~~~~~~~~~~~~~"
 
 
 class Issue:
@@ -60,6 +59,7 @@ class Issue:
     issue_type: types.IssueType
     issue_detail: Optional[str]
     matched_string: str
+    OUTPUT_SEPARATOR: str = "~~~~~~~~~~~~~~~~~~~~~"
 
     def __init__(
         self, issue_type: types.IssueType, matched_string: str, chunk: types.Chunk
@@ -106,7 +106,7 @@ class Issue:
         diff_body = diff_body.replace(
             self.matched_string, util.style_warning(self.matched_string)
         )
-        output.append(OUTPUT_SEPARATOR)
+        output.append(self.OUTPUT_SEPARATOR)
         output.append(util.style_ok(f"Reason: {self.issue_type.value}"))  # type: ignore
         if self.issue_detail:
             output.append(util.style_ok(f"Detail: {self.issue_detail}"))
@@ -118,7 +118,7 @@ class Issue:
         ]
 
         output.append(diff_body)
-        output.append(OUTPUT_SEPARATOR)
+        output.append(self.OUTPUT_SEPARATOR)
         return "\n".join(output)
 
     def __bytes__(self) -> bytes:

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -510,8 +510,7 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
             try:
                 length = int.from_bytes(self.issue_file.read(4), "little")
                 buf = self.issue_file.read(length)
-                issue = pickle.loads(gzip.decompress(buf))
-                yield from issue
+                yield from pickle.loads(gzip.decompress(buf))
             except EOFError:
                 self.logger.debug("pickle.load raised EOFError, exiting")
                 yield from self._issue_list

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 # -*- coding: utf-8 -*-
 
 import abc

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -520,7 +520,7 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
     def store_issue(self, issue: Issue) -> None:
         self._issue_count = self._issue_count + 1
         self._issue_list.append(issue)
-        if len(self._issue_list) >= self.global_options.max_buffered_issues:
+        if len(self._issue_list) >= self.global_options.buffer_size:
             compressed = gzip.compress(pickle.dumps(self._issue_list), compresslevel=9)
             length = len(compressed)
             self.issue_file.write(length.to_bytes(4, "little"))

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -65,6 +65,9 @@ class GlobalOptions:
       excluded from the list of current findings
     :param output_dir: A directory where detailed findings results will be
       written
+    :param temp_dir: A directory where temporary files will be written
+    :param max_buffered_issues: Maximum number of issues that will be buffered
+      on the heap
     :param git_rules_repo: A remote git repository where additional rules can be
       found
     :param git_rules_files: The files in the remote rules repository to load the
@@ -95,6 +98,8 @@ class GlobalOptions:
         "exclude_entropy_patterns",
         "exclude_signatures",
         "output_dir",
+        "temp_dir",
+        "max_buffered_issues",
         "git_rules_repo",
         "git_rules_files",
         "config",
@@ -117,6 +122,8 @@ class GlobalOptions:
     exclude_entropy_patterns: Tuple[Dict[str, str], ...]
     exclude_signatures: Union[Tuple[Dict[str, str], ...], Tuple[str, ...]]
     output_dir: Optional[str]
+    temp_dir: Optional[str]
+    max_buffered_issues: int
     git_rules_repo: Optional[str]
     git_rules_files: Tuple[str, ...]
     config: Optional[TextIO]

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -66,7 +66,7 @@ class GlobalOptions:
     :param output_dir: A directory where detailed findings results will be
       written
     :param temp_dir: A directory where temporary files will be written
-    :param max_buffered_issues: Maximum number of issues that will be buffered
+    :param buffer_size: Maximum number of issues that will be buffered
       on the heap
     :param git_rules_repo: A remote git repository where additional rules can be
       found
@@ -99,7 +99,7 @@ class GlobalOptions:
         "exclude_signatures",
         "output_dir",
         "temp_dir",
-        "max_buffered_issues",
+        "buffer_size",
         "git_rules_repo",
         "git_rules_files",
         "config",
@@ -123,7 +123,7 @@ class GlobalOptions:
     exclude_signatures: Union[Tuple[Dict[str, str], ...], Tuple[str, ...]]
     output_dir: Optional[str]
     temp_dir: Optional[str]
-    max_buffered_issues: int
+    buffer_size: int
     git_rules_repo: Optional[str]
     git_rules_files: Tuple[str, ...]
     config: Optional[TextIO]

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -103,7 +103,7 @@ def echo_result(
     else:
         for issue in scanner.scan():
             click.echo(bytes(issue))
-        if not scanner.issues:
+        if scanner.issue_count == 0:
             if not options.quiet:
                 click.echo(f"Time: {now}\nAll clear. No secrets detected.")
         if options.verbose > 0:
@@ -115,14 +115,16 @@ def echo_result(
             click.echo("\n".join(str(path) for path in scanner.excluded_entropy))
 
 
-def write_outputs(found_issues: List["Issue"], output_dir: pathlib.Path) -> List[str]:
+def write_outputs(
+    issues: Generator["Issue", None, None], output_dir: pathlib.Path
+) -> List[str]:
     """Write details of the issues to individual files in the specified directory.
 
     :param found_issues: A list of issues to be written out
     :param output_dir: The directory where the files should be written
     """
     result_files = []
-    for issue in found_issues:
+    for issue in issues:
         result_file = output_dir / f"{uuid.uuid4()}.json"
         result_file.write_text(json.dumps(issue.as_dict()))
         result_files.append(str(result_file))
@@ -250,7 +252,7 @@ def process_issues(
 
     echo_result(options, scan, repo_path, output_dir)
     if output_dir:
-        write_outputs(scan.issues, output_dir)
+        write_outputs(scan.scan(), output_dir)
         if options.output_format != types.OutputFormat.Json.value:
             click.echo(f"Results have been saved in {output_dir}")
 

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -83,7 +83,9 @@ class ScanTests(ScannerTestCase):
         self.options.entropy = True
         test_scanner = TestScanner(self.options)
         test_scanner._completed = True  # pylint: disable=protected-access
-        test_scanner._issues = [1, 2, 3]  # pylint: disable=protected-access
+        test_scanner._issue_list = [1, 2, 3]  # pylint: disable=protected-access
+        test_scanner._issue_count = 3  # pylint: disable=protected-access
+        test_scanner._issue_file = None  # pylint: disable=protected-access
         result = list(test_scanner.scan())
         mock_regex.assert_not_called()
         mock_entropy.assert_not_called()
@@ -111,13 +113,6 @@ class IssuesTests(ScannerTestCase):
         test_scanner = TestScanner(self.options)
         list(test_scanner.issues)  # pylint: disable=pointless-statement
         mock_scan.assert_called()
-
-    @mock.patch("tartufo.scanner.ScannerBase.scan")
-    def test_scanner_does_not_rescan(self, mock_scan: mock.MagicMock):
-        test_scanner = TestScanner(self.options)
-        test_scanner._completed = True  # pylint: disable=protected-access
-        test_scanner.issues  # pylint: disable=pointless-statement
-        mock_scan.assert_not_called()
 
 
 class IssueTests(unittest.TestCase):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -204,6 +204,7 @@ class ProcessIssuesTest(unittest.TestCase):
                 types.IssueType.Entropy, "foo", types.Chunk("foo", "/bar", {})
             )
         ]
+        mock_scanner.return_value._issue_count = 1  # pylint: disable=protected-access
         runner = CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(cli.main, ["scan-local-repo", "."])
@@ -216,6 +217,7 @@ class ProcessIssuesTest(unittest.TestCase):
         self, mock_scanner: mock.MagicMock
     ):
         mock_scanner.return_value.issues = []
+        mock_scanner.return_value.issue_count = 0
         runner = CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(cli.main, ["scan-local-repo", "."])
@@ -228,6 +230,7 @@ class ProcessIssuesTest(unittest.TestCase):
         self, mock_scanner: mock.MagicMock
     ):
         mock_scanner.return_value.issues = []
+        mock_scanner.return_value.issue_count = 0
         runner = CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(cli.main, ["-q", "-v", "scan-local-repo", "."])
@@ -240,6 +243,7 @@ class ProcessIssuesTest(unittest.TestCase):
         self, mock_scanner: mock.MagicMock
     ):
         mock_scanner.return_value.issues = []
+        mock_scanner.return_value.issue_count = 0
         runner = CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(cli.main, ["-q", "scan-local-repo", "."])
@@ -252,6 +256,7 @@ class ProcessIssuesTest(unittest.TestCase):
         self, mock_scanner: mock.MagicMock
     ):
         mock_scanner.return_value.issues = []
+        mock_scanner.return_value.issue_count = 0
         runner = CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(cli.main, ["-v", "scan-local-repo", "."])
@@ -267,6 +272,7 @@ class LoggingTests(unittest.TestCase):
         self, mock_formatter: mock.MagicMock, mock_scanner: mock.MagicMock
     ):
         mock_scanner.return_value.issues = []
+        mock_scanner.return_value.issue_count = 0
         runner = CliRunner()
         with runner.isolated_filesystem():
             runner.invoke(cli.main, ["scan-local-repo", "."])
@@ -282,6 +288,7 @@ class LoggingTests(unittest.TestCase):
         self, mock_formatter: mock.MagicMock, mock_scanner: mock.MagicMock
     ):
         mock_scanner.return_value.issues = []
+        mock_scanner.return_value.issue_count = 0
         runner = CliRunner()
         with runner.isolated_filesystem():
             runner.invoke(cli.main, ["--no-log-timestamps", "scan-local-repo", "."])
@@ -295,6 +302,7 @@ class LoggingTests(unittest.TestCase):
         self, mock_formatter: mock.MagicMock, mock_scanner: mock.MagicMock
     ):
         mock_scanner.return_value.issues = []
+        mock_scanner.return_value.issue_count = 0
         runner = CliRunner()
         with runner.isolated_filesystem():
             runner.invoke(cli.main, ["-vvvv", "scan-local-repo", "."])
@@ -307,6 +315,7 @@ class LoggingTests(unittest.TestCase):
     @mock.patch("tartufo.commands.scan_local_repo.GitRepoScanner")
     def test_excess_verbosity_does_not_exceed_debug(self, mock_scanner: mock.MagicMock):
         mock_scanner.return_value.issues = []
+        mock_scanner.return_value._issue_count = 0  # pylint: disable=protected-access
         runner = CliRunner()
         with runner.isolated_filesystem():
             runner.invoke(cli.main, ["-vvvvvvvvvvvvvvv", "scan-local-repo", "."])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -204,7 +204,7 @@ class ProcessIssuesTest(unittest.TestCase):
                 types.IssueType.Entropy, "foo", types.Chunk("foo", "/bar", {})
             )
         ]
-        mock_scanner.return_value._issue_count = 1  # pylint: disable=protected-access
+        mock_scanner.return_value.issue_count = 1
         runner = CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(cli.main, ["scan-local-repo", "."])
@@ -315,7 +315,7 @@ class LoggingTests(unittest.TestCase):
     @mock.patch("tartufo.commands.scan_local_repo.GitRepoScanner")
     def test_excess_verbosity_does_not_exceed_debug(self, mock_scanner: mock.MagicMock):
         mock_scanner.return_value.issues = []
-        mock_scanner.return_value._issue_count = 0  # pylint: disable=protected-access
+        mock_scanner.return_value.issue_count = 0
         runner = CliRunner()
         with runner.isolated_filesystem():
             runner.invoke(cli.main, ["-vvvvvvvvvvvvvvv", "scan-local-repo", "."])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -420,9 +420,10 @@ class CompileRulesTests(unittest.TestCase):
             config.compile_rules([{"foo": "bar"}])
 
     @mock.patch("tartufo.util.process_issues", new=mock.MagicMock())
-    @mock.patch("tartufo.commands.scan_local_repo.GitRepoScanner")
+    @mock.patch("tartufo.scanner.FolderScanner")
     def test_rule_patterns_are_read(self, mock_scanner: mock.MagicMock):
         mock_scanner.return_value.issues = []
+        mock_scanner.return_value.issue_count = 0
         conf = (
             pathlib.Path(__file__).parent
             / "data"

--- a/tests/test_folder_scanner.py
+++ b/tests/test_folder_scanner.py
@@ -22,6 +22,7 @@ class FolderScannerTestCase(unittest.TestCase):
         self.global_options.hex_entropy_score = 3
         self.global_options.exclude_signatures = ()
         self.global_options.exclude_path_patterns = [r"donotscan\.txt"]
+        self.global_options.max_buffered_issues = 50000
 
         test_scanner = scanner.FolderScanner(self.global_options, folder_path, recurse)
         issues = list(test_scanner.scan())
@@ -54,6 +55,7 @@ class FolderScannerTestCase(unittest.TestCase):
         self.global_options.exclude_signatures = ()
         self.global_options.b64_entropy_score = 4.5
         self.global_options.hex_entropy_score = 3
+        self.global_options.max_buffered_issues = 50000
 
         test_scanner = scanner.FolderScanner(self.global_options, folder_path, recurse)
         issues = list(test_scanner.scan())
@@ -73,6 +75,7 @@ class FolderScannerTestCase(unittest.TestCase):
         self.global_options.exclude_signatures = ()
         self.global_options.b64_entropy_score = 4.5
         self.global_options.hex_entropy_score = 3
+        self.global_options.max_buffered_issues = 50000
 
         test_scanner = scanner.FolderScanner(self.global_options, folder_path, recurse)
         issues = list(test_scanner.scan())

--- a/tests/test_folder_scanner.py
+++ b/tests/test_folder_scanner.py
@@ -22,7 +22,7 @@ class FolderScannerTestCase(unittest.TestCase):
         self.global_options.hex_entropy_score = 3
         self.global_options.exclude_signatures = ()
         self.global_options.exclude_path_patterns = [r"donotscan\.txt"]
-        self.global_options.max_buffered_issues = 50000
+        self.global_options.buffer_size = 50000
 
         test_scanner = scanner.FolderScanner(self.global_options, folder_path, recurse)
         issues = list(test_scanner.scan())
@@ -55,7 +55,7 @@ class FolderScannerTestCase(unittest.TestCase):
         self.global_options.exclude_signatures = ()
         self.global_options.b64_entropy_score = 4.5
         self.global_options.hex_entropy_score = 3
-        self.global_options.max_buffered_issues = 50000
+        self.global_options.buffer_size = 50000
 
         test_scanner = scanner.FolderScanner(self.global_options, folder_path, recurse)
         issues = list(test_scanner.scan())
@@ -75,7 +75,7 @@ class FolderScannerTestCase(unittest.TestCase):
         self.global_options.exclude_signatures = ()
         self.global_options.b64_entropy_score = 4.5
         self.global_options.hex_entropy_score = 3
-        self.global_options.max_buffered_issues = 50000
+        self.global_options.buffer_size = 50000
 
         test_scanner = scanner.FolderScanner(self.global_options, folder_path, recurse)
         issues = list(test_scanner.scan())


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [ ] Documentation (if applicable)
* [x] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->

## What's new?
- This pull request introduces new code that buffers excessive issues to a temporary file to avoid exhausting memory with a massive list[Issue] object.  This avoids out of memory errors for repos with very high issue counts and makes the memory usage of tartufo during a scan much more rational and predictable.
