### PR TITLE
Remove obsolete option from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,15 +83,6 @@ Options:
                                   or `text` can be specified. If not provided
                                   (default) the output will be generated in
                                   `text` format.
-  -e, --exclude-signatures TEXT   [DEPRECATED] Use the exclude-findings config
-                                  option instead. Specify signatures of
-                                  matches that you explicitly want to exclude
-                                  from the scan, and mark as okay. These
-                                  signatures are generated during the scan
-                                  process, and reported out with each
-                                  individual match. This option can be
-                                  specified multiple times, to exclude as many
-                                  signatures as you would like.
   -od, --output-dir DIRECTORY     If specified, all issues will be written out
                                   as individual JSON files to a uniquely named
                                   directory under this one. This will help

--- a/README.md
+++ b/README.md
@@ -60,22 +60,6 @@ Options:
                                   Check the names of files being scanned as
                                   well as their contents.  [default: scan-
                                   filenames]
-  -ip, --include-path-patterns TEXT
-                                  Specify a regular expression which matches
-                                  Git object paths to include in the scan.
-                                  This option can be specified multiple times
-                                  to include multiple patterns. If not
-                                  provided (default), all Git object paths are
-                                  included unless otherwise excluded via the
-                                  --exclude-path-patterns option.
-  -xp, --exclude-path-patterns TEXT
-                                  Specify a regular expression which matches
-                                  Git object paths to exclude from the scan.
-                                  This option can be specified multiple times
-                                  to exclude multiple patterns. If not
-                                  provided (default), no Git object paths are
-                                  excluded unless effectively excluded via the
-                                  --include-path-patterns option.
   -of, --output-format [json|compact|text]
                                   Specify the format in which the output needs
                                   to be generated `--output-format
@@ -88,6 +72,11 @@ Options:
                                   directory under this one. This will help
                                   with keeping the results of individual runs
                                   of tartufo separated.
+  -td, --temp-dir DIRECTORY       If specified, temporary files will be
+                                  written to the specified path
+  --buffer-size INTEGER           Maximum number of issue to buffer in memory
+                                  before shifting to temporary file buffering
+                                  [default: 10000]
   --git-rules-repo TEXT           A file path, or git URL, pointing to a git
                                   repository containing regex rules to be used
                                   for scanning. By default, all .json files

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -35,7 +35,6 @@ this:
 
    [tool.tartufo]
    repo-path = "."
-   json = false
    regex = true
    entropy = true
    exclude-path-patterns = [
@@ -69,15 +68,7 @@ Looking at this information, it's clear that this issue was found in a test
 file, and it's probably okay. Of course, you will want to look at the actual
 body of what was found and determine that for yourself. But let's say that this
 really is okay, and we want tell ``tartufo`` to ignore this issue in future
-scans. To do this, you can either specify it on the command line...
-
-.. code-block:: sh
-
-    > tartufo -e 2a3cb329b81351e357b09f1b97323ff726e72bd5ff8427c9295e6ef68226e1d1
-    # No output! Success!
-    >
-
-Or you can add it to your config file, so that this exclusion is always
+scans. To do this, you can add it to your config file, so that this exclusion is always
 remembered!
 
 .. code-block:: toml
@@ -100,7 +91,7 @@ As of version 3.0, a new format for specifying exclusion signatures has been add
 
 .. note::
 
-    Currently all 3 formats of signature exclusions are supported. However, only `TOML`_ `array of tables`_ format
+    Currently both formats of signature exclusions are supported. However, only `TOML`_ `array of tables`_ format
     will be supported in future versions.
 
 .. _limiting-scans-by-paths:

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -68,8 +68,7 @@ Looking at this information, it's clear that this issue was found in a test
 file, and it's probably okay. Of course, you will want to look at the actual
 body of what was found and determine that for yourself. But let's say that this
 really is okay, and we want tell ``tartufo`` to ignore this issue in future
-scans. To do this, you can add it to your config file, so that this exclusion is always
-remembered!
+scans. To do this, you can add it to your config file.
 
 .. code-block:: toml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,6 @@ exclude-signatures = [
   {signature = "c94ba36a7411bf89fab6e87076740deecdc7a61fcfbbc1aa5934608f6c4f3adb", reason = "tests/data/config/rule_pattern_config.toml"},
   {signature = "4f44b817b42c94fa01f47166ca7adaa0b750b1b6cd84f7ce3bf23a7728cdac57", reason = "commit hashes in github URLs in comments, tartufo/scanner.py"}
 ]
-json = false
 regex = true
 repo-path = "."
 

--- a/tests/data/pyproject.toml
+++ b/tests/data/pyproject.toml
@@ -1,2 +1,2 @@
 [tool.tartufo]
-json = true
+regex = true


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [x] Documentation (if applicable)
* [ ] Changelog entry
* [ ] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [ ] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
Fixes #321 

## What's new?
- Remove obsolete `json` option from documentation
