### PR TITLE
Bugfix: multiple configuration files not processed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ vX.X.X - Mar 3 2023
 Features:
 * [#455](https://github.com/godaddy/tartufo/pull/455) - Update documentation to fix incorrect wording
 
+Bug fixes:
+* [#467](https://github.com/godaddy/tartufo/issues/467) - Multiple fixes to configuration
+  file processing:
+  - If multiple configuration files were specified, only the last was processed
+    and no error or warning was generated. Now files are processed in order.
+  - When multiple configuration files are specified, list-valued parameters are
+    concatenated and single-valued parameters are overwritten by the last file
+    that defines them.
+  - Configuration files located in the target of a `scan-folder` operation were
+    ignored; now they are located and processed in the same manner as for a
+    `scan-local-repo` or `scan-remote-repo` operation.
+
 v4.0.1 - Mar 1 2023
 --------------------
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -8,28 +8,93 @@ unwieldy and lead to an overly cumbersome command. It also becomes difficult to
 reliably reproduce the same command in all environments when done this way.
 
 To help with these problems, ``tartufo`` can also be configured by way of a
-configuration file! You can `tell tartufo what config file to use
-<usage.html#cmdoption-tartufo-config>`__, or, it will automatically discover one
-for you. Starting in the current working directory, and traversing backward up
-the directory tree, it will search for both a ``tartufo.toml`` and a
-``pyproject.toml``. The latter is searched for as a matter of convenience for
-Python projects, such as ``tartufo`` itself. For an example of the tree
-traversal, let's say you running ``tartufo`` from the directory
-``/home/my_user/projects/my_project``. ``tartufo`` will look for the
-configuration files first in this directory, then in ``/home/my_user/projects/``,
-then in ``/home/my_user``, etc. The search stops when the first non-empty file
-is encountered.
+configuration file!
 
-If multiple configuration files are specified, they will be located and processed
-in order. When conflicting directives are provided in different files, the value
-in the last file processed takes precedence. List-valued directives (such as
+You can `tell tartufo what config file to use
+<usage.html#cmdoption-tartufo-config>`__ by specifying one or more configuration
+files on the command line. Each file is located and processed in order. When
+conflicting directives are provided in different files, the value in the last
+file processed takes precedence. List-valued directives (such as
 ``exclude-path-patterns``) that are present in multiple files are concatenated.
 
-Within these files, ``tartufo`` will look for a section labeled
-``[tool.tartufo]`` to find its configuration, and will load all items from there
-just as though they had been specified on the command line. This file must be
+.. _configuration-discovery:
+
+Configuration Discovery
+-----------------------
+
+``tartufo`` uses two additional heuristics to locate specified configuration files.
+First, the current working directory is used as a base for relative filenames.
+Second, if the specified file does not exist in the specified directory, ``tartufo``
+will search upwards in the directory hierarchy looking for a file with the same
+name.
+
+Additionally, ``tartufo`` will look for a configuration file in the scan target
+repository or folder. It looks first for ``tartufo.toml``, and if that does not
+exist, then ``pyproject.toml``. The latter is searched for as a matter of
+convenience for Python projects, such as ``tartufo`` itself. This file must
+exist in the repository root directory (or target folder). The discovered
+configuration file will be processed after configuration files specified on the
+command line, unless it was also specified on the command line -- in which case,
+it will not be read a second time.
+
+Therefore, while it normally a target's configuration file will override settings
+specified using ``--config`` on the command line, this behavior can be overridden
+by specifying the target's configuration explicitly first, and then the desired
+"master" configuration second.
+
+Consider:
+
+.. code-block:: shell
+
+   tartufo --config myconfig.toml scan-local-repo .
+
+``tartufo`` will look for ``myconfig.toml`` in the current directory, and then
+in the parent directory if it does not exist in ``.``, etc., and then look for
+either ``tartufo.toml`` or (if not found) ``pyproject.toml`` in the current
+directory (only) because that is the target of the scan. Directives in, say,
+``tartufo.toml`` would supersede settings in ``myconfig.toml``.
+
+For purposes of this scan, empty files are considered not to exist.
+
+However:
+
+.. code-block:: shell
+
+   tartufo --config tartufo.toml --config myconfig.toml scan-local-repo .
+
+will cause ``tartufo`` to read ``tartufo.toml`` in the current directory
+(assuming it exists, and in parent directories otherwise), and then ``myconfig.toml``
+as above, and then either ``tartufo.toml`` or ``pyproject.toml`` in the current
+directory (only) because that is the target of the scan.
+
+If ``tartufo.toml`` exists in the current directory, the effect is that
+``tartufo.toml`` is read first, ``myconfig.toml`` is read second (possibly
+overriding directives), and ``tartufo.toml`` is not read again because it was
+processed already (and any ``pyproject.toml`` is ignored because ``tartufo.toml``
+was found).
+
+If ``tartufo.toml`` is not present but exists in the parent directory, then the
+effect is that ``../tartufo.toml`` is read first, ``myconfig.toml`` is read next,
+and ``pyproject.toml`` (if it exists) would be processed last because it is in
+the scan target and ``tartufo.toml`` does not exist in the scan root.
+
+Note this behavior is not applicable to remote repository scans, because the
+remote repository will be cloned to a scratch directory and neither that directory
+nor the configuration files within it are available to specify with ``-config``.
+
+.. _configuration-processing:
+
+Configuration Processing
+------------------------
+
+Within each configuration file, ``tartufo`` will look for a section labeled
+``[tool.tartufo]`` to find its configuration. This file must be
 written in the `TOML`_ format, which should look mostly familiar if you have
 dealt with any other configuration file format before.
+
+When the same options appear in multiple files, single-valued options (such as
+booleans) will be set by the last processed file. List-valued options will be
+concatenated to form a longer list.
 
 All command line options can be specified in the configuration file, with or
 without the leading dashes, and using either dashes or underscores for word

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -37,7 +37,7 @@ configuration file will be processed after configuration files specified on the
 command line, unless it was also specified on the command line -- in which case,
 it will not be read a second time.
 
-Therefore, while it normally a target's configuration file will override settings
+Therefore, while normally a target's configuration file will override settings
 specified using ``--config`` on the command line, this behavior can be overridden
 by specifying the target's configuration explicitly first, and then the desired
 "master" configuration second.
@@ -78,7 +78,7 @@ effect is that ``../tartufo.toml`` is read first, ``myconfig.toml`` is read next
 and ``pyproject.toml`` (if it exists) would be processed last because it is in
 the scan target and ``tartufo.toml`` does not exist in the scan root.
 
-Note this behavior is not applicable to remote repository scans, because the
+**Note**: This behavior is not applicable to remote repository scans, because the
 remote repository will be cloned to a scratch directory and neither that directory
 nor the configuration files within it are available to specify with ``-config``.
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -17,7 +17,13 @@ Python projects, such as ``tartufo`` itself. For an example of the tree
 traversal, let's say you running ``tartufo`` from the directory
 ``/home/my_user/projects/my_project``. ``tartufo`` will look for the
 configuration files first in this directory, then in ``/home/my_user/projects/``,
-then in ``/home/my_user``, etc.
+then in ``/home/my_user``, etc. The search stops when the first non-empty file
+is encountered.
+
+If multiple configuration files are specified, they will be located and processed
+in order. When conflicting directives are provided in different files, the value
+in the last file processed takes precedence. List-valued directives (such as
+``exclude-path-patterns``) that are present in multiple files are concatenated.
 
 Within these files, ``tartufo`` will look for a section labeled
 ``[tool.tartufo]`` to find its configuration, and will load all items from there
@@ -28,7 +34,7 @@ dealt with any other configuration file format before.
 All command line options can be specified in the configuration file, with or
 without the leading dashes, and using either dashes or underscores for word
 separators. When the configuration is read in, this will all be normalized
-automatically. For example, the configuration for `tartufo` itself looks like
+automatically. For example, the configuration for ``tartufo`` itself looks like
 this:
 
 .. code-block:: toml

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -208,6 +208,7 @@ class TartufoCLI(click.MultiCommand):
     ),
     is_eager=True,
     callback=config.read_pyproject_toml,
+    multiple=True,
     help="Read configuration from specified file. [default: tartufo.toml]",
 )
 @click.option(

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -173,7 +173,7 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
             return
 
         # Do not reload data if it was already specified using `--config`
-        if str(config_file) != self.global_options.config:
+        if config_file.resolve() not in config.REFERENCED_CONFIG_FILES:
             self.config_data = data
 
     def compute_scaled_entropy_limit(self, maximum_bitrate: float) -> float:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -232,13 +232,6 @@ class ReadPyprojectTomlTests(unittest.TestCase):
             config.read_pyproject_toml(self.ctx, self.param, ("foobar.toml",))
 
     @mock.patch("tartufo.config.load_config_from_path")
-    def test_none_is_returned_if_file_not_found_and_none_specified(
-        self, mock_load: mock.MagicMock
-    ):
-        mock_load.side_effect = FileNotFoundError("No file for you!")
-        self.assertIsNone(config.read_pyproject_toml(self.ctx, self.param, ("",)))
-
-    @mock.patch("tartufo.config.load_config_from_path")
     def test_file_error_is_raised_if_specified_config_file_cant_be_read(
         self, mock_load: mock.MagicMock
     ):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -258,10 +258,10 @@ class ReadPyprojectTomlTests(unittest.TestCase):
             )
         os.chdir(str(cur_dir))
 
-    def test_fully_resolved_filename_is_returned(self):
+    def test_fully_resolved_filename_is_stored(self):
         cur_dir = pathlib.Path()
         os.chdir(str(self.data_dir / "config"))
-        result = config.read_pyproject_toml(self.ctx, self.param, ("",))
+        config.read_pyproject_toml(self.ctx, self.param, ("",))
         os.chdir(str(cur_dir))
         self.assertEqual(
             config.REFERENCED_CONFIG_FILES, {self.data_dir / "config" / "tartufo.toml"}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -306,9 +306,7 @@ class ReadPyprojectTomlTests(unittest.TestCase):
             ),
         ]
 
-        result = config.read_pyproject_toml(
-            self.ctx, self.param, (str(alpha), str(beta))
-        )
+        config.read_pyproject_toml(self.ctx, self.param, (str(alpha), str(beta)))
 
         # Single-valued attributes set to conflicting values will be set by
         # beta because it is specified last.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -229,7 +229,7 @@ class ReadPyprojectTomlTests(unittest.TestCase):
     ):
         mock_load.side_effect = FileNotFoundError("No file for you!")
         with self.assertRaisesRegex(click.FileError, "No file for you!"):
-            config.read_pyproject_toml(self.ctx, self.param, "foobar.toml")
+            config.read_pyproject_toml(self.ctx, self.param, ("foobar.toml",))
 
     @mock.patch("tartufo.config.load_config_from_path")
     def test_none_is_returned_if_file_not_found_and_none_specified(
@@ -246,7 +246,7 @@ class ReadPyprojectTomlTests(unittest.TestCase):
         os.chdir(str(self.data_dir))
         mock_load.side_effect = types.ConfigException("Bad TOML!")
         with self.assertRaisesRegex(click.FileError, "Bad TOML!") as exc:
-            config.read_pyproject_toml(self.ctx, self.param, "foobar.toml")
+            config.read_pyproject_toml(self.ctx, self.param, ("foobar.toml",))
             self.assertEqual(exc.exception.filename, str(self.data_dir / "foobar.toml"))
         os.chdir(str(cur_dir))
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -220,7 +220,7 @@ class ReadPyprojectTomlTests(unittest.TestCase):
     ):
         mock_load.return_value = (self.data_dir / "config" / "tartufo.toml", {})
         self.ctx.params["repo_path"] = str(self.data_dir / "config")
-        config.read_pyproject_toml(self.ctx, self.param, "")
+        config.read_pyproject_toml(self.ctx, self.param, ("",))
         mock_load.assert_called_once_with(self.data_dir / "config", "")
 
     @mock.patch("tartufo.config.load_config_from_path")
@@ -236,7 +236,7 @@ class ReadPyprojectTomlTests(unittest.TestCase):
         self, mock_load: mock.MagicMock
     ):
         mock_load.side_effect = FileNotFoundError("No file for you!")
-        self.assertIsNone(config.read_pyproject_toml(self.ctx, self.param, ""))
+        self.assertIsNone(config.read_pyproject_toml(self.ctx, self.param, ("",)))
 
     @mock.patch("tartufo.config.load_config_from_path")
     def test_file_error_is_raised_if_specified_config_file_cant_be_read(
@@ -258,7 +258,7 @@ class ReadPyprojectTomlTests(unittest.TestCase):
         os.chdir(str(self.data_dir))
         mock_load.side_effect = types.ConfigException("Bad TOML!")
         with self.assertRaisesRegex(click.FileError, "Bad TOML!") as exc:
-            config.read_pyproject_toml(self.ctx, self.param, "")
+            config.read_pyproject_toml(self.ctx, self.param, ("",))
             self.assertEqual(
                 exc.exception.filename, str(self.data_dir / "tartufo.toml")
             )
@@ -267,7 +267,7 @@ class ReadPyprojectTomlTests(unittest.TestCase):
     def test_fully_resolved_filename_is_returned(self):
         cur_dir = pathlib.Path()
         os.chdir(str(self.data_dir / "config"))
-        result = config.read_pyproject_toml(self.ctx, self.param, "")
+        result = config.read_pyproject_toml(self.ctx, self.param, ("",))
         os.chdir(str(cur_dir))
         self.assertEqual(result, str(self.data_dir / "config" / "tartufo.toml"))
 


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [X] Tests (if applicable)
* [X] Documentation (if applicable)
* [X] Changelog entry
* [X] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [X] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [X] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [X] Yes (backward compatible)
* [ ] No (breaking changes)

This is arguable but I believe "backward compatible" best describes the spirit of the change.

Behavior has changed, but the new behavior matches what users thought was the behavior all along (i.e. if you specify multiple configuration files, all specified configuration files will be used). The `read_project_toml()` function still returns a string, but in the event multiple files were specified, that string is a comma-delimited list of filenames instead of a single filename. However, no in-tree code ever looks at this return value (except for some unit tests).

## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->
fixes #467 

## What's new?
Several configuration file processing bugs have been fixed.

* When the `--config` parameter appears multiple times, tartufo now processes each specified file in order; previously it ignored all but the last file. The documentation was silent on whether this was a valid thing or not, but no warning or error was generated and users were doing this and believing it would do something useful.
* When running `scan-folder`, an oversight caused the target folder not to be scanned for configuration files. Now tartufo will scan for configuration files, the same way it does for `scan-local-repo` and `scan-remote-repo`
* The same problem occurred for `pre-commit`.
* The logic that was supposed to avoid reloading a configuration file was horribly broken before, and it was even more broken by added support for multiple `--config` options. This has been fixed.
* To reduce the chances of screwing this up in the future, Configuration processing has been pulled into a `load_config()` method and all of the open-coded stuff -- typically in `load_repo()` although it had nothing to do with repository loading -- has been replaced with calls to the new method

Additionally, merging of data from multiple files is improved. (This wasn't really a factor before, because tartufo never looked at more than one user-specified configuration file.) Single-valued attributes are overwritten (so the last configuration file that specifies a setting wins) and list-valued attributes are concatenated (generally aligning to the expected behavior). The documentation has been updated to describe this, and unit tests have been added to verify that's really what the code does.

The documentation updates also include greatly expanded material on how configuration files are detected, since that appears to be a point of enduring confusion among both users and maintainers. ;-)