### PR TITLE
Remove upward traversal logic for config discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ vX.X.X - Mar 3 2023
 
 Features:
 * [#455](https://github.com/godaddy/tartufo/pull/455) - Update documentation to fix incorrect wording
+* [#479](https://github.com/godaddy/tartufo/pull/479) - Remove upward traversal logic for config discovery
 
 Bug fixes:
 * [#467](https://github.com/godaddy/tartufo/issues/467) - Multiple fixes to configuration

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -42,8 +42,7 @@ Consider:
 
    tartufo --config myconfig.toml scan-local-repo .
 
-``tartufo`` will look for ``myconfig.toml`` in the current directory, and then
-in the parent directory if it does not exist in ``.``, etc., and then look for
+``tartufo`` will look for ``myconfig.toml`` in the current directory, and then look for
 either ``tartufo.toml`` or (if not found) ``pyproject.toml`` in the current
 directory (only) because that is the target of the scan. Directives in, say,
 ``tartufo.toml`` would supersede settings in ``myconfig.toml``.
@@ -57,7 +56,7 @@ However:
    tartufo --config tartufo.toml --config myconfig.toml scan-local-repo .
 
 will cause ``tartufo`` to read ``tartufo.toml`` in the current directory
-(assuming it exists, and in parent directories otherwise), and then ``myconfig.toml``
+(assuming it exists), and then ``myconfig.toml``
 as above, and then either ``tartufo.toml`` or ``pyproject.toml`` in the current
 directory (only) because that is the target of the scan.
 
@@ -67,10 +66,7 @@ overriding directives), and ``tartufo.toml`` is not read again because it was
 processed already (and any ``pyproject.toml`` is ignored because ``tartufo.toml``
 was found).
 
-If ``tartufo.toml`` is not present but exists in the parent directory, then the
-effect is that ``../tartufo.toml`` is read first, ``myconfig.toml`` is read next,
-and ``pyproject.toml`` (if it exists) would be processed last because it is in
-the scan target and ``tartufo.toml`` does not exist in the scan root.
+If any file specified by `--config` doesn't exist, tartufo will raise an error and exit.
 
 **Note**: This behavior is not applicable to remote repository scans, because the
 remote repository will be cloned to a scratch directory and neither that directory

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -12,10 +12,10 @@ configuration file!
 
 You can `tell tartufo what config file to use
 <usage.html#cmdoption-tartufo-config>`__ by specifying one or more configuration
-files on the command line. Each file is located and processed in order. When
-conflicting directives are provided in different files, the value in the last
-file processed takes precedence. Paths specified using --config are interpreted
-relative to the current working directory. List-valued directives (such as
+files on the command line. Paths specified using --config are interpreted
+relative to the current working directory.Each file is located and processed in order.
+When conflicting directives are provided in different files, the value in the last
+file processed takes precedence. List-valued directives (such as
 ``exclude-path-patterns``) that are present in multiple files are concatenated.
 
 .. _configuration-discovery:
@@ -45,7 +45,7 @@ Consider:
 
 ``tartufo`` will look for ``myconfig.toml`` in the current directory, and then look for
 either ``tartufo.toml`` or (if not found) ``pyproject.toml`` in the current
-directory (only) because that is the target of the scan. Directives in, say,
+directory because that is the target of the scan. Directives in, say,
 ``tartufo.toml`` would supersede settings in ``myconfig.toml``.
 
 For purposes of this scan, empty files are considered not to exist.

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -22,13 +22,7 @@ file processed takes precedence. List-valued directives (such as
 Configuration Discovery
 -----------------------
 
-``tartufo`` uses two additional heuristics to locate specified configuration files.
-First, the current working directory is used as a base for relative filenames.
-Second, if the specified file does not exist in the specified directory, ``tartufo``
-will search upwards in the directory hierarchy looking for a file with the same
-name.
-
-Additionally, ``tartufo`` will look for a configuration file in the scan target
+``tartufo`` will look for a configuration file in the scan target
 repository or folder. It looks first for ``tartufo.toml``, and if that does not
 exist, then ``pyproject.toml``. The latter is searched for as a matter of
 convenience for Python projects, such as ``tartufo`` itself. This file must

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -14,7 +14,8 @@ You can `tell tartufo what config file to use
 <usage.html#cmdoption-tartufo-config>`__ by specifying one or more configuration
 files on the command line. Each file is located and processed in order. When
 conflicting directives are provided in different files, the value in the last
-file processed takes precedence. List-valued directives (such as
+file processed takes precedence. Paths specified using --config are interpreted
+relative to the current working directory. List-valued directives (such as
 ``exclude-path-patterns``) that are present in multiple files are concatenated.
 
 .. _configuration-discovery:

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -23,7 +23,7 @@ relative to the current working directory. List-valued directives (such as
 Configuration Discovery
 -----------------------
 
-``tartufo`` will look for a configuration file in the scan target
+By default, ``tartufo`` will look for a configuration file in the scan target
 repository or folder. It looks first for ``tartufo.toml``, and if that does not
 exist, then ``pyproject.toml``. The latter is searched for as a matter of
 convenience for Python projects, such as ``tartufo`` itself. This file must

--- a/tartufo/config.py
+++ b/tartufo/config.py
@@ -32,43 +32,12 @@ REFERENCED_CONFIG_FILES: Set[pathlib.Path] = set()
 
 
 def load_config_from_path(
-    config_path: pathlib.Path, filename: Optional[str] = None, traverse: bool = True
+    config_path: pathlib.Path, filename: Optional[str] = None
 ) -> Tuple[pathlib.Path, MutableMapping[str, Any]]:
     """Scan a path for a configuration file, and return its contents.
 
     All key names are normalized to remove leading "-"/"--" and replace "-"
     with "_". For example, "--repo-path" becomes "repo_path".
-
-    In addition to checking the specified path, if ``traverse`` is ``True``,
-    this will traverse up through the directory structure, looking for a
-    configuration file in parent directories. For example, given this directory
-    structure:
-
-    ::
-
-      working_dir/
-      |- tartufo.toml
-      |- group1/
-      |  |- project1/
-      |  |  |- tartufo.toml
-      |  |- project2/
-      |- group2/
-         |- tartufo.toml
-         |- project1/
-         |- project2/
-            |- tartufo.toml
-
-    The following ``config_path`` values will load the configuration files at
-    the corresponding paths:
-
-    ============================ ====
-    config_path                  file
-    ---------------------------- ----
-    working_dir/group1/project1/ working_dir/group1/project1/tartufo.toml
-    working_dir/group1/project2/ working_dir/tartufo.toml
-    working_dir/group2/project1/ working_dir/group2/tartufo.toml
-    working_dir/group2/project2/ working_dir/group2/project2/tartufo.toml
-    ============================ ====
 
     :param config_path: The path to search for configuration files
     :param filename: A specific filename to look for. By default, this will look
@@ -95,8 +64,6 @@ def load_config_from_path(
                 break
             except (tomlkit.exceptions.ParseError, OSError) as exc:
                 raise types.ConfigException(f"Error reading configuration file: {exc}")
-    if not config and traverse and config_path.parent != config_path:
-        return load_config_from_path(config_path.parent, filename, traverse)
     if not config:
         raise FileNotFoundError(f"Could not find config file in {config_path}.")
     return (full_path, {k.replace("--", "").replace("-", "_"): v for k, v in config.items()})  # type: ignore

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -166,7 +166,7 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
         # Look for usable configuration file
         try:
             (config_file, data) = config.load_config_from_path(
-                pathlib.Path(config_path), traverse=False
+                pathlib.Path(config_path)
             )
         except (FileNotFoundError, types.ConfigException):
             # Nothing usable found; nothing to do

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -189,17 +189,6 @@ class LoadConfigFromPathTests(unittest.TestCase):
         ):
             config.load_config_from_path(self.data_dir)
 
-    def test_parent_directory_not_checked_if_traverse_is_false(self):
-        with self.assertRaisesRegex(
-            FileNotFoundError,
-            f"Could not find config file in {self.data_dir / 'config'}.".replace(
-                "\\", "\\\\"
-            ),
-        ):
-            config.load_config_from_path(
-                self.data_dir / "config", "pyproject.toml", False
-            )
-
     @mock.patch("tomlkit.loads")
     def test_config_keys_are_normalized(self, mock_load: mock.MagicMock):
         mock_load.return_value = {"tool": {"tartufo": {"--repo-path": "."}}}


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [x] Documentation (if applicable)
* [x] Changelog entry
* [x] A full explanation here in the PR description of the work done
This PR removes the upward traversal logic for configuration discovery in Tartufo. Tartufo will no longer look for configuration files in unspecified parent directories.

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [ ] Yes (backward compatible)
* [x] No (breaking changes)
This is a breaking change for users who were relying on upward traversal for configuration discovery

## Issue Linking
Fixes #475 

