### PR TITLE
fix: diff only if not already searched

### DIFF
--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -895,12 +895,12 @@ class GitRepoScanner(GitScanner):
                         "Skipping commit %s because it has no parents", curr_commit.hex
                     )
                     continue
-                diff: pygit2.Diff = self._repo.diff(prev_commit, curr_commit)
                 diff_hash = hashlib.md5(
                     (str(prev_commit) + str(curr_commit)).encode("utf-8")
                 ).digest()
                 if diff_hash in already_searched:
                     continue
+                diff: pygit2.Diff = self._repo.diff(prev_commit, curr_commit)
                 already_searched.add(diff_hash)
                 diff.find_similar()
                 for blob, file_path in self._iter_diff_index(diff):


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [x] Documentation (if applicable)
* [ ] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [x] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->

## What's new?
- Invoke diff call only if diff hash was not already searched. This is a massive performance improvement.
