### PR TITLE
add exclude-regex-patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ vX.X.X - Mar 3 2023
 
 Features:
 * [#455](https://github.com/godaddy/tartufo/pull/455) - Update documentation to fix incorrect wording
+* [#458](https://github.com/godaddy/tartufo/pull/458) - Adds `--exclude-regex-patterns` to allow for regex-based exclusions
 
 v4.0.1 - Mar 1 2023
 --------------------

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -203,6 +203,53 @@ match-type   No       String ("search" or "match")  Whether to perform a `search
 scope        No       String ("word" or "line")    Whether to match against the current word or full line of text
 ============ ======== ============================ ==============================================================
 
+.. regex-exclusion-patterns:
+
+Regex Exclusion Patterns
+++++++++++++++++++++++++++
+
+Regex scans can produce false positive matches such as environment variables in
+URLs. To avoid these false positives, you can use the
+``exclude-regex-patterns`` configuration option. These patterns will be
+applied to and matched against any strings flagged by regex pattern checks. As
+above, this directive utilizes an `array of tables`_, enabling two forms:
+
+Option 1:
+
+.. code-block:: toml
+
+    [tool.tartufo]
+    exclude-regex-patterns = [
+        {path-pattern = 'products_.*\.txt', pattern = '^SK[\d]{16,32}$', reason = 'SKU pattern that resembles Twilio API Key'},
+        {path-pattern = '\.github/workflows/.*\.yaml', pattern = 'https://\${\S+}:\${\S+}@\S+', reason = 'URL with env variables for auth'},
+    ]
+
+Option 2:
+
+.. code-block:: toml
+
+    [[tool.tartufo.exclude-regex-patterns]]
+    path-pattern = 'products_.*\.txt'
+    pattern = '^SK[\d]{16,32}$'
+    reason = 'SKU pattern that resembles Twilio API Key'
+
+    [[tool.tartufo.exclude-regex-patterns]]
+    path-pattern = '\.github/workflows/.*\.yaml'
+    pattern = 'https://\${\S+}:\${\S+}@\S+'
+    reason = 'URL with env variables for auth'
+
+
+There are 4 relevant keys for this directive, as described below.
+
+============ ======== ============================ ==============================================================
+Key          Required Value                        Description
+============ ======== ============================ ==============================================================
+pattern      Yes      Regular expression           The pattern used to check against the match
+path-pattern No       Regular expression           A pattern to specify to what files the exclusion will apply
+reason       No       String                       A plaintext reason the exclusion has been added
+match-type   No       String ("search" or "match")  Whether to perform a `search or match`_ regex operation
+============ ======== ============================ ==============================================================
+
 .. _TOML: https://toml.io/
 .. _array of tables: https://toml.io/en/v1.0.0#array-of-tables
 .. _search or match: https://docs.python.org/3/library/re.html#search-vs-match

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -206,7 +206,7 @@ scope        No       String ("word" or "line")    Whether to match against the 
 .. regex-exclusion-patterns:
 
 Regex Exclusion Patterns
-++++++++++++++++++++++++++
+++++++++++++++++++++++++
 
 Regex scans can produce false positive matches such as environment variables in
 URLs. To avoid these false positives, you can use the

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -239,7 +239,10 @@ Option 2:
     reason = 'URL with env variables for auth'
 
 
-There are 4 relevant keys for this directive, as described below.
+There are 4 relevant keys for this directive, as described below. Note that
+regex scans differ from entropy scans, so the exclusion pattern is always
+tested against the offending regex match(es). As a result, there is no
+``scope`` key for this directive.
 
 ============ ======== ============================ ==============================================================
 Key          Required Value                        Description

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -136,6 +136,16 @@ class TartufoCLI(click.MultiCommand):
     "scope": "word"|"line"}).""",
 )
 @click.option(
+    "-xr",
+    "--exclude-regex-patterns",
+    multiple=True,
+    hidden=True,
+    type=click.UNPROCESSED,
+    help="""Specify a regular expression which matches regex strings to exclude from the scan. This option can be
+    specified multiple times to exclude multiple patterns. If not provided (default), no regex strings will be
+    excluded. ({"path-pattern": {path regex}, "pattern": {pattern regex}, "match-type": "match"|"search"}).""",
+)
+@click.option(
     "-e",
     "--exclude-signatures",
     multiple=True,

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -264,7 +264,7 @@ def compile_path_rules(patterns: Iterable[str]) -> List[Pattern]:
     ]
 
 
-def compile_rules(patterns: Iterable[Dict[str, str]]) -> List[Rule]:
+def compile_rules(patterns: Iterable[Dict[str, str]], exclude_type: str) -> List[Rule]:
     """Take a list of regex string with paths and compile them into a List of Rule.
 
     :param patterns: The list of patterns to be compiled
@@ -278,12 +278,15 @@ def compile_rules(patterns: Iterable[Dict[str, str]]) -> List[Rule]:
             raise ConfigException(
                 f"Invalid value for match-type: {pattern.get('match-type')}"
             ) from exc
-        try:
-            scope = Scope(pattern.get("scope", Scope.Line.value))
-        except ValueError as exc:
-            raise ConfigException(
-                f"Invalid value for scope: {pattern.get('scope')}"
-            ) from exc
+        if exclude_type != "regex":
+            try:
+                scope = Scope(pattern.get("scope", Scope.Line.value))
+            except ValueError as exc:
+                raise ConfigException(
+                    f"Invalid value for scope: {pattern.get('scope')}"
+                ) from exc
+        else:
+            scope = Scope.Line
         try:
             rules.append(
                 Rule(
@@ -296,6 +299,6 @@ def compile_rules(patterns: Iterable[Dict[str, str]]) -> List[Rule]:
             )
         except KeyError as exc:
             raise ConfigException(
-                f"Invalid exclude-entropy-patterns: {patterns}"
+                f"Invalid exclude-{exclude_type}-patterns: {patterns}"
             ) from exc
     return rules

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -278,15 +278,17 @@ def compile_rules(patterns: Iterable[Dict[str, str]], exclude_type: str) -> List
             raise ConfigException(
                 f"Invalid value for match-type: {pattern.get('match-type')}"
             ) from exc
-        if exclude_type != "regex":
+        if exclude_type == "regex":
+            # regex exclusions always have line scope
+            scope = Scope.Line
+        else:
+            # entropy exclusions can specify scope
             try:
                 scope = Scope(pattern.get("scope", Scope.Line.value))
             except ValueError as exc:
                 raise ConfigException(
                     f"Invalid value for scope: {pattern.get('scope')}"
                 ) from exc
-        else:
-            scope = Scope.Line
         try:
             rules.append(
                 Rule(

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -58,6 +58,8 @@ class GlobalOptions:
     :param exclude_path_patterns: A list of paths to be excluded from the scan
     :param exclude_entropy_patterns: Patterns to be excluded from entropy
       matches
+    :param exclude_regex_patterns: Patterns to be excluded from regex
+      matches
     :param exclude_signatures: Signatures of previously found findings to be
       excluded from the list of current findings
     :param exclude_findings: Signatures of previously found findings to be
@@ -90,6 +92,7 @@ class GlobalOptions:
         "include_path_patterns",
         "exclude_path_patterns",
         "exclude_entropy_patterns",
+        "exclude_regex_patterns",
         "exclude_signatures",
         "output_dir",
         "temp_dir",
@@ -111,6 +114,7 @@ class GlobalOptions:
     include_path_patterns: Tuple[Dict[str, str], ...]
     exclude_path_patterns: Tuple[Dict[str, str], ...]
     exclude_entropy_patterns: Tuple[Dict[str, str], ...]
+    exclude_regex_patterns: Tuple[Dict[str, str], ...]
     exclude_signatures: Tuple[Dict[str, str], ...]
     output_dir: Optional[str]
     temp_dir: Optional[str]

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -18,6 +18,7 @@ from typing import (
     Generator,
     List,
     Optional,
+    NoReturn,
     Tuple,
     TYPE_CHECKING,
     Pattern,
@@ -257,7 +258,7 @@ else:
     style_ok = style_error = style_warning = partial(_style_func)
 
 
-def fail(msg: str, ctx: click.Context, code: int = 1) -> None:
+def fail(msg: str, ctx: click.Context, code: int = 1) -> NoReturn:
     """Print out a styled error message and exit.
 
     :param msg: The message to print out to the user

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -18,7 +18,6 @@ from typing import (
     Generator,
     List,
     Optional,
-    NoReturn,
     Tuple,
     TYPE_CHECKING,
     Pattern,
@@ -118,6 +117,17 @@ def echo_report_result(scanner: "ScannerBase", now: str):
             f"  {pattern} (path={path_pattern}, scope={m_scope}, type={m_type}): {reason}"
         )
 
+    click.echo("\nExcluded regex patterns:")
+    for e_item in scanner.excluded_regex:
+        pattern = e_item.pattern.pattern if e_item.pattern else ""
+        path_pattern = e_item.path_pattern.pattern if e_item.path_pattern else ""
+        m_scope = e_item.re_match_scope.value if e_item.re_match_scope else ""
+        m_type = e_item.re_match_type.value if e_item.re_match_type else ""
+        reason = e_item.name
+        click.echo(
+            f"  {pattern} (path={path_pattern}, scope={m_scope}, type={m_type}): {reason}"
+        )
+
 
 def echo_result(
     options: "types.GlobalOptions",
@@ -145,6 +155,9 @@ def echo_result(
             ],
             "exclude_entropy_patterns": [
                 str(pattern) for pattern in options.exclude_entropy_patterns
+            ],
+            "exclude_regex_patterns": [
+                str(pattern) for pattern in options.exclude_regex_patterns
             ],
             # This member is for reference. Read below...
             # "found_issues": [
@@ -186,6 +199,8 @@ def echo_result(
             click.echo("\n".join(scanner.excluded_signatures))
             click.echo("\nExcluded entropy patterns:")
             click.echo("\n".join(str(path) for path in scanner.excluded_entropy))
+            click.echo("\nExcluded regex patterns:")
+            click.echo("\n".join(str(path) for path in scanner.excluded_regex))
 
 
 def write_outputs(
@@ -242,7 +257,7 @@ else:
     style_ok = style_error = style_warning = partial(_style_func)
 
 
-def fail(msg: str, ctx: click.Context, code: int = 1) -> NoReturn:
+def fail(msg: str, ctx: click.Context, code: int = 1) -> None:
     """Print out a styled error message and exit.
 
     :param msg: The message to print out to the user

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -300,7 +300,8 @@ class CompileRulesTests(unittest.TestCase):
                 {"path-pattern": r"src/.*", "pattern": r"^[a-zA-Z0-9]{26}$"},
                 {"pattern": r"^[a-zA-Z0-9]test$"},
                 {"path-pattern": r"src/.*", "pattern": r"^[a-zA-Z0-9]{26}::test$"},
-            ]
+            ],
+            "entropy",
         )
         self.assertCountEqual(
             rules,
@@ -335,7 +336,28 @@ class CompileRulesTests(unittest.TestCase):
         rules = config.compile_rules(
             [
                 {"pattern": r"^[a-zA-Z0-9]::test$"},
-            ]
+            ],
+            "entropy",
+        )
+        self.assertEqual(
+            rules,
+            [
+                Rule(
+                    None,
+                    re.compile(r"^[a-zA-Z0-9]::test$"),
+                    re.compile(r""),
+                    re_match_type=MatchType.Search,
+                    re_match_scope=Scope.Line,
+                )
+            ],
+        )
+
+    def test_regex_ignores_scope(self):
+        rules = config.compile_rules(
+            [
+                {"pattern": r"^[a-zA-Z0-9]::test$", "scope": "word"},
+            ],
+            "regex",
         )
         self.assertEqual(
             rules,
@@ -354,7 +376,7 @@ class CompileRulesTests(unittest.TestCase):
         with self.assertRaisesRegex(
             types.ConfigException, "Invalid exclude-entropy-patterns: "
         ):
-            config.compile_rules([{"foo": "bar"}])
+            config.compile_rules([{"foo": "bar"}], "entropy")
 
     @mock.patch("tartufo.util.process_issues", new=mock.MagicMock())
     @mock.patch("tartufo.scanner.FolderScanner")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -707,6 +707,7 @@ class GeneralUtilTests(unittest.TestCase):
 
     @mock.patch("tartufo.util.blake2s")
     def test_signature_is_generated_with_snippet_and_filename(self, mock_hash):
+        util.generate_signature.cache_clear()
         util.generate_signature("foo", "bar")
         mock_hash.assert_called_once_with(b"foo$$bar")
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -270,6 +270,7 @@ class OutputTests(unittest.TestCase):
             output_format=types.OutputFormat.Json.value,
             exclude_signatures=[],
             exclude_entropy_patterns=[],
+            exclude_regex_patterns=[],
         )
 
         # We're generating JSON piecemeal, so if we want to be safe we'll recover
@@ -288,6 +289,7 @@ class OutputTests(unittest.TestCase):
                 "excluded_paths": [],
                 "excluded_signatures": [],
                 "exclude_entropy_patterns": [],
+                "exclude_regex_patterns": [],
                 "found_issues": [
                     {
                         "issue_type": "High Entropy",
@@ -334,10 +336,15 @@ class OutputTests(unittest.TestCase):
             "aaaaa::bbbbb",
             "ccccc::ddddd",
         ]
+        exclude_regex_patterns = [
+            "eeeee::fffff",
+            "ggggg::hhhhh",
+        ]
         options = generate_options(
             GlobalOptions,
             output_format=types.OutputFormat.Json.value,
             exclude_entropy_patterns=exclude_entropy_patterns,
+            exclude_regex_patterns=exclude_regex_patterns,
         )
 
         # We're generating JSON piecemeal, so if we want to be safe we'll recover
@@ -360,6 +367,10 @@ class OutputTests(unittest.TestCase):
                 "exclude_entropy_patterns": [
                     "aaaaa::bbbbb",
                     "ccccc::ddddd",
+                ],
+                "exclude_regex_patterns": [
+                    "eeeee::fffff",
+                    "ggggg::hhhhh",
                 ],
                 "found_issues": [
                     {
@@ -519,6 +530,7 @@ class OutputTests(unittest.TestCase):
             exclude_signatures=[],
             exclude_path_patterns=[],
             exclude_entropy_patterns=[],
+            exclude_regex_patterns=[],
         )
         mock_scanner.global_options = options
         mock_scanner.issues = []
@@ -561,6 +573,7 @@ class OutputTests(unittest.TestCase):
             exclude_signatures=[],
             exclude_path_patterns=[],
             exclude_entropy_patterns=[],
+            exclude_regex_patterns=[],
         )
         mock_scanner.global_options = options
         mock_scanner.issues = []
@@ -602,6 +615,7 @@ class OutputTests(unittest.TestCase):
             exclude_signatures=[],
             exclude_path_patterns=[],
             exclude_entropy_patterns=[],
+            exclude_regex_patterns=[],
         )
         mock_scanner.global_options = options
         issue_1 = scanner.Issue(


### PR DESCRIPTION
This mimics the functionality of the `exclude-entropy-patterns` option, but for regex scans. It is heavily based off #192 and other subsequent work around that feature. This will help reduce false positives such as env variables for user info auth in URLs.

Note that the `scope` is forced to `line` and not configurable due to the way the regex scan is done compared to the entropy scan.

A few unrelated formatting changes were necessary for `pre-commit` linters to pass.

I ran into issues trying to get the development environment setup properly (mainly poetry version differences). The new tests that were added passed, but I was running into 2 unrelated test failures -- not sure if related to the dev setup issues.

To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [x] Documentation (if applicable)
* [x] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [x] Feature
* [x] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [x] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->

## What's new?
- add `exclude-regex-patterns` option
