### PR TITLE
Fixes #336: _issue_file was not defined by default, causing scans to fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+v3.1.1 - 25 March 2022
+----------------------
+
+Bug Fixes:
+
+* [#336](https://github.com/godaddy/tartufo/issues/336) - `_issue_file` was not defined by default, causing all scans to fail
+
 v3.1.0 - 24 March 2022
 ----------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ maintainers = ["GoDaddy <oss@godaddy.com>"]
 name = "tartufo"
 readme = "README.md"
 repository = "https://github.com/godaddy/tartufo/"
-version = "3.1.0"
+version = "3.1.1"
 
 [tool.poetry.scripts]
 tartufo = "tartufo.cli:main"

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -147,7 +147,7 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
     _excluded_signatures: Optional[Tuple[str, ...]] = None
     _config_data: MutableMapping[str, Any] = {}
     _issue_list: List[Issue] = []
-    _issue_file: IO
+    _issue_file: Optional[IO] = None
     _issue_count: int
 
     def __init__(self, options: types.GlobalOptions) -> None:

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -107,6 +107,24 @@ class ScanTests(ScannerTestCase):
         mock_regex.assert_called()
 
 
+class IssueFileTests(ScannerTestCase):
+    @mock.patch("tempfile.NamedTemporaryFile")
+    def test_issue_file_creates_new_temporary_file(self, mock_temp: mock.MagicMock):
+        self.options.temp_dir = "/foo/bar"
+        test_scanner = TestScanner(self.options)
+        issue_file = test_scanner.issue_file
+        mock_temp.assert_called_once_with(dir="/foo/bar")
+        self.assertEqual(issue_file, mock_temp.return_value)
+
+    @mock.patch("tempfile.NamedTemporaryFile", mock.MagicMock())
+    def test_issue_file_is_cached(self):
+        self.options.temp_dir = "/foo/bar"
+        test_scanner = TestScanner(self.options)
+        file1 = test_scanner.issue_file
+        file2 = test_scanner.issue_file
+        self.assertEqual(file1, file2)
+
+
 class IssuesTests(ScannerTestCase):
     @mock.patch("tartufo.scanner.ScannerBase.scan")
     def test_empty_issue_list_causes_scan(self, mock_scan: mock.MagicMock):


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [X] Tests (if applicable)
* [ ] Documentation (if applicable)
* [X] Changelog entry
* [X] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [X] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [X] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->
Fixes #336 

## What's new?
- Quick bugfix and version bump for #336. I've included the version bump so that we can do a rapid release, since this broke all scans.
