### PR TITLE
Fix entropy exclusions on remote scans

### DIFF
--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -280,7 +280,9 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
         """Get a list of regexes used as an exclusive list of paths to scan."""
         if self._excluded_entropy is None:
             self.logger.info("Initializing excluded entropy patterns")
-            patterns = list(self.global_options.exclude_entropy_patterns or ())
+            patterns = list(self.global_options.exclude_entropy_patterns or ()) + list(
+                self.config_data.get("exclude_entropy_patterns", ())
+            )
             self._excluded_entropy = config.compile_rules(patterns) if patterns else []
             self.logger.debug(
                 "Excluded entropy was initialized as: %s", self._excluded_entropy


### PR DESCRIPTION
entropy exlusions defined in a repo's tartufo.toml were not being used
when running a remote scan against a repo. This change fixes that so
entropy exclusions get used as expected on remote repo scans.

To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
fixes https://github.com/godaddy/tartufo/issues/343
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->

## What's new?
- This change ensures that exclude-entropy-patterns defined in a repo's tartufo.toml are included when running a `scan-remote-repo` against a remote repo. Currently entropy exclusions defined in a tartufo.toml are ignored on a remote repo scan.
