### PR TITLE
Update default_regexes.json to expand Password in URL detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+v3.2.2 - 5 August 2022
+----------------------
+
+Bug fixes:
+* [#375](https://github.com/godaddy/tartufo/pull/376) - Update the "Password in URL" default_regexes.json to identify the following:
+  * usernames of lengths between 3-40
+  * passwords of length between 3-40 
+  * URL domain name, port, path, query parameters, and fragments of any length
+
 v3.2.1 - 20 July 2022
 ----------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-v3.2.2 - 5 August 2022
+Unreleased
 ----------------------
 
 Bug fixes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ maintainers = ["GoDaddy <oss@godaddy.com>"]
 name = "tartufo"
 readme = "README.md"
 repository = "https://github.com/godaddy/tartufo/"
-version = "3.2.1"
+version = "3.2.2"
 
 [tool.poetry.scripts]
 tartufo = "tartufo.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ maintainers = ["GoDaddy <oss@godaddy.com>"]
 name = "tartufo"
 readme = "README.md"
 repository = "https://github.com/godaddy/tartufo/"
-version = "3.2.2"
+version = "3.2.1"
 
 [tool.poetry.scripts]
 tartufo = "tartufo.cli:main"

--- a/tartufo/data/default_regexes.json
+++ b/tartufo/data/default_regexes.json
@@ -26,7 +26,7 @@
   "Heroku API Key": "[hH][eE][rR][oO][kK][uU].*[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}",
   "MailChimp API Key": "[0-9a-f]{32}-us[0-9]{1,2}",
   "Mailgun API Key": "key-[0-9a-zA-Z]{32}",
-  "Password in URL": "[a-zA-Z]{3,10}://[^/\\s:@]{3,20}:[^/\\s:@]{3,20}@.{1,100}[\"'\\s]",
+  "Password in URL": "[a-zA-Z]{3,10}://[^/\\s:@]{3,40}:[^/\\s:@]{3,40}@[^\"'\\s\\n]+[\"'\\s]",
   "PayPal Braintree Access Token": "access_token\\$production\\$[0-9a-z]{16}\\$[0-9a-f]{32}",
   "Picatic API Key": "sk_live_[0-9a-z]{32}",
   "Slack Webhook": "https://hooks\\.slack\\.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}",

--- a/tartufo/data/default_regexes.json
+++ b/tartufo/data/default_regexes.json
@@ -26,7 +26,7 @@
   "Heroku API Key": "[hH][eE][rR][oO][kK][uU].*[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}",
   "MailChimp API Key": "[0-9a-f]{32}-us[0-9]{1,2}",
   "Mailgun API Key": "key-[0-9a-zA-Z]{32}",
-  "Password in URL": "[a-zA-Z]{3,10}://[^/\\s:@]{3,40}:[^/\\s:@]{3,40}@[^\"'\\s\\n]+[\"'\\s]",
+  "Password in URL": "[a-zA-Z]{3,10}://[^/\\s:@]{3,40}:[^/\\s:@]{3,40}@[^\"'\\s]+",
   "PayPal Braintree Access Token": "access_token\\$production\\$[0-9a-z]{16}\\$[0-9a-f]{32}",
   "Picatic API Key": "sk_live_[0-9a-z]{32}",
   "Slack Webhook": "https://hooks\\.slack\\.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}",


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] Changelog entry
* [ ] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [X] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [X] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
#375 

## What's new?
Update the "Password in URL" default_regexes.json to allow for usernames/passwords of length 40 and remove the requirement of an fqdn/port/location/query_params of length less than 100.

## Notes
I would like additional help/guidance on testing the performance impact of this change. I did some runtime testing and saw minimal increase in cpu time.