### PR TITLE
feat(output): add report output format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,14 @@ ENV PIP_DEFAULT_TIMEOUT=100 \
     PIP_NO_CACHE_DIR=1 \
     POETRY_VERSION=1.1.12
 
+RUN apt-get update && apt-get upgrade -y && apt-get install make cmake gcc libssl-dev wget -y
+RUN wget https://github.com/libgit2/libgit2/archive/refs/tags/v1.4.0.tar.gz -O libgit2-1.4.0.tar.gz \
+    && tar xzf libgit2-1.4.0.tar.gz \
+    && cd libgit2-1.4.0/ \
+    && cmake . \
+    && make \
+    && make install
+RUN apt-get install libffi-dev -y
 RUN pip --no-cache-dir install "poetry==$POETRY_VERSION"
 RUN python -m venv /venv
 

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -122,6 +122,7 @@ class TartufoCLI(click.MultiCommand):
             types.OutputFormat.Json.value,
             types.OutputFormat.Compact.value,
             types.OutputFormat.Text.value,
+            types.OutputFormat.Report.value,
         ]
     ),
     default="text",

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -40,6 +40,7 @@ class OutputFormat(enum.Enum):
     Text = "text"  # pylint: disable=invalid-name
     Json = "json"  # pylint: disable=invalid-name
     Compact = "compact"  # pylint: disable=invalid-name
+    Report = "report"  # pylint: disable=invalid-name
 
 
 @dataclass

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import platform
 from dataclasses import fields
 from typing import Type, TypeVar
@@ -7,9 +8,15 @@ PY_VERSION = platform.python_version_tuple()
 PY_36 = ("3", "6", "0") <= PY_VERSION < ("3", "7", "0")
 PY_37 = ("3", "7", "0") <= PY_VERSION < ("3", "8", "0")
 BROKEN_USER_PATHS = WINDOWS and (PY_36 or PY_37)
+REPO_ROOT_PATH = Path(__file__).parent.parent
+DATA_PATH = REPO_ROOT_PATH.joinpath("tests", "data")
 
 
 OptionsType = TypeVar("OptionsType")  # pylint: disable=invalid-name
+
+
+def get_data_path(*added_paths: str) -> Path:
+    return Path.joinpath(DATA_PATH, *added_paths)
 
 
 def generate_options(option_class: Type[OptionsType], **kwargs) -> OptionsType:

--- a/tests/test_scan_local_repo.py
+++ b/tests/test_scan_local_repo.py
@@ -34,27 +34,28 @@ class ScanLocalRepoTests(unittest.TestCase):
             )
 
     def test_new_file_shows_up(self):
-        file_name = "secret_1.key"
+        file_name = helpers.get_data_path("config", "secret_1.key")
         runner = CliRunner()
         # Add file with high entropy
         secret_key = sha256(b"hello world")
-        with open(file_name, "a") as file:
+        with open(file_name.absolute(), "a") as file:
             file.write(secret_key.hexdigest())
-        repo = Repository(".")
+        repo = Repository(helpers.REPO_ROOT_PATH)
 
         # Check that tartufo picks up on newly added files
-        repo.index.add("tests/data/config/" + file_name)
+        file_name_relative = "tests/data/config/secret_1.key"
+        repo.index.add(file_name_relative)
         repo.index.write()  # This actually writes the index to disk. Without it, the tracked file is not actually staged.
         result = runner.invoke(cli.main, ["--entropy-sensitivity", "1", "pre-commit"])
         self.assertNotEqual(result.exit_code, 0)
 
         # Cleanup
-        repo.index.remove("tests/data/config/" + file_name)
+        repo.index.remove(file_name_relative)
         repo.index.write()  # This actually writes the index to disk. Without it, secret.key will not removed from the index.
         remove(file_name)
 
     def test_new_unstaged_file_does_not_show_up(self):
-        file_name = "secret_2.key"
+        file_name = helpers.get_data_path("secret_2.key")
         runner = CliRunner()
         # Add file with high entropy
         secret_key = sha256(b"hello world")


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [x] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->

## What's new?

- added report format to output a reviewer-friendly report
- fix Docker build

```text
$ tartufo --output-format report scan-local-repo .
Tartufo Scan Results (Time: 2022-11-09T16:24:34.012693)
All clear. No secrets detected.

Configuration:
  version:             3.2.1
  entropy:             Enabled
    sensitivity: 75
  regex:               Enabled

Excluded paths:
  package-lock.json: Autogenerated package lock file
  cicd.yaml: cert thumbprint
  README.md: readme example

Excluded signatures:
  a32cedf592e11c8d2efd06e4bd7906b340b64cb2f4b1cbb925fe908042d5d7bb: simple test file

Excluded entropy patterns:
  thumbprint:\s{1}[a-zA-Z0-9]{40} (path=cicd.yaml, scope=line, type=search): cert thumbprint
```
