### PR TITLE
Only use colored output in a TTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Unreleased
+----------------------
+
+Bug fixes:
+* [#360](https://github.com/godaddy/tartufo/issues/360) - Fix ANSI escape sequences being written to files on redirection
+
 v3.1.4 - 31 May 2022
 ----------------------
 
@@ -82,7 +88,7 @@ Bug fixes:
 * [#284](https://github.com/godaddy/tartufo/pull/284) - Fix handling of first
   commit during local scans; an exception was raised instead of processing the
   commit.
-  
+
 Misc:
 
 * [#282](https://github.com/godaddy/tartufo/pull/282) - Remove old style config for `exclude-entropy-patterns`


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [ ] Documentation (if applicable)
* [x] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)

## Issue Linking

Closes #360 

## What's new?

This PR adds a check to the `util` module to see if the program is running in a TTY.

It affects the `style_ok`, `style_error`, and `style_warning` functions.

If we are in a TTY, the `click.style` is used normally as it has been in the past.
Otherwise, a wrapper function is used and passed to `functools.partial` instead.

The wrapper function allows callers of the functions to still pass arbitrary `click.style` arguments, they will just be ignored if we're not running in a TTY.

If you have an idea for a better implementation, I would be happy to make changes.
