### PR TITLE
Add update-signatures command to migrate deprecated signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Unreleased
+----------------------
+
+Features:
+* [#368](https://github.com/godaddy/tartufo/pull/368) - Add update-signatures command to migrate deprecated signatures
+
 v3.2.0 - 6 July 2022
 ----------------------
 

--- a/docs/source/upgrading3.rst
+++ b/docs/source/upgrading3.rst
@@ -154,6 +154,18 @@ Deprecated Options
 required at this time, replacing these options with their newer equivalents will
 reduce future disruptions when they are retired.
 
+Updating Signatures
+-------------------
+
+``tartufo`` release 3.2.0 deprecated a number of signatures that were generated
+with the leading `+`/`-` from the git diff erroneously. These signatures will no
+longer work in release 4. An additional command ``tartufo update-signatures`` was
+added which scans a local repository, automatically updates the deprecated
+exclude-signatures in your tartufo config file, and removes any resulting duplicates.
+
+Use ``--no-update-configuration`` to prevent ``tartufo`` from overwriting your config.
+Use ``--no-remove-duplicates`` to prevent ``tartufo`` from removing duplicate signatures.
+
 External Rules Files
 ++++++++++++++++++++
 

--- a/docs/source/upgrading3.rst
+++ b/docs/source/upgrading3.rst
@@ -166,7 +166,7 @@ exclude-signatures in your tartufo config file, and removes any resulting duplic
 Use ``--no-update-configuration`` to prevent ``tartufo`` from overwriting your config.
 Use ``--no-remove-duplicates`` to prevent ``tartufo`` from removing duplicate signatures.
 
-When removing duplicate signatures, ``tartufo`` will keep the first signature it finds
+When removing duplicate signatures ``tartufo`` will keep the first signature it finds
 and discard the rest.
 
 External Rules Files

--- a/docs/source/upgrading3.rst
+++ b/docs/source/upgrading3.rst
@@ -166,6 +166,9 @@ exclude-signatures in your tartufo config file, and removes any resulting duplic
 Use ``--no-update-configuration`` to prevent ``tartufo`` from overwriting your config.
 Use ``--no-remove-duplicates`` to prevent ``tartufo`` from removing duplicate signatures.
 
+When removing duplicate signatures, ``tartufo`` will keep the first signature it finds
+and discard the rest.
+
 External Rules Files
 ++++++++++++++++++++
 

--- a/tartufo/commands/update_signatures.py
+++ b/tartufo/commands/update_signatures.py
@@ -38,7 +38,7 @@ def scan_local_repo(
     :param max_depth: A maximum depth, or maximum number of commits back in history, to scan
     :param branch: A specific branch to scan
     :param include_submodules: Whether to also scan submodules of the repository
-    :returns: The number of items replaced in config_data
+    :returns: A tuple containing optional scanner, stdout, and stderr from the scan
     """
     stdout = io.StringIO()
     stderr = io.StringIO()

--- a/tartufo/commands/update_signatures.py
+++ b/tartufo/commands/update_signatures.py
@@ -218,8 +218,10 @@ def main(
         # Explicitly fail if we didn't get a scanner back
         util.fail(util.style_error("Unable to update signatures"), ctx)
 
+    plural = lambda n: "" if n == 1 else "s"
     deprecations = get_deprecations(stderr)
-    click.echo(f"Found {len(deprecations)} unique deprecated signatures.")
+    ndeps = len(deprecations)
+    click.echo(f"Found {ndeps} deprecated signature{plural(ndeps)}.")
     updated = replace_deprecated_signatures(deprecations, config_data)
 
     dups = 0
@@ -229,9 +231,8 @@ def main(
     if update_configuration and (deprecations or dups):
         # Only rewrite the config if we have altered it
         write_updated_signatures(config_path, config_data)
-        plural = lambda n: "" if n == 1 else "s"
 
         click.echo(f"Removed {dups} duplicated signature{plural(dups)}.")
-        click.echo(f"Updated {updated} total deprecated signature{plural(updated)}.")
+        click.echo(f"Updated {updated} deprecated signature{plural(updated)}.")
 
     return scanner

--- a/tartufo/commands/update_signatures.py
+++ b/tartufo/commands/update_signatures.py
@@ -1,0 +1,137 @@
+import contextlib
+import io
+import pathlib
+import re
+import typing as t
+
+import click
+import tomlkit
+
+from tartufo import types, util
+from tartufo.config import load_config_from_path
+from tartufo.scanner import GitRepoScanner
+
+
+def _scan_local_repo(
+    options: types.GlobalOptions,
+    repo_path: str,
+    since_commit: t.Optional[str],
+    max_depth: int,
+    branch: t.Optional[str],
+    include_submodules: bool,
+) -> t.Union[GitRepoScanner, None]:
+    """We had to duplicate the scan local repo command callback, to
+    alter the exception logic a bit and prevent swallowing errors.
+    """
+    git_options = types.GitOptions(
+        since_commit=since_commit,
+        max_depth=max_depth,
+        branch=branch,
+        include_submodules=include_submodules,
+    )
+
+    try:
+        scanner = GitRepoScanner(options, git_options, str(repo_path))
+        util.process_issues(repo_path, scanner, options)
+    except types.GitLocalException:
+        message = f"{repo_path} is not a valid git repository."
+        click.echo(util.style_error(message), err=True)
+        return None
+    except types.TartufoException as exc:
+        click.echo(util.style_error(str(exc)), err=True)
+        return None
+
+    return scanner
+
+
+@click.command("update-signatures")
+@click.option("--since-commit", help="Only scan from a given commit hash.", hidden=True)
+@click.option(
+    "--max-depth",
+    default=1000000,
+    show_default=True,
+    help="The max commit depth to go back when searching for secrets.",
+    hidden=True,
+)
+@click.option("--branch", help="Specify a branch name to scan only that branch.")
+@click.argument(
+    "repo-path",
+    type=click.Path(exists=True, file_okay=False, resolve_path=True, allow_dash=False),
+)
+@click.option(
+    "--include-submodules/--exclude-submodules",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Controls whether the contents of git submodules are scanned",
+)
+@click.pass_obj
+@click.pass_context
+def main(
+    ctx: click.Context,
+    options: types.GlobalOptions,
+    repo_path: str,
+    since_commit: t.Optional[str],
+    max_depth: int,
+    branch: t.Optional[str],
+    include_submodules: bool,
+) -> GitRepoScanner:
+    """Scan a local repository and update any deprecated signatures."""
+    config_path, config_data = load_config_from_path(pathlib.Path(repo_path))
+    if not config_data.get("exclude_signatures"):
+        util.fail(
+            util.style_warning("No signatures found in configuration, exiting..."), ctx
+        )
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    deprecations = set()
+    deprecation_rgx = re.compile(
+        r"DeprecationWarning: Signature (\w+) was.*use signature (\w+) instead\."
+    )
+
+    with contextlib.redirect_stdout(stdout):
+        with contextlib.redirect_stderr(stderr):
+            # Deprecation warnings are printed to stderr
+            scanner = _scan_local_repo(
+                options, repo_path, since_commit, max_depth, branch, include_submodules
+            )
+
+    del stdout  # We are discarding stdout from the scan-local-repo command
+    # Should we print it to the user instead?
+
+    if not scanner:
+        # Explicitly fail if we didn't get a scanner back
+        util.fail(util.style_error("Unable to update signatures"), ctx)
+
+    # Start at the beginning of the buffer
+    stderr.seek(0)
+    for line in stderr:
+        match = deprecation_rgx.search(line)
+
+        if match:
+            # This line had a deprecation warning
+            deprecations.add(match.groups())
+
+    click.echo(f"Found {len(deprecations)} unique deprecated signatures.")
+    for (i, (old_sig, new_sig)) in enumerate(deprecations):
+        for target_signature in filter(
+            lambda s: s["signature"] == old_sig, config_data["exclude_signatures"]
+        ):
+            # Iterate all the deprecations and update them everywhere
+            # they are found in the exclude-signatures section of config
+            click.echo(f"{i + 1}) Updating {old_sig!r} -> {new_sig!r}")
+            target_signature["signature"] = new_sig
+
+    # Read the current config, for clean overwrite
+    with open(str(config_path), "r") as f:
+        result = tomlkit.loads(f.read())
+
+    # Assign the new signatures and write it to the config
+    result["tool"]["tartufo"]["exclude-signatures"] = config_data["exclude_signatures"]
+    with open(str(config_path), "w") as f:
+        f.write(tomlkit.dumps(result))
+
+    # We would have failed earlier so this assert is safe
+    assert scanner is not None
+    return scanner

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -17,6 +17,7 @@ from typing import (
     Generator,
     List,
     Optional,
+    NoReturn,
     Tuple,
     TYPE_CHECKING,
     Pattern,
@@ -170,7 +171,7 @@ else:
     style_ok = style_error = style_warning = partial(_style_func)
 
 
-def fail(msg: str, ctx: click.Context, code: int = 1) -> None:
+def fail(msg: str, ctx: click.Context, code: int = 1) -> NoReturn:
     """Print out a styled error message and exit.
 
     :param msg: The message to print out to the user

--- a/tests/test_update_signatures.py
+++ b/tests/test_update_signatures.py
@@ -190,17 +190,13 @@ class UpdateSignaturesTests(TestCase):
         mock_get_deprecations.assert_called_once()
         mock_scan_local.assert_called_once()
         mock_load_config.assert_called_once()
-        self.assertTrue(
-            result.output.startswith("Found 2 deprecated signatures.\n")
-        )
+        self.assertTrue(result.output.startswith("Found 2 deprecated signatures.\n"))
 
         # The numbers before the paren can vary so we leave them out of the test
         self.assertTrue(") '123' -> 'abc'\n" in result.output)
         self.assertTrue(") '456' -> 'def'\n" in result.output)
         self.assertTrue("Removed 0 duplicated signatures.\n" in result.output)
-        self.assertTrue(
-            result.output.endswith("Updated 2 deprecated signatures.\n")
-        )
+        self.assertTrue(result.output.endswith("Updated 2 deprecated signatures.\n"))
 
     @mock.patch("tartufo.commands.update_signatures.write_updated_signatures")
     @mock.patch("tartufo.commands.update_signatures.get_deprecations")
@@ -246,18 +242,14 @@ class UpdateSignaturesTests(TestCase):
         mock_get_deprecations.assert_called_once()
         mock_scan_local.assert_called_once()
         mock_load_config.assert_called_once()
-        self.assertTrue(
-            result.output.startswith("Found 3 deprecated signatures.\n")
-        )
+        self.assertTrue(result.output.startswith("Found 3 deprecated signatures.\n"))
 
         # The numbers before the paren can vary so we leave them out of the test
         self.assertTrue(") '123' -> 'abc'\n" in result.output)
         self.assertTrue(") '456' -> 'def'\n" in result.output)
         self.assertTrue(") '789' -> 'abc'\n" in result.output)
         self.assertTrue("Removed 1 duplicated signature.\n" in result.output)
-        self.assertTrue(
-            result.output.endswith("Updated 3 deprecated signatures.\n")
-        )
+        self.assertTrue(result.output.endswith("Updated 3 deprecated signatures.\n"))
 
     @mock.patch("tartufo.commands.update_signatures.write_updated_signatures")
     @mock.patch("tartufo.commands.update_signatures.replace_deprecated_signatures")

--- a/tests/test_update_signatures.py
+++ b/tests/test_update_signatures.py
@@ -190,15 +190,16 @@ class UpdateSignaturesTests(TestCase):
         mock_get_deprecations.assert_called_once()
         mock_scan_local.assert_called_once()
         mock_load_config.assert_called_once()
-        self.assertEqual(
-            result.output,
-            (
-                "Found 2 unique deprecated signatures.\n"
-                "1) '456' -> 'def'\n"
-                "2) '123' -> 'abc'\n"
-                "Removed 0 duplicated signatures.\n"
-                "Updated 2 total deprecated signatures.\n"
-            ),
+        self.assertTrue(
+            result.output.startswith("Found 2 unique deprecated signatures.\n")
+        )
+
+        # The numbers before the paren can vary so we leave them out of the test
+        self.assertTrue(") '123' -> 'abc'\n" in result.output)
+        self.assertTrue(") '456' -> 'def'\n" in result.output)
+        self.assertTrue("Removed 0 duplicated signatures.\n" in result.output)
+        self.assertTrue(
+            result.output.endswith("Updated 2 total deprecated signatures.\n")
         )
 
     @mock.patch("tartufo.commands.update_signatures.write_updated_signatures")
@@ -245,16 +246,17 @@ class UpdateSignaturesTests(TestCase):
         mock_get_deprecations.assert_called_once()
         mock_scan_local.assert_called_once()
         mock_load_config.assert_called_once()
-        self.assertEqual(
-            result.output,
-            (
-                "Found 3 unique deprecated signatures.\n"
-                "1) '456' -> 'def'\n"
-                "2) '789' -> 'abc'\n"
-                "3) '123' -> 'abc'\n"
-                "Removed 1 duplicated signature.\n"
-                "Updated 3 total deprecated signatures.\n"
-            ),
+        self.assertTrue(
+            result.output.startswith("Found 3 unique deprecated signatures.\n")
+        )
+
+        # The numbers before the paren can vary so we leave them out of the test
+        self.assertTrue(") '123' -> 'abc'\n" in result.output)
+        self.assertTrue(") '456' -> 'def'\n" in result.output)
+        self.assertTrue(") '789' -> 'abc'\n" in result.output)
+        self.assertTrue("Removed 1 duplicated signature.\n" in result.output)
+        self.assertTrue(
+            result.output.endswith("Updated 3 total deprecated signatures.\n")
         )
 
     @mock.patch("tartufo.commands.update_signatures.write_updated_signatures")

--- a/tests/test_update_signatures.py
+++ b/tests/test_update_signatures.py
@@ -135,7 +135,7 @@ class UpdateSignaturesTests(TestCase):
                 "1) Updating '456' -> 'def'\n"
                 "2) Updating '123' -> 'abc'\n"
                 "Updated 2 total deprecated signatures.\n"
-            )
+            ),
         )
 
     @mock.patch("tartufo.commands.update_signatures.write_updated_signatures")

--- a/tests/test_update_signatures.py
+++ b/tests/test_update_signatures.py
@@ -239,10 +239,6 @@ class UpdateSignaturesTests(TestCase):
         with open(file_name, "w") as config_file:
             config_file.write(initial_file_content)
 
-        with open(file_name, "r") as config_file:
-            file_content = config_file.read()
-            self.assertEqual(initial_file_content, file_content)
-
         update_signatures.replace_deprecated_signatures(
             expected_deprecations, config_data
         )

--- a/tests/test_update_signatures.py
+++ b/tests/test_update_signatures.py
@@ -50,7 +50,7 @@ class UpdateSignaturesTests(TestCase):
     def test_update_signatures_when_scanner_is_none(
         self, mock_load_config: mock.MagicMock, mock_scan_local: mock.MagicMock
     ) -> None:
-        mock_scan_local.return_value = None, "a", "b"
+        mock_scan_local.return_value = None, "b"
         mock_load_config.return_value = Path("."), {
             "exclude_signatures": [{"signature": "a"}]
         }
@@ -64,6 +64,70 @@ class UpdateSignaturesTests(TestCase):
         self.assertGreater(result.exit_code, 0)
         self.assertEqual(result.output, "Unable to update signatures\n")
 
+    @mock.patch("tartufo.commands.update_signatures.write_updated_signatures")
+    @mock.patch("tartufo.commands.update_signatures.get_deprecations")
+    @mock.patch("tartufo.commands.update_signatures.remove_duplicated_entries")
+    @mock.patch("tartufo.commands.update_signatures.scan_local_repo")
+    @mock.patch("tartufo.commands.update_signatures.load_config_from_path")
+    def test_when_no_remove_duplicates(
+        self,
+        mock_load_config: mock.MagicMock,
+        mock_scan_local: mock.MagicMock,
+        mock_remove_dups: mock.MagicMock,
+        mock_get_deprecations: mock.MagicMock,
+        mock_write: mock.MagicMock,
+    ) -> None:
+        mock_scanner = mock.MagicMock()
+        mock_write.return_value = None
+        mock_get_deprecations.return_value = {("123", "abc"), ("456", "def")}
+        mock_scan_local.return_value = mock_scanner, "b"
+        mock_load_config.return_value = Path("."), {
+            "exclude_signatures": [{"signature": "a"}]
+        }
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            runner.invoke(
+                cli.main, ["update-signatures", ".", "--no-remove-duplicates"]
+            )
+
+        mock_get_deprecations.assert_called_once()
+        mock_remove_dups.assert_not_called()
+        mock_scan_local.assert_called_once()
+        mock_load_config.assert_called_once()
+        mock_write.assert_called_once()
+
+    @mock.patch("tartufo.commands.update_signatures.write_updated_signatures")
+    @mock.patch("tartufo.commands.update_signatures.get_deprecations")
+    @mock.patch("tartufo.commands.update_signatures.remove_duplicated_entries")
+    @mock.patch("tartufo.commands.update_signatures.scan_local_repo")
+    @mock.patch("tartufo.commands.update_signatures.load_config_from_path")
+    def test_when_remove_duplicates(
+        self,
+        mock_load_config: mock.MagicMock,
+        mock_scan_local: mock.MagicMock,
+        mock_remove_dups: mock.MagicMock,
+        mock_get_deprecations: mock.MagicMock,
+        mock_write: mock.MagicMock,
+    ) -> None:
+        mock_scanner = mock.MagicMock()
+        mock_scan_local.return_value = mock_scanner, "b"
+        mock_write.return_value = None
+        mock_get_deprecations.return_value = {("123", "abc"), ("456", "def")}
+        mock_load_config.return_value = Path("."), {
+            "exclude_signatures": [{"signature": "a"}]
+        }
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            runner.invoke(cli.main, ["update-signatures", "."])
+
+        mock_get_deprecations.assert_called_once()
+        mock_remove_dups.assert_called_once()
+        mock_scan_local.assert_called_once()
+        mock_load_config.assert_called_once()
+        mock_write.assert_called_once()
+
     @mock.patch("tartufo.commands.update_signatures.types.GlobalOptions")
     @mock.patch("tartufo.commands.update_signatures.util.process_issues")
     def test_scan_local_with_git_local_exc(
@@ -71,7 +135,7 @@ class UpdateSignaturesTests(TestCase):
     ) -> None:
         mock_process_issues.side_effect = types.GitLocalException()
 
-        scanner, _, stderr = update_signatures.scan_local_repo(
+        scanner, stderr = update_signatures.scan_local_repo(
             mock_global_options, ".", None, 1, None, False
         )
 
@@ -85,7 +149,7 @@ class UpdateSignaturesTests(TestCase):
     ) -> None:
         mock_process_issues.side_effect = types.TartufoException("TARTUFO EXC")
 
-        scanner, _, stderr = update_signatures.scan_local_repo(
+        scanner, stderr = update_signatures.scan_local_repo(
             mock_global_options, ".", None, 1, None, False
         )
 
@@ -108,7 +172,6 @@ class UpdateSignaturesTests(TestCase):
         mock_get_deprecations.return_value = {("123", "abc"), ("456", "def")}
         mock_scan_local.return_value = (
             mock_scanner,
-            "",
             (
                 "DeprecationWarning: Signature 123 was ... use signature abc instead.\n"
                 "DeprecationWarning: Signature 456 was ... use signature def instead."
@@ -131,9 +194,66 @@ class UpdateSignaturesTests(TestCase):
             result.output,
             (
                 "Found 2 unique deprecated signatures.\n"
-                "1) Updating '456' -> 'def'\n"
-                "2) Updating '123' -> 'abc'\n"
+                "1) '456' -> 'def'\n"
+                "2) '123' -> 'abc'\n"
+                "Removed 0 duplicated signatures.\n"
                 "Updated 2 total deprecated signatures.\n"
+            ),
+        )
+
+    @mock.patch("tartufo.commands.update_signatures.write_updated_signatures")
+    @mock.patch("tartufo.commands.update_signatures.get_deprecations")
+    @mock.patch("tartufo.commands.update_signatures.scan_local_repo")
+    @mock.patch("tartufo.commands.update_signatures.load_config_from_path")
+    def test_found_output_with_duplicated_signatures(
+        self,
+        mock_load_config: mock.MagicMock,
+        mock_scan_local: mock.MagicMock,
+        mock_get_deprecations: mock.MagicMock,
+        mock_write: mock.MagicMock,
+    ) -> None:
+        mock_scanner = mock.MagicMock()
+        mock_write.return_value = None
+        mock_get_deprecations.return_value = {
+            ("123", "abc"),
+            ("456", "def"),
+            ("789", "abc"),
+        }
+
+        mock_scan_local.return_value = (
+            mock_scanner,
+            (
+                "DeprecationWarning: Signature 123 was ... use signature abc instead.\n"
+                "DeprecationWarning: Signature 456 was ... use signature def instead.\n"
+                "DeprecationWarning: Signature 789 was ... use signature abc instead."
+            ),
+        )
+
+        mock_load_config.return_value = Path("."), {
+            "exclude_signatures": [
+                {"signature": "123"},
+                {"signature": "456"},
+                {"signature": "789"},
+            ]
+        }
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(cli.main, ["update-signatures", "."])
+
+        mock_write.assert_called_once()
+        mock_get_deprecations.assert_called_once()
+        mock_scan_local.assert_called_once()
+        mock_load_config.assert_called_once()
+        self.assertEqual(
+            result.output,
+            (
+                "Found 3 unique deprecated signatures.\n"
+                "1) '456' -> 'def'\n"
+                "2) '789' -> 'abc'\n"
+                "3) '123' -> 'abc'\n"
+                "Removed 1 duplicated signature.\n"
+                "Updated 3 total deprecated signatures.\n"
             ),
         )
 
@@ -154,7 +274,7 @@ class UpdateSignaturesTests(TestCase):
         mock_write.return_value = None
         mock_replace.return_value = 2
         mock_get_deprecations.return_value = {}
-        mock_scan_local.return_value = mock_scanner, "", ""
+        mock_scan_local.return_value = mock_scanner, ""
         mock_load_config.return_value = Path("."), {"exclude_signatures": "a"}
 
         runner = CliRunner()
@@ -165,6 +285,25 @@ class UpdateSignaturesTests(TestCase):
         mock_get_deprecations.assert_called_once()
         mock_scan_local.assert_called_once()
         self.assertEqual(result.output, "Found 0 unique deprecated signatures.\n")
+
+    def test_remove_duplicated_entries(self) -> None:
+        initial_data = {
+            "exclude_signatures": [
+                {"signature": "123", "reason": "first"},
+                {"signature": "123", "reason": "second"},
+                {"signature": "456"},
+            ]
+        }
+
+        expected_data = {
+            "exclude_signatures": [
+                {"signature": "123", "reason": "first"},
+                {"signature": "456"},
+            ]
+        }
+
+        update_signatures.remove_duplicated_entries(initial_data)
+        self.assertEqual(initial_data, expected_data)
 
     def test_get_deprecations_with_deprecations(self) -> None:
         expected_deprecations = {("123", "abc"), ("456", "def"), ("789", "ghi")}

--- a/tests/test_update_signatures.py
+++ b/tests/test_update_signatures.py
@@ -43,7 +43,7 @@ class UpdateSignaturesTests(TestCase):
 
         mock_scanner.assert_called_once()
         mock_load_config.assert_called_once()
-        self.assertEqual(result.output, "Found 0 unique deprecated signatures.\n")
+        self.assertEqual(result.output, "Found 0 deprecated signatures.\n")
 
     @mock.patch("tartufo.commands.update_signatures.scan_local_repo")
     @mock.patch("tartufo.commands.update_signatures.load_config_from_path")
@@ -191,7 +191,7 @@ class UpdateSignaturesTests(TestCase):
         mock_scan_local.assert_called_once()
         mock_load_config.assert_called_once()
         self.assertTrue(
-            result.output.startswith("Found 2 unique deprecated signatures.\n")
+            result.output.startswith("Found 2 deprecated signatures.\n")
         )
 
         # The numbers before the paren can vary so we leave them out of the test
@@ -199,7 +199,7 @@ class UpdateSignaturesTests(TestCase):
         self.assertTrue(") '456' -> 'def'\n" in result.output)
         self.assertTrue("Removed 0 duplicated signatures.\n" in result.output)
         self.assertTrue(
-            result.output.endswith("Updated 2 total deprecated signatures.\n")
+            result.output.endswith("Updated 2 deprecated signatures.\n")
         )
 
     @mock.patch("tartufo.commands.update_signatures.write_updated_signatures")
@@ -247,7 +247,7 @@ class UpdateSignaturesTests(TestCase):
         mock_scan_local.assert_called_once()
         mock_load_config.assert_called_once()
         self.assertTrue(
-            result.output.startswith("Found 3 unique deprecated signatures.\n")
+            result.output.startswith("Found 3 deprecated signatures.\n")
         )
 
         # The numbers before the paren can vary so we leave them out of the test
@@ -256,7 +256,7 @@ class UpdateSignaturesTests(TestCase):
         self.assertTrue(") '789' -> 'abc'\n" in result.output)
         self.assertTrue("Removed 1 duplicated signature.\n" in result.output)
         self.assertTrue(
-            result.output.endswith("Updated 3 total deprecated signatures.\n")
+            result.output.endswith("Updated 3 deprecated signatures.\n")
         )
 
     @mock.patch("tartufo.commands.update_signatures.write_updated_signatures")
@@ -286,7 +286,7 @@ class UpdateSignaturesTests(TestCase):
         mock_replace.assert_called_once()
         mock_get_deprecations.assert_called_once()
         mock_scan_local.assert_called_once()
-        self.assertEqual(result.output, "Found 0 unique deprecated signatures.\n")
+        self.assertEqual(result.output, "Found 0 deprecated signatures.\n")
 
     def test_remove_duplicated_entries(self) -> None:
         initial_data = {

--- a/tests/test_update_signatures.py
+++ b/tests/test_update_signatures.py
@@ -4,7 +4,6 @@ from os import remove
 from pathlib import Path
 from typing import Sequence, Set
 
-
 from unittest import mock, TestCase
 import tomlkit
 from click.testing import CliRunner

--- a/tests/test_update_signatures.py
+++ b/tests/test_update_signatures.py
@@ -1,0 +1,263 @@
+import io
+import textwrap
+from os import remove
+from pathlib import Path
+from typing import Sequence, Set
+
+
+from unittest import mock, TestCase
+import tomlkit
+from click.testing import CliRunner
+
+from tartufo import cli, types
+from tartufo.commands import update_signatures
+
+
+class UpdateSignaturesTests(TestCase):
+    @mock.patch("tartufo.commands.update_signatures.load_config_from_path")
+    def test_with_no_signatures_in_config(
+        self, mock_load_config: mock.MagicMock
+    ) -> None:
+        mock_load_config.return_value = Path("."), {"test": None}
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(cli.main, ["update-signatures", "."])
+
+        mock_load_config.assert_called_once()
+        self.assertEqual(
+            result.output, "No signatures found in configuration, exiting...\n"
+        )
+
+    @mock.patch("tartufo.commands.update_signatures.GitRepoScanner")
+    @mock.patch("tartufo.commands.update_signatures.load_config_from_path")
+    def test_with_no_deprecated_signatures(
+        self, mock_load_config: mock.MagicMock, mock_scanner: mock.MagicMock
+    ) -> None:
+        mock_load_config.return_value = Path("."), {
+            "exclude_signatures": [{"signature": "a"}]
+        }
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(cli.main, ["update-signatures", "."])
+
+        mock_scanner.assert_called_once()
+        mock_load_config.assert_called_once()
+        self.assertEqual(result.output, "Found 0 unique deprecated signatures.\n")
+
+    @mock.patch("tartufo.commands.update_signatures.scan_local_repo")
+    @mock.patch("tartufo.commands.update_signatures.load_config_from_path")
+    def test_update_signatures_when_scanner_is_none(
+        self, mock_load_config: mock.MagicMock, mock_scan_local: mock.MagicMock
+    ) -> None:
+        mock_scan_local.return_value = None, "a", "b"
+        mock_load_config.return_value = Path("."), {
+            "exclude_signatures": [{"signature": "a"}]
+        }
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(cli.main, ["update-signatures", "."])
+
+        mock_scan_local.assert_called_once()
+        mock_load_config.assert_called_once()
+        self.assertGreater(result.exit_code, 0)
+        self.assertEqual(result.output, "Unable to update signatures\n")
+
+    @mock.patch("tartufo.commands.update_signatures.types.GlobalOptions")
+    @mock.patch("tartufo.commands.update_signatures.util.process_issues")
+    def test_scan_local_with_git_local_exc(
+        self, mock_process_issues: mock.MagicMock, mock_global_options: mock.MagicMock
+    ) -> None:
+        mock_process_issues.side_effect = types.GitLocalException()
+
+        scanner, _, stderr = update_signatures.scan_local_repo(
+            mock_global_options, ".", None, 1, None, False
+        )
+
+        mock_process_issues.assert_called_once_with(".", scanner, mock_global_options)
+        self.assertEqual(stderr.getvalue(), ". is not a valid git repository.\n")
+
+    @mock.patch("tartufo.commands.update_signatures.types.GlobalOptions")
+    @mock.patch("tartufo.commands.update_signatures.util.process_issues")
+    def test_scan_local_with_tartufo_exc(
+        self, mock_process_issues: mock.MagicMock, mock_global_options: mock.MagicMock
+    ) -> None:
+        mock_process_issues.side_effect = types.TartufoException("TARTUFO EXC")
+
+        scanner, _, stderr = update_signatures.scan_local_repo(
+            mock_global_options, ".", None, 1, None, False
+        )
+
+        mock_process_issues.assert_called_once_with(".", scanner, mock_global_options)
+        self.assertEqual(stderr.getvalue(), "TARTUFO EXC\n")
+
+    @mock.patch("tartufo.commands.update_signatures.write_updated_signatures")
+    @mock.patch("tartufo.commands.update_signatures.get_deprecations")
+    @mock.patch("tartufo.commands.update_signatures.scan_local_repo")
+    @mock.patch("tartufo.commands.update_signatures.load_config_from_path")
+    def test_found_output_with_signatures(
+        self,
+        mock_load_config: mock.MagicMock,
+        mock_scan_local: mock.MagicMock,
+        mock_get_deprecations: mock.MagicMock,
+        mock_write: mock.MagicMock,
+    ) -> None:
+        mock_scanner = mock.MagicMock()
+        mock_write.return_value = None
+        mock_get_deprecations.return_value = {("123", "abc"), ("456", "def")}
+        mock_scan_local.return_value = (
+            mock_scanner,
+            "",
+            (
+                "DeprecationWarning: Signature 123 was ... use signature abc instead.\n"
+                "DeprecationWarning: Signature 456 was ... use signature def instead."
+            ),
+        )
+
+        mock_load_config.return_value = Path("."), {
+            "exclude_signatures": [{"signature": "123"}, {"signature": "456"}]
+        }
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(cli.main, ["update-signatures", "."])
+
+        mock_write.assert_called_once()
+        mock_get_deprecations.assert_called_once()
+        mock_scan_local.assert_called_once()
+        mock_load_config.assert_called_once()
+        self.assertEqual(
+            result.output,
+            (
+                "Found 2 unique deprecated signatures.\n"
+                "1) Updating '456' -> 'def'\n"
+                "2) Updating '123' -> 'abc'\n"
+                "Updated 2 total deprecated signatures.\n"
+            )
+        )
+
+    @mock.patch("tartufo.commands.update_signatures.write_updated_signatures")
+    @mock.patch("tartufo.commands.update_signatures.replace_deprecated_signatures")
+    @mock.patch("tartufo.commands.update_signatures.get_deprecations")
+    @mock.patch("tartufo.commands.update_signatures.scan_local_repo")
+    @mock.patch("tartufo.commands.update_signatures.load_config_from_path")
+    def test_found_output_with_no_signatures(
+        self,
+        mock_load_config: mock.MagicMock,
+        mock_scan_local: mock.MagicMock,
+        mock_get_deprecations: mock.MagicMock,
+        mock_replace: mock.MagicMock,
+        mock_write: mock.MagicMock,
+    ) -> None:
+        mock_scanner = mock.MagicMock()
+        mock_write.return_value = None
+        mock_replace.return_value = 2
+        mock_get_deprecations.return_value = {}
+        mock_scan_local.return_value = mock_scanner, "", ""
+        mock_load_config.return_value = Path("."), {"exclude_signatures": "a"}
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(cli.main, ["update-signatures", "."])
+
+        mock_replace.assert_called_once()
+        mock_get_deprecations.assert_called_once()
+        mock_scan_local.assert_called_once()
+        self.assertEqual(result.output, "Found 0 unique deprecated signatures.\n")
+
+    def test_get_deprecations_with_deprecations(self) -> None:
+        expected_deprecations = {("123", "abc"), ("456", "def"), ("789", "ghi")}
+        stderr = io.StringIO(
+            "DeprecationWarning: Signature 123 was ... use signature abc instead.\n"
+            "DeprecationWarning: Signature 456 was ... use signature def instead.\n"
+            "DeprecationWarning: Signature 789 was ... use signature ghi instead."
+        )
+
+        deprecations = update_signatures.get_deprecations(stderr)
+
+        self.assertEqual(len(deprecations), 3)
+        self.assertTrue(isinstance(deprecations, set))
+        self.assertEqual(deprecations, expected_deprecations)
+
+    def test_get_deprecations_with_no_deprecations(self) -> None:
+        stderr = io.StringIO("No deprecations here :).")
+
+        deprecations = update_signatures.get_deprecations(stderr)
+
+        self.assertTrue(isinstance(deprecations, set))
+        self.assertEqual(len(deprecations), 0)
+
+    def test_replace_deprecated_signatures(self) -> None:
+        deprecations: Set[Sequence[str]] = set()
+        deprecations.update((("123", "abc"), ("456", "def"), ("789", "ghi")))
+        expected_result = {
+            "exclude_signatures": [
+                {"signature": "abc"},
+                {"signature": "def"},
+                {"signature": "ghi"},
+            ]
+        }
+
+        config_data = {
+            "exclude_signatures": [
+                {"signature": "123"},
+                {"signature": "456"},
+                {"signature": "789"},
+            ]
+        }
+
+        update_signatures.replace_deprecated_signatures(deprecations, config_data)
+        self.assertEqual(config_data, expected_result)
+
+    def test_write_updated_signatures(self) -> None:
+        def build_file_content(*signatures: str) -> str:
+            return textwrap.dedent(
+                """[tool.tartufo]
+                exclude-signatures = [
+                    {signature = '%s'},
+                    {signature = '%s'},
+                    {signature = '%s'}
+                ]
+                """  # pylint: disable=C0209
+                % signatures
+            )
+
+        file_name = Path("test.toml")
+        initial_file_content = build_file_content("123", "456", "789")
+        expected_deprecations: Set[Sequence[str]] = set()
+        expected_deprecations.update((("123", "abc"), ("456", "def"), ("789", "ghi")))
+        config_data = {
+            "exclude_signatures": [
+                {"signature": "123"},
+                {"signature": "456"},
+                {"signature": "789"},
+            ]
+        }
+
+        with open(file_name, "w") as config_file:
+            config_file.write(initial_file_content)
+
+        with open(file_name, "r") as config_file:
+            file_content = config_file.read()
+            self.assertEqual(initial_file_content, file_content)
+
+        update_signatures.replace_deprecated_signatures(
+            expected_deprecations, config_data
+        )
+        update_signatures.write_updated_signatures(file_name, config_data)
+
+        result_config_data = {
+            "tool": {
+                "tartufo": {
+                    key.replace("_", "-"): value for key, value in config_data.items()
+                }
+            }
+        }
+
+        with open(file_name, "r") as config_file:
+            file_content = config_file.read()
+            self.assertEqual(result_config_data, tomlkit.loads(file_content))
+
+        remove(file_name)


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [x] Documentation (if applicable)
* [x] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [x] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)

## What's new?

This pull request addresses the recent deprecation of some signatures which were generated with the leading `+`/`-` from the git diff. That issue is documented [here](https://github.com/godaddy/tartufo/issues/347).

As stated by the deprecation warning, in tartufo v4.X those signatures will no longer be valid.
In an attempt to ease the migration for all parties involved, this command allows for migration with a single command.

The command performs a local scan (we assume the user is scanning locally, this needs to be documented), parses the deprecations from the ouput there, and makes adjustments in the end users tartufo config file.

Help snippet:
```
Commands:
  scan-local-repo    Scan a repository already cloned to your local system.
  scan-folder        Scan a folder.
  update-signatures  Update deprecated signatures for a local repository.
  pre-commit         Scan staged changes in a pre-commit hook.
  scan-remote-repo   Automatically clone and scan a remote git repository.
```

Invoked identically to the `scan-local-repo` command, it accepts all the same options as well.
- E.G. `tartufo update-signatures .`

---

### Usage

I used tartufo itself for testing, and will include my results here. 
Prior to updating the signatures tartufo was producing the following deprecations:

```
/home/jonx/projects/work/tartufo/tartufo/scanner.py:661: DeprecationWarning: Signature 358a1ae040ab71b3aafeb4318e5d9e318ff1b681c5bf0e99d381584a33ee7833 was generated by an old version of tartufo and is deprecated. tartufo 4.x will not recognize this signature. Please update your configuration to use signature 38d3398905c382a79857e884f33062a5a38e4e3f8b5d54f269879601b2e847fc instead.
  warnings.warn(
/home/jonx/projects/work/tartufo/tartufo/scanner.py:661: DeprecationWarning: Signature 358a1ae040ab71b3aafeb4318e5d9e318ff1b681c5bf0e99d381584a33ee7833 was generated by an old version of tartufo and is deprecated. tartufo 4.x will not recognize this signature. Please update your configuration to use signature 38d3398905c382a79857e884f33062a5a38e4e3f8b5d54f269879601b2e847fc instead.
  warnings.warn(
/home/jonx/projects/work/tartufo/tartufo/scanner.py:661: DeprecationWarning: Signature 6c70b4a712ada69f2a6c919edc783cf485b6637e3c5429de376ef1a451a042e4 was generated by an old version of tartufo and is deprecated. tartufo 4.x will not recognize this signature. Please update your configuration to use signature d26b223efb2087d4a3db7b3ff0f65362372c46190fd74b8061db8099f4a2ee60 instead.
  warnings.warn(
/home/jonx/projects/work/tartufo/tartufo/scanner.py:661: DeprecationWarning: Signature 357841766ca69979608e4e7fb1da2addeafe6d15cade15466c39d903cc0488a8 was generated by an old version of tartufo and is deprecated. tartufo 4.x will not recognize this signature. Please update your configuration to use signature 94c45f9acae0551a2438fa8932fac466e903fd9a09bd2e11897198b133937ccd instead.
  warnings.warn(
/home/jonx/projects/work/tartufo/tartufo/scanner.py:661: DeprecationWarning: Signature 88152f1d10077f417ee5aea5fa86adaa5b74d3f2de2e87ce4b4aa5cd79c7b2f5 was generated by an old version of tartufo and is deprecated. tartufo 4.x will not recognize this signature. Please update your configuration to use signature 482e7b31188f1e59dd6eb5b21c46f7467449ffcbeba9a4ca412dfcd8ea9ef66f instead.
  warnings.warn(
/home/jonx/projects/work/tartufo/tartufo/scanner.py:661: DeprecationWarning: Signature 23996f9309c042d37958d28c2cc0c16a060a03376ee075b5b077609e2a299e44 was generated by an old version of tartufo and is deprecated. tartufo 4.x will not recognize this signature. Please update your configuration to use signature 482e7b31188f1e59dd6eb5b21c46f7467449ffcbeba9a4ca412dfcd8ea9ef66f instead.
  warnings.warn(
/home/jonx/projects/work/tartufo/tartufo/scanner.py:661: DeprecationWarning: Signature 85109edb8081a60f3a44139a98b643b8cacb777f4d5c814276ae729d50fe414c was generated by an old version of tartufo and is deprecated. tartufo 4.x will not recognize this signature. Please update your configuration to use signature bf48e316ecad0a37071ed81cc54a6b629a1a3bf73cf52d06a77c9fbaf91bc833 instead.
  warnings.warn(
Time: 2022-07-17T13:36:54.860205
All clear. No secrets detected.
```

---

Running the command:

```bash
$ tartufo update-signatures .                                                                                                                                                                            
Found 6 unique deprecated signatures.
1) Updating '23996f9309c042d37958d28c2cc0c16a060a03376ee075b5b077609e2a299e44' -> '482e7b31188f1e59dd6eb5b21c46f7467449ffcbeba9a4ca412dfcd8ea9ef66f'
2) Updating '6c70b4a712ada69f2a6c919edc783cf485b6637e3c5429de376ef1a451a042e4' -> 'd26b223efb2087d4a3db7b3ff0f65362372c46190fd74b8061db8099f4a2ee60'
3) Updating '88152f1d10077f417ee5aea5fa86adaa5b74d3f2de2e87ce4b4aa5cd79c7b2f5' -> '482e7b31188f1e59dd6eb5b21c46f7467449ffcbeba9a4ca412dfcd8ea9ef66f'
4) Updating '358a1ae040ab71b3aafeb4318e5d9e318ff1b681c5bf0e99d381584a33ee7833' -> '38d3398905c382a79857e884f33062a5a38e4e3f8b5d54f269879601b2e847fc'
5) Updating '357841766ca69979608e4e7fb1da2addeafe6d15cade15466c39d903cc0488a8' -> '94c45f9acae0551a2438fa8932fac466e903fd9a09bd2e11897198b133937ccd'
6) Updating '85109edb8081a60f3a44139a98b643b8cacb777f4d5c814276ae729d50fe414c' -> 'bf48e316ecad0a37071ed81cc54a6b629a1a3bf73cf52d06a77c9fbaf91bc833'
Updated 6 total deprecated signatures.
```

---

After running the command, the pyproject.toml was altered as follows:

```diff
diff --git a/pyproject.toml b/pyproject.toml
index 8088fce..0e50d97 100644
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,8 +96,8 @@ exclude-signatures = [
   {signature = "dbc084c22395931afd734a5be53f1cde913c7d988034b856087c744b424d9673", reason = "High entropy string BASE64_CHARS in truffleHog/truffleHog.py 9-Jan-2017"},
   {signature = "bc67523b08b2170ca9b802535684454140679af3156bff808508cf32b33aa240", reason = "High entropy string random_stringHex in tests.py 28-Sep-21017"},
   {signature = "978dc8605ef9bf471e467dd2d8570fd658f0a5f25378799a2ad8bb6ea480173d", reason = "High entropy string random_stringB64 in tests.py 28-Sep-21017"},
-  {signature = "85109edb8081a60f3a44139a98b643b8cacb777f4d5c814276ae729d50fe414c", reason = "High entropy string in secretFile.txt 30-Dec-2016"},
-  {signature = "23996f9309c042d37958d28c2cc0c16a060a03376ee075b5b077609e2a299e44", reason = "High entropy string in temp/nothing 30-Dec-2016"},
+  {signature = "bf48e316ecad0a37071ed81cc54a6b629a1a3bf73cf52d06a77c9fbaf91bc833", reason = "High entropy string in secretFile.txt 30-Dec-2016"},
+  {signature = "482e7b31188f1e59dd6eb5b21c46f7467449ffcbeba9a4ca412dfcd8ea9ef66f", reason = "High entropy string in temp/nothing 30-Dec-2016"},
   {signature = "51dad1be0950e627bb3660a6246b42ddc6d6d431267b309af2469114fd2df2e5", reason = "Regular expression match, RSA private key in truffleHog/regexChecks.py 8-Dec-2017"},
   {signature = "74c056ae650ffb202ea3b68207dce82ebeae0414cfe3b49f9db0c79841473da1", reason = "Regular expression match, PGP private key block in truffleHog/regexChecks.py 8-Dec-2017"},
   {signature = "36617c71d89b78193c99fdd2a28027319dfdb361d649372bc72c45317f9edf24", reason = "Regular expression match, SSH (EC) private key in truffleHog/regexChecks.py 8-Dec-2017"},
@@ -131,13 +131,13 @@ exclude-signatures = [
   {signature = "586f9df1870fcfafd3070dc553e97db25b3fce82c9144602567d69a86597c06f", reason = "High entropy string commit_w_secret in tests/test_scanner.py 11-Nov-2019"},
   {signature = "842533f44cf32fb3d93a7f56227977aa4f16caafe82ace8f5f4de27d750c1ec1", reason = "High entropy string since_commit in tests/test_scanner.py 11-Nov-2019"},
   {signature = "d039c652f27c4d42026c5b5c9be31bfe368b283b24248e98d92f131272580053", reason = "High entropy string BASE64_CHARS in tartufo/scanner.py 25-Aug-2020"},
-  {signature = "6c70b4a712ada69f2a6c919edc783cf485b6637e3c5429de376ef1a451a042e4", reason = "tests/data/scan_folder/donotscan.txt"},
-  {signature = "357841766ca69979608e4e7fb1da2addeafe6d15cade15466c39d903cc0488a8", reason = "tests/data/scan_folder/test.txt"},
+  {signature = "d26b223efb2087d4a3db7b3ff0f65362372c46190fd74b8061db8099f4a2ee60", reason = "tests/data/scan_folder/donotscan.txt"},
+  {signature = "94c45f9acae0551a2438fa8932fac466e903fd9a09bd2e11897198b133937ccd", reason = "tests/data/scan_folder/test.txt"},
   {signature = "743b893e30777d9c4e28d3d341ca4ba1c2541a9c62b497dece75c2a64420e770", reason = "tests/test_folder_scanner.py"},
-  {signature = "358a1ae040ab71b3aafeb4318e5d9e318ff1b681c5bf0e99d381584a33ee7833", reason = "tests/data/scan_folder/scan_sub_folder/sub_folder_test.txt"},
+  {signature = "38d3398905c382a79857e884f33062a5a38e4e3f8b5d54f269879601b2e847fc", reason = "tests/data/scan_folder/scan_sub_folder/sub_folder_test.txt"},
   {signature = "9d1b278fa384c9dc58d607130d97740910309d13b29f13f7ed6348738ea4f32c", reason = "tests/test_folder_scanner.py 16-Nov-2021"},
   {signature = "9f675d4d7f43e484e07fb199a1e7ec372ef204631c1f4ec054acc3119fbde4cf", reason = "build_and_publish_docker_file 13-Jun-2019"},
-  {signature = "88152f1d10077f417ee5aea5fa86adaa5b74d3f2de2e87ce4b4aa5cd79c7b2f5", reason = "nothing file, 30-Dec-2016"},
+  {signature = "482e7b31188f1e59dd6eb5b21c46f7467449ffcbeba9a4ca412dfcd8ea9ef66f", reason = "nothing file, 30-Dec-2016"},
   {signature = "c94ba36a7411bf89fab6e87076740deecdc7a61fcfbbc1aa5934608f6c4f3adb", reason = "tests/data/config/rule_pattern_config.toml"},
   {signature = "4f44b817b42c94fa01f47166ca7adaa0b750b1b6cd84f7ce3bf23a7728cdac57", reason = "commit hashes in github URLs in comments, tartufo/scanner.py"}
 ]
 ```

---

### Thoughts

- Tests should be feature complete, with full coverage.
- I took a more functional approach here because frankly this command didn't feel like it would benefit from OOP in any way. 
- I haven't explicitly written any documentation other than the stuff added by click and sphinx automatically from docstrings, I am interested in getting feedback on how that should be structured.