### PR TITLE
Handle the case where exclude-signatures is a list of strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ Unreleased
 ----------------------
 
 Bug fixes:
-* [#372](https://github.com/godaddy/tartufo/pull/372) - Handle the case where exclude-signatures is a list of strings
+* [#372](https://github.com/godaddy/tartufo/pull/372)
+  - [#371](https://github.com/godaddy/tartufo/issues/371) Handle the case where exclude-signatures is a list of strings
+  - [#373](https://github.com/godaddy/tartufo/issues/373) Pass a string to click.echo rather than bytes
 
 v3.2.1 - 20 July 2022
 ----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Unreleased
+----------------------
+
+Bug fixes:
+* [#372](https://github.com/godaddy/tartufo/pull/372) - Handle the case where exclude-signatures is a list of strings
+
 v3.2.1 - 20 July 2022
 ----------------------
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -864,7 +864,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "tomlkit"
-version = "0.11.1"
+version = "0.11.4"
 description = "Style preserving TOML library"
 category = "main"
 optional = false
@@ -1006,7 +1006,7 @@ docs = ["recommonmark", "sphinx", "sphinx-autodoc-typehints", "sphinx-click", "s
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "7e3a8db3f206be1a5543dd411f2ce8218876907489e8ce8d52f73940fd77d9fb"
+content-hash = "76d48e62fa80585829933c1bdfd3a8936009d6b80edf6541b23625c67d06b56a"
 
 [metadata.files]
 alabaster = [
@@ -1622,8 +1622,8 @@ tomli = [
     {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
 ]
 tomlkit = [
-    {file = "tomlkit-0.11.1-py3-none-any.whl", hash = "sha256:1c5bebdf19d5051e2e1de6cf70adfc5948d47221f097fcff7a3ffc91e953eaf5"},
-    {file = "tomlkit-0.11.1.tar.gz", hash = "sha256:61901f81ff4017951119cd0d1ed9b7af31c821d6845c8c477587bbdcd5e5854e"},
+    {file = "tomlkit-0.11.4-py3-none-any.whl", hash = "sha256:25d4e2e446c453be6360c67ddfb88838cfc42026322770ba13d1fbd403a93a5c"},
+    {file = "tomlkit-0.11.4.tar.gz", hash = "sha256:3235a9010fae54323e727c3ac06fb720752fe6635b3426e379daec60fbd44a83"},
 ]
 tox = [
     {file = "tox-3.24.5-py2.py3-none-any.whl", hash = "sha256:be3362472a33094bce26727f5f771ca0facf6dafa217f65875314e9a6600c95c"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -864,11 +864,11 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "tomlkit"
-version = "0.7.2"
+version = "0.11.1"
 description = "Style preserving TOML library"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6,<4.0"
 
 [[package]]
 name = "tox"
@@ -1006,7 +1006,7 @@ docs = ["recommonmark", "sphinx", "sphinx-autodoc-typehints", "sphinx-click", "s
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "a6b7c9893e5ec231d120b929666208426ce4c3c77acc51c23190d260ff34d5bf"
+content-hash = "7e3a8db3f206be1a5543dd411f2ce8218876907489e8ce8d52f73940fd77d9fb"
 
 [metadata.files]
 alabaster = [
@@ -1622,8 +1622,8 @@ tomli = [
     {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
 ]
 tomlkit = [
-    {file = "tomlkit-0.7.2-py2.py3-none-any.whl", hash = "sha256:173ad840fa5d2aac140528ca1933c29791b79a374a0861a80347f42ec9328117"},
-    {file = "tomlkit-0.7.2.tar.gz", hash = "sha256:d7a454f319a7e9bd2e249f239168729327e4dd2d27b17dc68be264ad1ce36754"},
+    {file = "tomlkit-0.11.1-py3-none-any.whl", hash = "sha256:1c5bebdf19d5051e2e1de6cf70adfc5948d47221f097fcff7a3ffc91e953eaf5"},
+    {file = "tomlkit-0.11.1.tar.gz", hash = "sha256:61901f81ff4017951119cd0d1ed9b7af31c821d6845c8c477587bbdcd5e5854e"},
 ]
 tox = [
     {file = "tox-3.24.5-py2.py3-none-any.whl", hash = "sha256:be3362472a33094bce26727f5f771ca0facf6dafa217f65875314e9a6600c95c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ sphinx-autodoc-typehints = {version = "^1.12.0", optional = true}
 sphinx-click = {version = "^3.0.2", optional = true}
 sphinx-rtd-theme = {version = "^1.0.0", optional = true}
 sphinxcontrib-spelling = {version = "^7.2.1", optional = true}
-tomlkit = "^0.7.2"
+tomlkit = "^0.11.1"
 cached-property = "^1.5.2"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ sphinx-autodoc-typehints = {version = "^1.12.0", optional = true}
 sphinx-click = {version = "^3.0.2", optional = true}
 sphinx-rtd-theme = {version = "^1.0.0", optional = true}
 sphinxcontrib-spelling = {version = "^7.2.1", optional = true}
-tomlkit = "^0.11.1"
+tomlkit = "^0.11.4"
 cached-property = "^1.5.2"
 
 [tool.poetry.dev-dependencies]

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -104,7 +104,7 @@ def echo_result(
             )
     else:
         for issue in scanner.scan():
-            click.echo(bytes(issue))
+            click.echo(str(issue))
         if scanner.issue_count == 0:
             if not options.quiet:
                 click.echo(f"Time: {now}\nAll clear. No secrets detected.")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -115,13 +115,13 @@ class OutputTests(unittest.TestCase):
         mock_scanner.exclude_signatures = []
         mock_scanner.scan.return_value = (1, 2, 3, 4)
         util.echo_result(options, mock_scanner, "", "")
-        # Ensure that the issues are output as a byte stream
+
         mock_click.echo.assert_has_calls(
             [
-                mock.call(bytes(1)),
-                mock.call(bytes(2)),
-                mock.call(bytes(3)),
-                mock.call(bytes(4)),
+                mock.call(str(1)),
+                mock.call(str(2)),
+                mock.call(str(3)),
+                mock.call(str(4)),
             ]
         )
         self.assertEqual(mock_click.echo.call_count, 4)


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [ ] Documentation (if applicable)
* [x] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->

Closes #371 
Closes #373 

## What's new?

I added an upwrap function to handle the case where `exclude-signatures` is a list of strings. 
I also added additional error handling for the case when there is no config file/no `tool.tartufo` section.

`tomlkit` 0.7.2, the current version in use by `tartufo`, had a bug where values would not update properly.
I created a minimal reproducible example of that:

```py
import tomlkit

toml_content = """
items = [
    "a",
    "c"
]
"""

data = tomlkit.loads(toml_content)
for i, item in enumerate(data["items"]):
    if item == "c":
        data["items"][i] = "b"

print(data["items"])
print([*data["items"]])
```

Result:
```
['a', 'c']
['a', 'b']
```

Expected result:
```
['a', 'b']
['a', 'b']
```

Based on this I updated `tomlkit` to the latest version 0.11.1 and that issue is now resolved.
I added a couple more tests to handle the new cases.