### PR TITLE
Setting up new flag --target-config/--no-target-config to skip use of config files repo/folder being scanned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ vX.X.X - Mar 3 2023
 --------------------
 
 Features:
-* [#473](https://github.com/godaddy/tartufo/pull/473) - Introduces new flag `--target-config/--no-target-config` to process or skip using config file in the repository or folder being scanned
+* [#473](https://github.com/godaddy/tartufo/pull/473) - Introduces new flag `--target-config/--no-target-config` to enable or disable processing of the config file in the repository or folder being scanned
 * [#455](https://github.com/godaddy/tartufo/pull/455) - Update documentation to fix incorrect wording
 * [#458](https://github.com/godaddy/tartufo/pull/458) - Adds `--exclude-regex-patterns` to allow for regex-based exclusions
 * [#479](https://github.com/godaddy/tartufo/pull/479) - Remove upward traversal logic for config discovery

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ vX.X.X - Mar 3 2023
 --------------------
 
 Features:
+* [#473](https://github.com/godaddy/tartufo/pull/473) - Introduces new flag `--target-config/--no-target-config` to process or skip using config file in the repository being scanned
 * [#455](https://github.com/godaddy/tartufo/pull/455) - Update documentation to fix incorrect wording
 * [#458](https://github.com/godaddy/tartufo/pull/458) - Adds `--exclude-regex-patterns` to allow for regex-based exclusions
 * [#479](https://github.com/godaddy/tartufo/pull/479) - Remove upward traversal logic for config discovery

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ vX.X.X - Mar 3 2023
 --------------------
 
 Features:
-* [#473](https://github.com/godaddy/tartufo/pull/473) - Introduces new flag `--target-config/--no-target-config` to process or skip using config file in the repository being scanned
+* [#473](https://github.com/godaddy/tartufo/pull/473) - Introduces new flag `--target-config/--no-target-config` to process or skip using config file in the repository or folder being scanned
 * [#455](https://github.com/godaddy/tartufo/pull/455) - Update documentation to fix incorrect wording
 * [#458](https://github.com/godaddy/tartufo/pull/458) - Adds `--exclude-regex-patterns` to allow for regex-based exclusions
 * [#479](https://github.com/godaddy/tartufo/pull/479) - Remove upward traversal logic for config discovery

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Options:
                                   specified multiple times.
   --config FILE                   Read configuration from specified file.
                                   [default: tartufo.toml]
+  --target-config/--no-target-config
+                                  Enable or Disable processing of config file in the
+                                  repository being scanned
+                                  i.e. config files like tartufo.toml or pyproject.toml
+                                  setup in the repository being scanned
+                                  [default: target-config]
   -q, --quiet / --no-quiet        Quiet mode. No outputs are reported if the
                                   scan is successful and doesn't find any
                                   issues

--- a/README.md
+++ b/README.md
@@ -89,9 +89,8 @@ Options:
                                   [default: tartufo.toml]
   --target-config/--no-target-config
                                   Enable or Disable processing of the config file in the
-                                  repository being scanned
+                                  repository or folder being scanned
                                   i.e. config files like tartufo.toml or pyproject.toml
-                                  setup in the repository or folder being scanned
                                   [default: target-config]
   -q, --quiet / --no-quiet        Quiet mode. No outputs are reported if the
                                   scan is successful and doesn't find any

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Options:
   --config FILE                   Read configuration from specified file.
                                   [default: tartufo.toml]
   --target-config/--no-target-config
-                                  Enable or Disable processing of config file in the
+                                  Enable or Disable processing of the config file in the
                                   repository being scanned
                                   i.e. config files like tartufo.toml or pyproject.toml
                                   setup in the repository or folder being scanned

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Options:
                                   Enable or Disable processing of config file in the
                                   repository being scanned
                                   i.e. config files like tartufo.toml or pyproject.toml
-                                  setup in the repository being scanned
+                                  setup in the repository or folder being scanned
                                   [default: target-config]
   -q, --quiet / --no-quiet        Quiet mode. No outputs are reported if the
                                   scan is successful and doesn't find any

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -41,7 +41,7 @@ Consider:
 
 .. code-block:: shell
 
-   tartufo --config myconfig.toml scan-local-repo .
+   tartufo --config myconfig.toml scan-local-repo <target_directory>
 
 ``tartufo`` will look for ``myconfig.toml`` in the current directory, and then look for
 either ``tartufo.toml`` or (if not found) ``pyproject.toml`` in the current
@@ -54,14 +54,14 @@ However:
 
 .. code-block:: shell
 
-   tartufo --config tartufo.toml --config myconfig.toml scan-local-repo .
+   tartufo --config tartufo.toml --config myconfig.toml scan-local-repo <target_directory>
 
 will cause ``tartufo`` to read ``tartufo.toml`` in the current directory
 (assuming it exists), and then ``myconfig.toml``
 as above, and then either ``tartufo.toml`` or ``pyproject.toml`` in the current
 directory (only) because that is the target of the scan.
 
-If ``tartufo.toml`` exists in the current directory, the effect is that
+If ``tartufo.toml`` exists in the target directory, the effect is that
 ``tartufo.toml`` is read first, ``myconfig.toml`` is read second (possibly
 overriding directives), and ``tartufo.toml`` is not read again because it was
 processed already (and any ``pyproject.toml`` is ignored because ``tartufo.toml``

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -44,8 +44,8 @@ Consider:
    tartufo --config myconfig.toml scan-local-repo <target_directory>
 
 ``tartufo`` will look for ``myconfig.toml`` in the current directory, and then look for
-either ``tartufo.toml`` or (if not found) ``pyproject.toml`` in the target
-directory because that is the target of the scan. Directives in, say,
+either ``tartufo.toml`` or (if not found) ``pyproject.toml`` in the ``target_directory``
+because that is the target of the scan. Directives in, say,
 ``tartufo.toml`` would supersede settings in ``myconfig.toml``.
 
 For purposes of this scan, empty files are considered not to exist.
@@ -54,7 +54,7 @@ However:
 
 .. code-block:: shell
 
-   tartufo --config <tartufo.toml in target directory> --config myconfig.toml scan-local-repo <target_directory>
+   tartufo --config <tartufo.toml in target_directory> --config myconfig.toml scan-local-repo <target_directory>
 
 will cause ``tartufo`` to read ``tartufo.toml`` in the target directory
 (assuming it exists), and then ``myconfig.toml``

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -44,7 +44,7 @@ Consider:
    tartufo --config myconfig.toml scan-local-repo <target_directory>
 
 ``tartufo`` will look for ``myconfig.toml`` in the current directory, and then look for
-either ``tartufo.toml`` or (if not found) ``pyproject.toml`` in the current
+either ``tartufo.toml`` or (if not found) ``pyproject.toml`` in the target
 directory because that is the target of the scan. Directives in, say,
 ``tartufo.toml`` would supersede settings in ``myconfig.toml``.
 
@@ -54,15 +54,14 @@ However:
 
 .. code-block:: shell
 
-   tartufo --config tartufo.toml --config myconfig.toml scan-local-repo <target_directory>
+   tartufo --config <tartufo.toml in target directory> --config myconfig.toml scan-local-repo <target_directory>
 
-will cause ``tartufo`` to read ``tartufo.toml`` in the current directory
+will cause ``tartufo`` to read ``tartufo.toml`` in the target directory
 (assuming it exists), and then ``myconfig.toml``
-as above, and then either ``tartufo.toml`` or ``pyproject.toml`` in the current
-directory (only) because that is the target of the scan.
+as above
 
 If ``tartufo.toml`` exists in the target directory, the effect is that
-``tartufo.toml`` is read first, ``myconfig.toml`` is read second (possibly
+``tartufo.toml`` from target directory is read first, ``myconfig.toml`` from current directory is read second (possibly
 overriding directives), and ``tartufo.toml`` is not read again because it was
 processed already (and any ``pyproject.toml`` is ignored because ``tartufo.toml``
 was found).

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -12,8 +12,8 @@ configuration file!
 
 You can `tell tartufo what config file to use
 <usage.html#cmdoption-tartufo-config>`__ by specifying one or more configuration
-files on the command line. Paths specified using --config are interpreted
-relative to the current working directory.Each file is located and processed in order.
+files on the command line. Paths specified using ``--config`` are interpreted
+relative to the current working directory. Each file is located and processed in order.
 When conflicting directives are provided in different files, the value in the last
 file processed takes precedence. List-valued directives (such as
 ``exclude-path-patterns``) that are present in multiple files are concatenated.
@@ -24,10 +24,9 @@ Configuration Discovery
 -----------------------
 
 By default, ``tartufo`` will look for a configuration file in the scan target
-repository or folder. It looks first for ``tartufo.toml``, and if that does not
+repository or folder. It looks for ``tartufo.toml`` first, and if that does not
 exist, then ``pyproject.toml``. The latter is searched for as a matter of
-convenience for Python projects, such as ``tartufo`` itself. This file must
-exist in the repository root directory (or target folder). The discovered
+convenience for Python projects, such as ``tartufo`` itself. The discovered
 configuration file will be processed after configuration files specified on the
 command line, unless it was also specified on the command line -- in which case,
 it will not be read a second time.
@@ -54,19 +53,16 @@ However:
 
 .. code-block:: shell
 
-   tartufo --config <tartufo.toml in target_directory> --config myconfig.toml scan-local-repo <target_directory>
+   tartufo --config tartufo.toml --config myconfig.toml scan-local-repo .
 
-will cause ``tartufo`` to read ``tartufo.toml`` in the target directory
-(assuming it exists), and then ``myconfig.toml``
-as above
+will cause ``tartufo`` to read ``tartufo.toml`` in the current directory
+(assuming it exists, because it the scan target), and then ``myconfig.toml`` as above.
 
-If ``tartufo.toml`` exists in the target directory, the effect is that
-``tartufo.toml`` from target directory is read first, ``myconfig.toml`` from current directory is read second (possibly
-overriding directives), and ``tartufo.toml`` is not read again because it was
-processed already (and any ``pyproject.toml`` is ignored because ``tartufo.toml``
-was found).
+If ``tartufo.toml`` exists, the effect is that ``tartufo.toml`` is read first, ``myconfig.toml``
+is read second (possibly overriding directives), and ``tartufo.toml`` is not read again because it was
+processed already (and any ``pyproject.toml`` is ignored because ``tartufo.toml`` was found).
 
-If any file specified by `--config` doesn't exist, tartufo will raise an error and exit.
+If any file specified by ``--config`` doesn't exist, tartufo will raise an error and exit.
 
 **Note**: This behavior is not applicable to remote repository scans, because the
 remote repository will be cloned to a scratch directory and neither that directory

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -262,6 +262,13 @@ class TartufoCLI(click.MultiCommand):
     help="""Enable or disable terminal color. If not provided (default), enabled if
     output is a terminal (TTY).""",
 )
+@click.option(
+    "--target-config/--no-target-config",
+    is_flag=True,
+    default=True,
+    show_default=True,
+    help="Skipping auto discovery and use of config file present in the repository being scanned",
+)
 # The first positional argument here would be a hard-coded version, hence the `None`
 @click.version_option(None, "-V", "--version")
 @click.pass_context

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -267,7 +267,7 @@ class TartufoCLI(click.MultiCommand):
     is_flag=True,
     default=True,
     show_default=True,
-    help="Enable or disable discovery and use of config file present in the repository or folder being scanned",
+    help="Enable or Disable processing of the config file present in the repository or folder being scanned",
 )
 # The first positional argument here would be a hard-coded version, hence the `None`
 @click.version_option(None, "-V", "--version")

--- a/tartufo/cli.py
+++ b/tartufo/cli.py
@@ -267,7 +267,7 @@ class TartufoCLI(click.MultiCommand):
     is_flag=True,
     default=True,
     show_default=True,
-    help="Skipping auto discovery and use of config file present in the repository being scanned",
+    help="Enable or disable discovery and use of config file present in the repository or folder being scanned",
 )
 # The first positional argument here would be a hard-coded version, hence the `None`
 @click.version_option(None, "-V", "--version")

--- a/tartufo/scanner.py
+++ b/tartufo/scanner.py
@@ -163,7 +163,9 @@ class ScannerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
 
         :param config_path: Directory expected to hold configuration file
         """
-
+        # Skipping loading default project config if --no-target-config is supplied.
+        if not self.global_options.target_config:
+            return
         # Look for usable configuration file
         try:
             (config_file, data) = config.load_config_from_path(

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -83,7 +83,7 @@ class GlobalOptions:
       values, while a value of 100 will detect only wholly random values.
     :param color: Enable or disable terminal color. If not provided (default),
       enabled if output is a terminal (TTY).
-    :param target_config: Enable/Disable tartufo config available in scanning repository or folder from being used.
+    :param target_config: Enable/Disable processing of the tartufo config available in scanning repository or folder.
     """
 
     __slots__ = (

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -83,7 +83,7 @@ class GlobalOptions:
       values, while a value of 100 will detect only wholly random values.
     :param color: Enable or disable terminal color. If not provided (default),
       enabled if output is a terminal (TTY).
-    :param target_config: Enable/Disable tartufo config available in scanning repository from being used.
+    :param target_config: Enable/Disable tartufo config available in scanning repository or folder from being used.
     """
 
     __slots__ = (

--- a/tartufo/types.py
+++ b/tartufo/types.py
@@ -83,6 +83,7 @@ class GlobalOptions:
       values, while a value of 100 will detect only wholly random values.
     :param color: Enable or disable terminal color. If not provided (default),
       enabled if output is a terminal (TTY).
+    :param target_config: Enable/Disable tartufo config available in scanning repository from being used.
     """
 
     __slots__ = (
@@ -108,6 +109,7 @@ class GlobalOptions:
         "output_format",
         "entropy_sensitivity",
         "color",
+        "target_config",
     )
     rule_patterns: Tuple[Dict[str, str], ...]
     default_regexes: bool
@@ -131,6 +133,7 @@ class GlobalOptions:
     output_format: Optional[OutputFormat]
     entropy_sensitivity: int
     color: Optional[bool]
+    target_config: bool
 
 
 @dataclass

--- a/tests/test_git_repo_scanner.py
+++ b/tests/test_git_repo_scanner.py
@@ -67,6 +67,7 @@ class RepoLoadTests(ScannerTestCase):
     @mock.patch("pygit2.Repository", new=mock.MagicMock())
     @mock.patch("tartufo.config.load_config_from_path")
     def test_extra_inclusions_get_added(self, mock_load: mock.MagicMock):
+        self.global_options.target_config = True
         mock_load.return_value = (
             self.data_dir / "pyproject.toml",
             {
@@ -91,6 +92,7 @@ class RepoLoadTests(ScannerTestCase):
     @mock.patch("pygit2.Repository", new=mock.MagicMock())
     @mock.patch("tartufo.config.load_config_from_path")
     def test_extra_exclusions_get_added(self, mock_load: mock.MagicMock):
+        self.global_options.target_config = True
         mock_load.return_value = (
             self.data_dir / "pyproject.toml",
             {
@@ -121,6 +123,7 @@ class RepoLoadTests(ScannerTestCase):
     @mock.patch("pygit2.Repository", new=mock.MagicMock())
     @mock.patch("tartufo.config.load_config_from_path")
     def test_extra_signatures_get_added(self, mock_load: mock.MagicMock):
+        self.global_options.target_config = True
         mock_load.return_value = (
             self.data_dir / "pyproject.toml",
             {
@@ -137,6 +140,27 @@ class RepoLoadTests(ScannerTestCase):
         )
         test_scanner.load_repo("../tartufo")
         self.assertCountEqual(test_scanner.excluded_signatures, ["bar", "foo"])
+
+    @mock.patch("pygit2.Repository", new=mock.MagicMock())
+    @mock.patch("tartufo.config.load_config_from_path")
+    def test_pyproject_signatures_get_excluded(self, mock_load: mock.MagicMock):
+        self.global_options.target_config = False
+        mock_load.return_value = (
+            self.data_dir / "pyproject.toml",
+            {
+                "exclude_signatures": [
+                    {"signature": "foo", "reason": "Reason to exclude signature"}
+                ]
+            },
+        )
+        self.global_options.exclude_signatures = (
+            {"signature": "bar", "reason": "Reason to exclude signature"},
+        )
+        test_scanner = scanner.GitRepoScanner(
+            self.global_options, self.git_options, str(self.data_dir)
+        )
+        test_scanner.load_repo("../tartufo")
+        self.assertCountEqual(test_scanner.excluded_signatures, ["bar"])
 
 
 class FilterSubmoduleTests(ScannerTestCase):


### PR DESCRIPTION

To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [x] Documentation (if applicable)
* [x] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
fixes https://github.com/godaddy/tartufo/issues/469

## What's new?
- Adding a new flag --no-target-config to skip processing of the repository's config file if needed.
