### PR TITLE
Processing rule-patterns from default configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Features:
 * [#479](https://github.com/godaddy/tartufo/pull/479) - Remove upward traversal logic for config discovery
 
 Bug fixes:
+* [#482](https://github.com/godaddy/tartufo/pull/482) - Code updates to process rule-patterns set up in the target's default config file i.e. tartufo.toml or pyproject.toml
 * [#467](https://github.com/godaddy/tartufo/issues/467) - Multiple fixes to configuration
   file processing:
   - If multiple configuration files were specified, only the last was processed


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [ ] Documentation (if applicable)
* [x] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
fixes #476 

## What's new?
- Processing of rule patterns has not been working correctly after deprecation of [--rules](https://github.com/godaddy/tartufo/issues/256). The PR fixes the issue.  
