### PR TITLE
Add --no-git-check option to skip confirmation dialog for scan-folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Features:
   * Rebase container to python 3.11
   * Add CI step to verify container is operational
 
+* [#348](https://github.com/godaddy/tartufo/pull/348) - Add --no-git-check option
+  to skip confirmation dialog for scan-folder
+
 v3.3.1 - 23 Nov 2022
 --------------------
 

--- a/tartufo/commands/scan_folder.py
+++ b/tartufo/commands/scan_folder.py
@@ -28,7 +28,11 @@ from tartufo.scanner import FolderScanner
 @click.pass_obj
 @click.pass_context
 def main(
-    ctx: click.Context, options: types.GlobalOptions, target: str, recurse: bool, git_check: bool
+    ctx: click.Context,
+    options: types.GlobalOptions,
+    target: str,
+    recurse: bool,
+    git_check: bool,
 ) -> FolderScanner:
     """Scan a folder."""
     try:

--- a/tartufo/commands/scan_folder.py
+++ b/tartufo/commands/scan_folder.py
@@ -14,6 +14,13 @@ from tartufo.scanner import FolderScanner
     show_default=True,
     help="Recurse and scan the entire folder",
 )
+@click.option(
+    "--git-check/--no-git-check",
+    is_flag=True,
+    default=True,
+    show_default=True,
+    help="Check if folder is a git repo and show confirmation dialog",
+)
 @click.argument(
     "target",
     type=click.Path(exists=True, file_okay=False, resolve_path=True, allow_dash=False),
@@ -21,12 +28,12 @@ from tartufo.scanner import FolderScanner
 @click.pass_obj
 @click.pass_context
 def main(
-    ctx: click.Context, options: types.GlobalOptions, target: str, recurse: bool
+    ctx: click.Context, options: types.GlobalOptions, target: str, recurse: bool, git_check: bool
 ) -> FolderScanner:
     """Scan a folder."""
     try:
         resume: bool = True
-        if util.path_contains_git(target) is True:
+        if git_check and util.path_contains_git(target) is True:
             resume = click.confirm(
                 "This folder is a git repository, and should be scanned using the "
                 "scan-local-repo command. Are you sure you wish to proceed?"

--- a/tartufo/commands/scan_folder.py
+++ b/tartufo/commands/scan_folder.py
@@ -19,7 +19,7 @@ from tartufo.scanner import FolderScanner
     is_flag=True,
     default=True,
     show_default=True,
-    help="Check if folder is a git repo and show confirmation dialog",
+    help="Skip check if the folder is a git repo",
 )
 @click.argument(
     "target",


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [ ] Documentation (if applicable)
* [x] Changelog entry
* [ ] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->

## What's new?

Add `--no-git-check` option to skip confirmation dialog when using `scan-folder` command. Useful when piping into `jq` to find the offenses in the current version of the files in git repo.