### PR TITLE
feat: add color option to force terminal colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ Options:
   -of, --output-format [json|compact|text|report]
                                   Specify the format in which the output needs
                                   to be generated `--output-format
-                                  json/compact/text`. Either `json`, `compact`
-                                  `text` or `report` can be specified. If not provided
-                                  (default) the output will be generated in
-                                  `text` format.
+                                  json/compact/text/report`. Either `json`,
+                                  `compact`, `text` or `report` can be
+                                  specified. If not provided (default) the
+                                  output will be generated in `text` format.
   -od, --output-dir DIRECTORY     If specified, all issues will be written out
                                   as individual JSON files to a uniquely named
                                   directory under this one. This will help
@@ -105,6 +105,9 @@ Options:
                                   likelihood that a given string will be
                                   identified as suspicious.  [default: 75;
                                   0<=x<=100]
+  --color / --no-color            Enable or disable terminal color. If not
+                                  provided (default), enabled if output is a
+                                  terminal (TTY).
   -V, --version                   Show the version and exit.
   -h, --help                      Show this message and exit.
 

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 
 import click
 
-from tartufo import config, scanner, types
+from tartufo import config, scanner, types, util
 
 
 PLUGIN_DIR = pathlib.Path(__file__).parent / "commands"
@@ -120,7 +120,7 @@ class TartufoCLI(click.MultiCommand):
     ),
     default="text",
     help="""Specify the format in which the output needs to be generated
-    `--output-format json/compact/text`. Either `json`, `compact`, `text`
+    `--output-format json/compact/text/report`. Either `json`, `compact`, `text`
     or `report` can be specified. If not provided (default) the output will be generated
     in `text` format.""",
 )
@@ -243,6 +243,14 @@ class TartufoCLI(click.MultiCommand):
     Decreasing the scanner's sensitivity increases the likelihood that a given
     string will be identified as suspicious.""",
 )
+@click.option(
+    "--color/--no-color",
+    is_flag=True,
+    default=None,
+    show_default=True,
+    help="""Enable or disable terminal color. If not provided (default), enabled if
+    output is a terminal (TTY).""",
+)
 # The first positional argument here would be a hard-coded version, hence the `None`
 @click.version_option(None, "-V", "--version")
 @click.pass_context
@@ -257,6 +265,10 @@ def main(ctx: click.Context, **kwargs: config.OptionTypes) -> None:
 
     options = types.GlobalOptions(**kwargs)  # type: ignore
     ctx.obj = options
+
+    util.init_styles(options)
+    ctx.color = options.color
+
     if options.quiet and options.verbose > 0:
         raise click.BadParameter("-v/--verbose and -q/--quiet are mutually exclusive.")
 

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -79,6 +79,8 @@ class GlobalOptions:
     :param entropy_sensitivity: A number from 0 - 100 representing the
       sensitivity of entropy scans. A value of 0 will detect totally non-random
       values, while a value of 100 will detect only wholly random values.
+    :param color: Enable or disable terminal color. If not provided (default),
+      enabled if output is a terminal (TTY).
     """
 
     __slots__ = (
@@ -102,6 +104,7 @@ class GlobalOptions:
         "log_timestamps",
         "output_format",
         "entropy_sensitivity",
+        "color",
     )
     rule_patterns: Tuple[Dict[str, str], ...]
     default_regexes: bool
@@ -123,6 +126,7 @@ class GlobalOptions:
     log_timestamps: bool
     output_format: Optional[OutputFormat]
     entropy_sensitivity: int
+    color: Optional[bool]
 
 
 @dataclass

--- a/tartufo/util.py
+++ b/tartufo/util.py
@@ -38,6 +38,11 @@ if TYPE_CHECKING:
 DATETIME_FORMAT: str = "%Y-%m-%d %H:%M:%S"
 
 
+style_ok: Callable = click.style
+style_error: Callable = click.style
+style_warning: Callable = click.style
+
+
 def del_rw(_func: Callable, name: str, _exc: Exception) -> None:
     """Attempt to grant permission to and force deletion of a file.
 
@@ -227,19 +232,23 @@ def clone_git_repo(
     return pathlib.Path(project_path), origin
 
 
-if sys.stdout.isatty():
-    style_ok = partial(click.style, fg="bright_green")
-    style_error = partial(click.style, fg="red", bold=True)
-    style_warning = partial(click.style, fg="bright_yellow")
-else:
-    # If stdout is not a TTY, don't include color - just pass the string back
-    def _style_func(msg: str, *_: Any, **__: Any) -> str:
-        # We define this func and pass it to partial still to preserve
-        # typing integrity and prevent issues when callers expect to be
-        # able to pass the same args as click.style accepts
-        return msg
+def init_styles(options: types.GlobalOptions):
+    global_vars = globals()
+    if options.color is True or (sys.stdout.isatty() and options.color is None):
+        global_vars["style_ok"] = partial(click.style, fg="bright_green")
+        global_vars["style_error"] = partial(click.style, fg="red", bold=True)
+        global_vars["style_warning"] = partial(click.style, fg="bright_yellow")
+    else:
+        # If stdout is not a TTY, don't include color - just pass the string back
+        def _style_func(msg: str, *_: Any, **__: Any) -> str:
+            # We define this func and pass it to partial still to preserve
+            # typing integrity and prevent issues when callers expect to be
+            # able to pass the same args as click.style accepts
+            return msg
 
-    style_ok = style_error = style_warning = partial(_style_func)
+        global_vars["style_ok"] = global_vars["style_error"] = global_vars[
+            "style_warning"
+        ] = partial(_style_func)
 
 
 def fail(msg: str, ctx: click.Context, code: int = 1) -> NoReturn:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -664,9 +664,44 @@ class GeneralUtilTests(unittest.TestCase):
         mock_click.echo.assert_called_once_with(mock_style.return_value, err=True)
 
     @mock.patch("tartufo.util.sys.stdout")
+    def test_style_when_color_is_disabled(self, mock_stdout):
+        mock_stdout.isatty.return_value = True
+        importlib.reload(util)  # Forces sys.stdout.isatty to False
+
+        options = generate_options(GlobalOptions, verbose=0, color=False)
+        util.init_styles(options)
+
+        ok_result = util.style_ok("OK")
+        error_result = util.style_error("ERROR")
+        warning_result = util.style_warning("WARNING")
+
+        self.assertEqual(ok_result, "OK")
+        self.assertEqual(error_result, "ERROR")
+        self.assertEqual(warning_result, "WARNING")
+
+    @mock.patch("tartufo.util.sys.stdout")
+    def test_style_when_color_is_enabled(self, mock_stdout):
+        mock_stdout.isatty.return_value = False
+        importlib.reload(util)  # Forces sys.stdout.isatty to False
+
+        options = generate_options(GlobalOptions, verbose=0, color=True)
+        util.init_styles(options)
+
+        ok_result = util.style_ok("OK")
+        error_result = util.style_error("ERROR")
+        warning_result = util.style_warning("WARNING")
+
+        self.assertEqual(ok_result, "\x1b[92mOK\x1b[0m")
+        self.assertEqual(error_result, "\x1b[31m\x1b[1mERROR\x1b[0m")
+        self.assertEqual(warning_result, "\x1b[93mWARNING\x1b[0m")
+
+    @mock.patch("tartufo.util.sys.stdout")
     def test_style_when_not_a_tty(self, mock_stdout):
         mock_stdout.isatty.return_value = False
         importlib.reload(util)  # Forces sys.stdout.isatty to False
+
+        options = generate_options(GlobalOptions, verbose=0)
+        util.init_styles(options)
 
         ok_result = util.style_ok("OK")
         error_result = util.style_error("ERROR")
@@ -681,6 +716,9 @@ class GeneralUtilTests(unittest.TestCase):
     def test_style_when_is_a_tty(self, mock_stdout):
         mock_stdout.isatty.return_value = True
         importlib.reload(util)  # Forces sys.stdout.isatty to True
+
+        options = generate_options(GlobalOptions, verbose=0)
+        util.init_styles(options)
 
         ok_result = util.style_ok("OK")
         error_result = util.style_error("ERROR")


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [x] Documentation (if applicable)
* [ ] Changelog entry
* [ ] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->

## What's new?
- add `--color|--no-color` options to force terminal colors. This will default to true if TTY.
