### PR TITLE
Setting up new flag --no-target-config to skip use of local config files if required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ vX.X.X - Mar 3 2023
 --------------------
 
 Features:
+* [#473](https://github.com/godaddy/tartufo/pull/473) - Introduces new flag `--no-local-config` to skip processing of local config files if needed.
 * [#455](https://github.com/godaddy/tartufo/pull/455) - Update documentation to fix incorrect wording
 
 Bug fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ vX.X.X - Mar 3 2023
 --------------------
 
 Features:
-* [#473](https://github.com/godaddy/tartufo/pull/473) - Introduces new flag `--local-config/--no-local-config` to process or skip using local config files.
+* [#473](https://github.com/godaddy/tartufo/pull/473) - Introduces new flag `-target-config/--no-target-config` to process or skip using config file in the repository being scanned
 * [#455](https://github.com/godaddy/tartufo/pull/455) - Update documentation to fix incorrect wording
 
 Bug fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ vX.X.X - Mar 3 2023
 --------------------
 
 Features:
-* [#473](https://github.com/godaddy/tartufo/pull/473) - Introduces new flag `--no-local-config` to skip processing of local config files if needed.
+* [#473](https://github.com/godaddy/tartufo/pull/473) - Introduces new flag `--local-config/--no-local-config` to process or skip using local config files.
 * [#455](https://github.com/godaddy/tartufo/pull/455) - Update documentation to fix incorrect wording
 
 Bug fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ vX.X.X - Mar 3 2023
 Features:
 * [#455](https://github.com/godaddy/tartufo/pull/455) - Update documentation to fix incorrect wording
 
+Bug fixes:
+* [#467](https://github.com/godaddy/tartufo/issues/467) - Multiple fixes to configuration
+  file processing:
+  - If multiple configuration files were specified, only the last was processed
+    and no error or warning was generated. Now files are processed in order.
+  - When multiple configuration files are specified, list-valued parameters are
+    concatenated and single-valued parameters are overwritten by the last file
+    that defines them.
+  - Configuration files located in the target of a `scan-folder` operation were
+    ignored; now they are located and processed in the same manner as for a
+    `scan-local-repo` or `scan-remote-repo` operation.
+
 v4.0.1 - Mar 1 2023
 --------------------
 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ Options:
                                   specified multiple times.
   --config FILE                   Read configuration from specified file.
                                   [default: tartufo.toml]
-  --local-config / --no-local-config BOOL
-                                  Enable or Disable processing of local config file
+  --target-config/--no-target-config BOOL
+                                  Enable or Disable processing of config file in the
+                                  repository being scanned
                                   i.e. config files like tartufo.toml or pyproject.toml
-                                  setup in local working directory
+                                  setup in the repository being scanned
                                   [default: local-config]
   -q, --quiet / --no-quiet        Quiet mode. No outputs are reported if the
                                   scan is successful and doesn't find any

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Options:
                                   specified multiple times.
   --config FILE                   Read configuration from specified file.
                                   [default: tartufo.toml]
+  --no-local-config BOOL          Skip processing of local config file
+                                  i.e. config files like tartufo.toml or pyproject.toml
+                                  setup in local working directory
+                                  [default: False]
   -q, --quiet / --no-quiet        Quiet mode. No outputs are reported if the
                                   scan is successful and doesn't find any
                                   issues

--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ Options:
                                   specified multiple times.
   --config FILE                   Read configuration from specified file.
                                   [default: tartufo.toml]
-  --no-local-config BOOL          Skip processing of local config file
+  --local-config / --no-local-config BOOL
+                                  Enable or Disable processing of local config file
                                   i.e. config files like tartufo.toml or pyproject.toml
                                   setup in local working directory
-                                  [default: False]
+                                  [default: local-config]
   -q, --quiet / --no-quiet        Quiet mode. No outputs are reported if the
                                   scan is successful and doesn't find any
                                   issues

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -8,28 +8,93 @@ unwieldy and lead to an overly cumbersome command. It also becomes difficult to
 reliably reproduce the same command in all environments when done this way.
 
 To help with these problems, ``tartufo`` can also be configured by way of a
-configuration file! You can `tell tartufo what config file to use
-<usage.html#cmdoption-tartufo-config>`__, or, it will automatically discover one
-for you. Starting in the current working directory, and traversing backward up
-the directory tree, it will search for both a ``tartufo.toml`` and a
-``pyproject.toml``. The latter is searched for as a matter of convenience for
-Python projects, such as ``tartufo`` itself. For an example of the tree
-traversal, let's say you running ``tartufo`` from the directory
-``/home/my_user/projects/my_project``. ``tartufo`` will look for the
-configuration files first in this directory, then in ``/home/my_user/projects/``,
-then in ``/home/my_user``, etc. The search stops when the first non-empty file
-is encountered.
+configuration file!
 
-If multiple configuration files are specified, they will be located and processed
-in order. When conflicting directives are provided in different files, the value
-in the last file processed takes precedence. List-valued directives (such as
+You can `tell tartufo what config file to use
+<usage.html#cmdoption-tartufo-config>`__ by specifying one or more configuration
+files on the command line. Each file is located and processed in order. When
+conflicting directives are provided in different files, the value in the last
+file processed takes precedence. List-valued directives (such as
 ``exclude-path-patterns``) that are present in multiple files are concatenated.
 
-Within these files, ``tartufo`` will look for a section labeled
-``[tool.tartufo]`` to find its configuration, and will load all items from there
-just as though they had been specified on the command line. This file must be
+.. _configuration-discovery:
+
+Configuration Discovery
+-----------------------
+
+``tartufo`` uses two additional heuristics to locate specified configuration files.
+First, the current working directory is used as a base for relative filenames.
+Second, if the specified file does not exist in the specified directory, ``tartufo``
+will search upwards in the directory hierarchy looking for a file with the same
+name.
+
+Additionally, ``tartufo`` will look for a configuration file in the scan target
+repository or folder. It looks first for ``tartufo.toml``, and if that does not
+exist, then ``pyproject.toml``. The latter is searched for as a matter of
+convenience for Python projects, such as ``tartufo`` itself. This file must
+exist in the repository root directory (or target folder). The discovered
+configuration file will be processed after configuration files specified on the
+command line, unless it was also specified on the command line -- in which case,
+it will not be read a second time.
+
+Therefore, while it normally a target's configuration file will override settings
+specified using ``--config`` on the command line, this behavior can be overridden
+by specifying the target's configuration explicitly first, and then the desired
+"master" configuration second.
+
+Consider:
+
+.. code-block:: shell
+
+   tartufo --config myconfig.toml scan-local-repo .
+
+``tartufo`` will look for ``myconfig.toml`` in the current directory, and then
+in the parent directory if it does not exist in ``.``, etc., and then look for
+either ``tartufo.toml`` or (if not found) ``pyproject.toml`` in the current
+directory (only) because that is the target of the scan. Directives in, say,
+``tartufo.toml`` would supersede settings in ``myconfig.toml``.
+
+For purposes of this scan, empty files are considered not to exist.
+
+However:
+
+.. code-block:: shell
+
+   tartufo --config tartufo.toml --config myconfig.toml scan-local-repo .
+
+will cause ``tartufo`` to read ``tartufo.toml`` in the current directory
+(assuming it exists, and in parent directories otherwise), and then ``myconfig.toml``
+as above, and then either ``tartufo.toml`` or ``pyproject.toml`` in the current
+directory (only) because that is the target of the scan.
+
+If ``tartufo.toml`` exists in the current directory, the effect is that
+``tartufo.toml`` is read first, ``myconfig.toml`` is read second (possibly
+overriding directives), and ``tartufo.toml`` is not read again because it was
+processed already (and any ``pyproject.toml`` is ignored because ``tartufo.toml``
+was found).
+
+If ``tartufo.toml`` is not present but exists in the parent directory, then the
+effect is that ``../tartufo.toml`` is read first, ``myconfig.toml`` is read next,
+and ``pyproject.toml`` (if it exists) would be processed last because it is in
+the scan target and ``tartufo.toml`` does not exist in the scan root.
+
+Note this behavior is not applicable to remote repository scans, because the
+remote repository will be cloned to a scratch directory and neither that directory
+nor the configuration files within it are available to specify with ``-config``.
+
+.. _configuration-processing:
+
+Configuration Processing
+------------------------
+
+Within each configuration file, ``tartufo`` will look for a section labeled
+``[tool.tartufo]`` to find its configuration. This file must be
 written in the `TOML`_ format, which should look mostly familiar if you have
 dealt with any other configuration file format before.
+
+When the same options appear in multiple files, single-valued options (such as
+booleans) will be set by the last processed file. List-valued options will be
+concatenated to form a longer list.
 
 All command line options can be specified in the configuration file, with or
 without the leading dashes, and using either dashes or underscores for word

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -17,7 +17,13 @@ Python projects, such as ``tartufo`` itself. For an example of the tree
 traversal, let's say you running ``tartufo`` from the directory
 ``/home/my_user/projects/my_project``. ``tartufo`` will look for the
 configuration files first in this directory, then in ``/home/my_user/projects/``,
-then in ``/home/my_user``, etc.
+then in ``/home/my_user``, etc. The search stops when the first non-empty file
+is encountered.
+
+If multiple configuration files are specified, they will be located and processed
+in order. When conflicting directives are provided in different files, the value
+in the last file processed takes precedence. List-valued directives (such as
+``exclude-path-patterns``) that are present in multiple files are concatenated.
 
 Within these files, ``tartufo`` will look for a section labeled
 ``[tool.tartufo]`` to find its configuration, and will load all items from there
@@ -28,7 +34,7 @@ dealt with any other configuration file format before.
 All command line options can be specified in the configuration file, with or
 without the leading dashes, and using either dashes or underscores for word
 separators. When the configuration is read in, this will all be normalized
-automatically. For example, the configuration for `tartufo` itself looks like
+automatically. For example, the configuration for ``tartufo`` itself looks like
 this:
 
 .. code-block:: toml

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -253,9 +253,9 @@ class TartufoCLI(click.MultiCommand):
     output is a terminal (TTY).""",
 )
 @click.option(
-    "--no-local-config",
+    "--local-config/--no-local-config",
     is_flag=True,
-    default=False,
+    default=True,
     show_default=True,
     help="Skipping auto discovery and use of local config file",
 )

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -253,11 +253,11 @@ class TartufoCLI(click.MultiCommand):
     output is a terminal (TTY).""",
 )
 @click.option(
-    "--local-config/--no-local-config",
+    "--target-config/--no-target-config",
     is_flag=True,
     default=True,
     show_default=True,
-    help="Skipping auto discovery and use of local config file",
+    help="Skipping auto discovery and use of config file present in the repository being scanned",
 )
 # The first positional argument here would be a hard-coded version, hence the `None`
 @click.version_option(None, "-V", "--version")

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -252,6 +252,13 @@ class TartufoCLI(click.MultiCommand):
     help="""Enable or disable terminal color. If not provided (default), enabled if
     output is a terminal (TTY).""",
 )
+@click.option(
+    "--no-local-config",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Skipping auto discovery and use of local config file",
+)
 # The first positional argument here would be a hard-coded version, hence the `None`
 @click.version_option(None, "-V", "--version")
 @click.pass_context

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -208,6 +208,7 @@ class TartufoCLI(click.MultiCommand):
     ),
     is_eager=True,
     callback=config.read_pyproject_toml,
+    multiple=True,
     help="Read configuration from specified file. [default: tartufo.toml]",
 )
 @click.option(

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -162,7 +162,9 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
 
         :param config_path: Directory expected to hold configuration file
         """
-
+        # Skipping loading local config if --no-local-config is supplied.
+        if self.global_options.no_local_config:
+            return
         # Look for usable configuration file
         try:
             (config_file, data) = config.load_config_from_path(

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -162,8 +162,8 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
 
         :param config_path: Directory expected to hold configuration file
         """
-        # Skipping loading local config if --no-local-config is supplied.
-        if not self.global_options.local_config:
+        # Skipping loading default project config if --no-target-config is supplied.
+        if not self.global_options.target_config:
             return
         # Look for usable configuration file
         try:

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -163,7 +163,7 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
         :param config_path: Directory expected to hold configuration file
         """
         # Skipping loading local config if --no-local-config is supplied.
-        if self.global_options.no_local_config:
+        if not self.global_options.local_config:
             return
         # Look for usable configuration file
         try:

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -173,7 +173,7 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
             return
 
         # Do not reload data if it was already specified using `--config`
-        if str(config_file) != self.global_options.config:
+        if config_file.resolve() not in config.REFERENCED_CONFIG_FILES:
             self.config_data = data
 
     def compute_scaled_entropy_limit(self, maximum_bitrate: float) -> float:

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -81,7 +81,7 @@ class GlobalOptions:
       values, while a value of 100 will detect only wholly random values.
     :param color: Enable or disable terminal color. If not provided (default),
       enabled if output is a terminal (TTY).
-    :param local_config: Enable/Disable local tartufo config from being used.
+    :param target_config: Enable/Disable tartufo config available in scanning repository from being used.
     """
 
     __slots__ = (
@@ -106,7 +106,7 @@ class GlobalOptions:
         "output_format",
         "entropy_sensitivity",
         "color",
-        "local_config",
+        "target_config",
     )
     rule_patterns: Tuple[Dict[str, str], ...]
     default_regexes: bool
@@ -129,7 +129,7 @@ class GlobalOptions:
     output_format: Optional[OutputFormat]
     entropy_sensitivity: int
     color: Optional[bool]
-    local_config: bool
+    target_config: bool
 
 
 @dataclass

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -81,6 +81,7 @@ class GlobalOptions:
       values, while a value of 100 will detect only wholly random values.
     :param color: Enable or disable terminal color. If not provided (default),
       enabled if output is a terminal (TTY).
+    :param no_local_config: Disable local tartufo config from being used.
     """
 
     __slots__ = (
@@ -105,6 +106,7 @@ class GlobalOptions:
         "output_format",
         "entropy_sensitivity",
         "color",
+        "no_local_config",
     )
     rule_patterns: Tuple[Dict[str, str], ...]
     default_regexes: bool
@@ -127,6 +129,7 @@ class GlobalOptions:
     output_format: Optional[OutputFormat]
     entropy_sensitivity: int
     color: Optional[bool]
+    no_local_config: bool
 
 
 @dataclass

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -81,7 +81,7 @@ class GlobalOptions:
       values, while a value of 100 will detect only wholly random values.
     :param color: Enable or disable terminal color. If not provided (default),
       enabled if output is a terminal (TTY).
-    :param no_local_config: Disable local tartufo config from being used.
+    :param local_config: Enable/Disable local tartufo config from being used.
     """
 
     __slots__ = (
@@ -106,7 +106,7 @@ class GlobalOptions:
         "output_format",
         "entropy_sensitivity",
         "color",
-        "no_local_config",
+        "local_config",
     )
     rule_patterns: Tuple[Dict[str, str], ...]
     default_regexes: bool
@@ -129,7 +129,7 @@ class GlobalOptions:
     output_format: Optional[OutputFormat]
     entropy_sensitivity: int
     color: Optional[bool]
-    no_local_config: bool
+    local_config: bool
 
 
 @dataclass

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -232,13 +232,6 @@ class ReadPyprojectTomlTests(unittest.TestCase):
             config.read_pyproject_toml(self.ctx, self.param, ("foobar.toml",))
 
     @mock.patch("tartufo.config.load_config_from_path")
-    def test_none_is_returned_if_file_not_found_and_none_specified(
-        self, mock_load: mock.MagicMock
-    ):
-        mock_load.side_effect = FileNotFoundError("No file for you!")
-        self.assertIsNone(config.read_pyproject_toml(self.ctx, self.param, ("",)))
-
-    @mock.patch("tartufo.config.load_config_from_path")
     def test_file_error_is_raised_if_specified_config_file_cant_be_read(
         self, mock_load: mock.MagicMock
     ):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -258,10 +258,10 @@ class ReadPyprojectTomlTests(unittest.TestCase):
             )
         os.chdir(str(cur_dir))
 
-    def test_fully_resolved_filename_is_returned(self):
+    def test_fully_resolved_filename_is_stored(self):
         cur_dir = pathlib.Path()
         os.chdir(str(self.data_dir / "config"))
-        result = config.read_pyproject_toml(self.ctx, self.param, ("",))
+        config.read_pyproject_toml(self.ctx, self.param, ("",))
         os.chdir(str(cur_dir))
         self.assertEqual(
             config.REFERENCED_CONFIG_FILES, {self.data_dir / "config" / "tartufo.toml"}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -306,9 +306,7 @@ class ReadPyprojectTomlTests(unittest.TestCase):
             ),
         ]
 
-        result = config.read_pyproject_toml(
-            self.ctx, self.param, (str(alpha), str(beta))
-        )
+        config.read_pyproject_toml(self.ctx, self.param, (str(alpha), str(beta)))
 
         # Single-valued attributes set to conflicting values will be set by
         # beta because it is specified last.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -229,7 +229,7 @@ class ReadPyprojectTomlTests(unittest.TestCase):
     ):
         mock_load.side_effect = FileNotFoundError("No file for you!")
         with self.assertRaisesRegex(click.FileError, "No file for you!"):
-            config.read_pyproject_toml(self.ctx, self.param, "foobar.toml")
+            config.read_pyproject_toml(self.ctx, self.param, ("foobar.toml",))
 
     @mock.patch("tartufo.config.load_config_from_path")
     def test_none_is_returned_if_file_not_found_and_none_specified(
@@ -246,7 +246,7 @@ class ReadPyprojectTomlTests(unittest.TestCase):
         os.chdir(str(self.data_dir))
         mock_load.side_effect = types.ConfigException("Bad TOML!")
         with self.assertRaisesRegex(click.FileError, "Bad TOML!") as exc:
-            config.read_pyproject_toml(self.ctx, self.param, "foobar.toml")
+            config.read_pyproject_toml(self.ctx, self.param, ("foobar.toml",))
             self.assertEqual(exc.exception.filename, str(self.data_dir / "foobar.toml"))
         os.chdir(str(cur_dir))
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -220,7 +220,7 @@ class ReadPyprojectTomlTests(unittest.TestCase):
     ):
         mock_load.return_value = (self.data_dir / "config" / "tartufo.toml", {})
         self.ctx.params["repo_path"] = str(self.data_dir / "config")
-        config.read_pyproject_toml(self.ctx, self.param, "")
+        config.read_pyproject_toml(self.ctx, self.param, ("",))
         mock_load.assert_called_once_with(self.data_dir / "config", "")
 
     @mock.patch("tartufo.config.load_config_from_path")
@@ -236,7 +236,7 @@ class ReadPyprojectTomlTests(unittest.TestCase):
         self, mock_load: mock.MagicMock
     ):
         mock_load.side_effect = FileNotFoundError("No file for you!")
-        self.assertIsNone(config.read_pyproject_toml(self.ctx, self.param, ""))
+        self.assertIsNone(config.read_pyproject_toml(self.ctx, self.param, ("",)))
 
     @mock.patch("tartufo.config.load_config_from_path")
     def test_file_error_is_raised_if_specified_config_file_cant_be_read(
@@ -258,7 +258,7 @@ class ReadPyprojectTomlTests(unittest.TestCase):
         os.chdir(str(self.data_dir))
         mock_load.side_effect = types.ConfigException("Bad TOML!")
         with self.assertRaisesRegex(click.FileError, "Bad TOML!") as exc:
-            config.read_pyproject_toml(self.ctx, self.param, "")
+            config.read_pyproject_toml(self.ctx, self.param, ("",))
             self.assertEqual(
                 exc.exception.filename, str(self.data_dir / "tartufo.toml")
             )
@@ -267,7 +267,7 @@ class ReadPyprojectTomlTests(unittest.TestCase):
     def test_fully_resolved_filename_is_returned(self):
         cur_dir = pathlib.Path()
         os.chdir(str(self.data_dir / "config"))
-        result = config.read_pyproject_toml(self.ctx, self.param, "")
+        result = config.read_pyproject_toml(self.ctx, self.param, ("",))
         os.chdir(str(cur_dir))
         self.assertEqual(result, str(self.data_dir / "config" / "tartufo.toml"))
 

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -67,7 +67,7 @@ class RepoLoadTests(ScannerTestCase):
     @mock.patch("pygit2.Repository", new=mock.MagicMock())
     @mock.patch("tartufo.config.load_config_from_path")
     def test_extra_inclusions_get_added(self, mock_load: mock.MagicMock):
-        self.global_options.local_config = True
+        self.global_options.target_config = True
         mock_load.return_value = (
             self.data_dir / "pyproject.toml",
             {
@@ -92,7 +92,7 @@ class RepoLoadTests(ScannerTestCase):
     @mock.patch("pygit2.Repository", new=mock.MagicMock())
     @mock.patch("tartufo.config.load_config_from_path")
     def test_extra_exclusions_get_added(self, mock_load: mock.MagicMock):
-        self.global_options.local_config = True
+        self.global_options.target_config = True
         mock_load.return_value = (
             self.data_dir / "pyproject.toml",
             {
@@ -123,7 +123,7 @@ class RepoLoadTests(ScannerTestCase):
     @mock.patch("pygit2.Repository", new=mock.MagicMock())
     @mock.patch("tartufo.config.load_config_from_path")
     def test_extra_signatures_get_added(self, mock_load: mock.MagicMock):
-        self.global_options.local_config = True
+        self.global_options.target_config = True
         mock_load.return_value = (
             self.data_dir / "pyproject.toml",
             {
@@ -144,7 +144,7 @@ class RepoLoadTests(ScannerTestCase):
     @mock.patch("pygit2.Repository", new=mock.MagicMock())
     @mock.patch("tartufo.config.load_config_from_path")
     def test_pyproject_signatures_get_excluded(self, mock_load: mock.MagicMock):
-        self.global_options.local_config = False
+        self.global_options.target_config = False
         mock_load.return_value = (
             self.data_dir / "pyproject.toml",
             {

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -67,6 +67,7 @@ class RepoLoadTests(ScannerTestCase):
     @mock.patch("pygit2.Repository", new=mock.MagicMock())
     @mock.patch("tartufo.config.load_config_from_path")
     def test_extra_inclusions_get_added(self, mock_load: mock.MagicMock):
+        self.global_options.local_config = True
         mock_load.return_value = (
             self.data_dir / "pyproject.toml",
             {
@@ -91,6 +92,7 @@ class RepoLoadTests(ScannerTestCase):
     @mock.patch("pygit2.Repository", new=mock.MagicMock())
     @mock.patch("tartufo.config.load_config_from_path")
     def test_extra_exclusions_get_added(self, mock_load: mock.MagicMock):
+        self.global_options.local_config = True
         mock_load.return_value = (
             self.data_dir / "pyproject.toml",
             {
@@ -121,6 +123,7 @@ class RepoLoadTests(ScannerTestCase):
     @mock.patch("pygit2.Repository", new=mock.MagicMock())
     @mock.patch("tartufo.config.load_config_from_path")
     def test_extra_signatures_get_added(self, mock_load: mock.MagicMock):
+        self.global_options.local_config = True
         mock_load.return_value = (
             self.data_dir / "pyproject.toml",
             {
@@ -137,6 +140,27 @@ class RepoLoadTests(ScannerTestCase):
         )
         test_scanner.load_repo("../tartufo")
         self.assertCountEqual(test_scanner.excluded_signatures, ["bar", "foo"])
+
+    @mock.patch("pygit2.Repository", new=mock.MagicMock())
+    @mock.patch("tartufo.config.load_config_from_path")
+    def test_pyproject_signatures_get_excluded(self, mock_load: mock.MagicMock):
+        self.global_options.local_config = False
+        mock_load.return_value = (
+            self.data_dir / "pyproject.toml",
+            {
+                "exclude_signatures": [
+                    {"signature": "foo", "reason": "Reason to exclude signature"}
+                ]
+            },
+        )
+        self.global_options.exclude_signatures = (
+            {"signature": "bar", "reason": "Reason to exclude signature"},
+        )
+        test_scanner = scanner.GitRepoScanner(
+            self.global_options, self.git_options, str(self.data_dir)
+        )
+        test_scanner.load_repo("../tartufo")
+        self.assertCountEqual(test_scanner.excluded_signatures, ["bar"])
 
 
 class FilterSubmoduleTests(ScannerTestCase):


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [x] Documentation (if applicable)
* [x] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
fixes #469

## What's new?
- Adding a new flag `--no-target-config` to skip processing of repository's config file if needed.
